### PR TITLE
Update CMake from vcpkg patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,14 +63,22 @@ endif()
 add_subdirectory(src)
 
 # add usage example
-add_subdirectory(example)
+option(BUILD_EXAMPLES "Build usage examples" ON)
+if(BUILD_EXAMPLES)
+    add_subdirectory(example)
+endif()
 
 # generate project documentation
-add_subdirectory(docs)
+option(BUILD_DOCS "Generate docs" ON)
+if(BUILD_DOCS)
+    add_subdirectory(docs)
+endif()
 
 # add unit tests
-enable_testing()
-add_subdirectory(test)
+include(CTest)
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()
 
 # tests for standalone headers
 include(TestPublicHeaders)

--- a/src/mp-unitsConfig.cmake
+++ b/src/mp-unitsConfig.cmake
@@ -39,14 +39,14 @@ function(__check_libcxx_in_use variable)
 endfunction()
 
 include(CMakeFindDependencyMacro)
-find_dependency(fmt)
-find_dependency(gsl-lite)
+find_dependency(fmt CONFIG)
+find_dependency(gsl-lite CONFIG)
 
 # add range-v3 dependency only for clang + libc++
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     __check_libcxx_in_use(__units_libcxx)
     if(__units_libcxx AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14")
-        find_dependency(range-v3)
+        find_dependency(range-v3 CONFIG)
     endif()
     unset(__units_libcxx)
 endif()


### PR DESCRIPTION
This patch will simply make build of tests, example and documentation optional.
And CONFIG option is missing in find_dependency in Config.cmake
