### PR TITLE
Proper output of 8-bit values

### DIFF
--- a/src/core-io/include/mp-units/ostream.h
+++ b/src/core-io/include/mp-units/ostream.h
@@ -34,7 +34,7 @@ namespace detail {
 template<typename CharT, class Traits, auto R, typename Rep>
 void to_stream(std::basic_ostream<CharT, Traits>& os, const quantity<R, Rep>& q)
 {
-  os << q.number();
+  os << std::to_string(q.number());
   if constexpr (has_unit_symbol(get_unit(R))) {
     os << " ";
     unit_symbol_to<CharT>(std::ostream_iterator<CharT>(os), get_unit(R));


### PR DESCRIPTION
Feeding 8-bit values into std::ostream result in characters rather than numbers. Fix this by enforcing string output.