### PR TITLE
Fix "control reaches end of non void function" error.

### DIFF
--- a/example/unmanned_aerial_vehicle.cpp
+++ b/example/unmanned_aerial_vehicle.cpp
@@ -26,6 +26,7 @@
 #include <mp-units/systems/international/international.h>
 #include <mp-units/systems/isq/space_and_time.h>
 #include <mp-units/systems/si/unit_symbols.h>
+#include <cassert>
 #include <iostream>
 
 using namespace mp_units;
@@ -56,6 +57,7 @@ constexpr const char* to_text(earth_gravity_model m)
     case egm2008_1:
       return "EGM2008-1";
   }
+  assert(false && "unsupported enum value");
 }
 
 template<earth_gravity_model M>


### PR DESCRIPTION
This code fixes "control reaches end of non void function" warning that is an error in our project. It does so by adding assertion that is knowingly false. This assertion is not reachable with the proper code, but would become possible to reach if more values are added to the enum.