### PR TITLE
Renaming of accessor functions

### DIFF
--- a/docs/users_guide/framework_basics/generic_interfaces.md
+++ b/docs/users_guide/framework_basics/generic_interfaces.md
@@ -65,11 +65,11 @@ some issues start to be clearly visible:
    Trying to use an integral type in this scenario will work only for `s1`, while `s2` and `s3`
    will fail to compile. Failing to compile is a good thing here as the library tries to prevent
    the user from doing a clearly wrong thing. To make the code compile, the user needs to use
-   a dedicated [`value_cast`](value_conversions.md#value-truncating-conversions) like this:
+   dedicated [`value_cast` or `force_in`](value_conversions.md#value-truncating-conversions) like this:
 
     ```cpp
     quantity<isq::speed[mi / h]> s2 = avg_speed(value_cast<km>(140 * mi), 2 * h);
-    quantity<isq::speed[m / s]> s3 = avg_speed(value_cast<km>(20 * m), value_cast<h>(2 * s));
+    quantity<isq::speed[m / s]> s3 = avg_speed((20 * m).force_in(km), (2 * s).force_in(h));
     ```
 
     but the above will obviously provide an incorrect behavior (i.e. division by `0` in the evaluation

--- a/docs/users_guide/framework_basics/text_output.md
+++ b/docs/users_guide/framework_basics/text_output.md
@@ -73,8 +73,8 @@ associated with this quantity.
     before passing it to the text output:
 
     ```cpp
-    std::cout << v1.in(km / h) << '\n';          // 110 km/h
-    std::cout << value_cast<m / s>(v1) << '\n';  // 30.5556 m/s
+    std::cout << v1.in(km / h) << '\n';       // 110 km/h
+    std::cout << v1.force_in(m / s) << '\n';  // 30.5556 m/s
     ```
 
 

--- a/docs/users_guide/framework_basics/value_conversions.md
+++ b/docs/users_guide/framework_basics/value_conversions.md
@@ -59,11 +59,17 @@ The second solution is to force a truncating conversion:
 ```cpp
 auto q1 = 5 * m;
 std::cout << value_cast<km>(q1) << '\n';
-quantity<si::kilo<si::metre>, int> q2 = value_cast<km>(q1);
+quantity<si::kilo<si::metre>, int> q2 = q1.force_in(km);
 ```
 
 This explicit cast makes it clear that something unsafe is going on. It is easy to spot in code
 reviews or while chasing a bug in the source code.
+
+!!! note
+
+    `q.force_in(U)` is just a shortcut to run `value_cast<U>(q)`. There is no difference in behavior
+    between those two interfaces. `q.force_in(U)` was added for consistency with `q.in(U)` and
+    `q.force_numerical_value_in(U)`.
 
 Another place where this cast is useful is when a user wants to convert a quantity with
 a floating-point representation to the one using an integral one. Again this is a truncating

--- a/example/avg_speed.cpp
+++ b/example/avg_speed.cpp
@@ -56,7 +56,7 @@ constexpr QuantityOf<isq::speed> auto avg_speed(QuantityOf<isq::length> auto d, 
 template<QuantityOf<isq::length> D, QuantityOf<isq::time> T, QuantityOf<isq::speed> V>
 void print_result(D distance, T duration, V speed)
 {
-  const auto result_in_kmph = value_cast<si::kilo<si::metre> / non_si::hour>(speed);
+  const auto result_in_kmph = speed.force_in(si::kilo<si::metre> / non_si::hour);
   std::cout << "Average speed of a car that makes " << distance << " in " << duration << " is " << result_in_kmph
             << ".\n";
 }
@@ -101,7 +101,7 @@ void example()
 
     // it is not possible to make a lossless conversion of miles to meters on an integral type
     // (explicit cast needed)
-    print_result(distance, duration, fixed_int_si_avg_speed(value_cast<si::metre>(distance), duration));
+    print_result(distance, duration, fixed_int_si_avg_speed(distance.force_in(m), duration));
     print_result(distance, duration, fixed_double_si_avg_speed(distance, duration));
     print_result(distance, duration, avg_speed(distance, duration));
   }
@@ -119,7 +119,7 @@ void example()
     // also it is not possible to make a lossless conversion of miles to meters on an integral type
     // (explicit cast needed)
     print_result(distance, duration,
-                 fixed_int_si_avg_speed(value_cast<int>(value_cast<si::metre>(distance)), value_cast<int>(duration)));
+                 fixed_int_si_avg_speed(value_cast<int>(distance.force_in(m)), value_cast<int>(duration)));
     print_result(distance, duration, fixed_double_si_avg_speed(distance, duration));
     print_result(distance, duration, avg_speed(distance, duration));
   }
@@ -133,7 +133,7 @@ void example()
 
     // it is not possible to make a lossless conversion of centimeters to meters on an integral type
     // (explicit cast needed)
-    print_result(distance, duration, fixed_int_si_avg_speed(value_cast<si::metre>(distance), duration));
+    print_result(distance, duration, fixed_int_si_avg_speed(distance.force_in(m), duration));
     print_result(distance, duration, fixed_double_si_avg_speed(distance, duration));
     print_result(distance, duration, avg_speed(distance, duration));
   }
@@ -149,7 +149,7 @@ void example()
     // it is not possible to make a lossless conversion of centimeters to meters on an integral type
     // (explicit cast needed)
     print_result(distance, duration,
-                 fixed_int_si_avg_speed(value_cast<int>(value_cast<m>(distance)), value_cast<int>(duration)));
+                 fixed_int_si_avg_speed(value_cast<int>(distance.force_in(m)), value_cast<int>(duration)));
 
     print_result(distance, duration, fixed_double_si_avg_speed(distance, duration));
     print_result(distance, duration, avg_speed(distance, duration));

--- a/example/conversion_factor.cpp
+++ b/example/conversion_factor.cpp
@@ -58,6 +58,5 @@ int main()
             << MP_UNITS_STD_FMT::format("lengthB.value( {} ) == lengthA.value( {} ) * conversion_factor( {} )\n",
                                         lengthB.numerical_value_ref_in(lengthB.unit),
                                         lengthA.numerical_value_ref_in(lengthA.unit),
-
                                         conversion_factor(lengthB, lengthA));
 }

--- a/example/conversion_factor.cpp
+++ b/example/conversion_factor.cpp
@@ -33,7 +33,7 @@ template<mp_units::Quantity Target, mp_units::Quantity Source>
   requires std::constructible_from<Target, Source>
 inline constexpr double conversion_factor(Target, Source)
 {
-  return mp_units::value_cast<Target::unit>(1. * Source::reference).numerical_value_ref_in(Target::unit);
+  return (1. * Source::reference).force_numerical_value_in(Target::unit);
 }
 
 }  // namespace

--- a/example/conversion_factor.cpp
+++ b/example/conversion_factor.cpp
@@ -33,7 +33,7 @@ template<mp_units::Quantity Target, mp_units::Quantity Source>
   requires std::constructible_from<Target, Source>
 inline constexpr double conversion_factor(Target, Source)
 {
-  return mp_units::value_cast<Target::unit>(1. * Source::reference).numerical_value();
+  return mp_units::value_cast<Target::unit>(1. * Source::reference).numerical_value_ref_in(Target::unit);
 }
 
 }  // namespace
@@ -56,6 +56,8 @@ int main()
   std::cout << MP_UNITS_STD_FMT::format("conversion factor from lengthA::unit of {:%q} to lengthB::unit of {:%q}:\n\n",
                                         lengthA, lengthB)
             << MP_UNITS_STD_FMT::format("lengthB.value( {} ) == lengthA.value( {} ) * conversion_factor( {} )\n",
-                                        lengthB.numerical_value(), lengthA.numerical_value(),
+                                        lengthB.numerical_value_ref_in(lengthB.unit),
+                                        lengthA.numerical_value_ref_in(lengthA.unit),
+
                                         conversion_factor(lengthB, lengthA));
 }

--- a/example/currency.cpp
+++ b/example/currency.cpp
@@ -81,11 +81,9 @@ quantity<To, Rep> exchange_to(quantity<From, Rep> q)
 template<ReferenceOf<currency> auto To, ReferenceOf<currency> auto From, auto PO, typename Rep>
 quantity_point<To, PO, Rep> exchange_to(quantity_point<From, PO, Rep> q)
 {
-  return quantity_point{zero +
-
-                        static_cast<Rep>(exchange_rate<q.unit, get_unit(To)>() *
-                                         (q - q.absolute_point_origin).numerical_value_ref_in(q.unit)) *
-                          To};
+  return quantity_point{zero + static_cast<Rep>(exchange_rate<q.unit, get_unit(To)>() *
+                                                (q - q.absolute_point_origin).numerical_value_ref_in(q.unit)) *
+                                 To};
 }
 
 int main()

--- a/example/currency.cpp
+++ b/example/currency.cpp
@@ -81,9 +81,11 @@ quantity<To, Rep> exchange_to(quantity<From, Rep> q)
 template<ReferenceOf<currency> auto To, ReferenceOf<currency> auto From, auto PO, typename Rep>
 quantity_point<To, PO, Rep> exchange_to(quantity_point<From, PO, Rep> q)
 {
-  return quantity_point{
-    zero +
-    static_cast<Rep>(exchange_rate<q.unit, get_unit(To)>() * (q - q.absolute_point_origin).numerical_value()) * To};
+  return quantity_point{zero +
+
+                        static_cast<Rep>(exchange_rate<q.unit, get_unit(To)>() *
+                                         (q - q.absolute_point_origin).numerical_value_ref_in(q.unit)) *
+                          To};
 }
 
 int main()

--- a/example/currency.cpp
+++ b/example/currency.cpp
@@ -82,7 +82,7 @@ template<ReferenceOf<currency> auto To, ReferenceOf<currency> auto From, auto PO
 quantity_point<To, PO, Rep> exchange_to(quantity_point<From, PO, Rep> q)
 {
   return quantity_point{zero + static_cast<Rep>(exchange_rate<q.unit, get_unit(To)>() *
-                                                (q - q.absolute_point_origin).numerical_value_ref_in(q.unit)) *
+                                                (q - q.absolute_point_origin).numerical_value_in(q.unit)) *
                                  To};
 }
 

--- a/example/currency.cpp
+++ b/example/currency.cpp
@@ -93,6 +93,6 @@ int main()
   quantity_point price_usd = zero + 100 * us_dollar;
   quantity_point price_euro = exchange_to<euro>(price_usd);
 
-  std::cout << price_usd.quantity_from_origin() << " -> " << price_euro.quantity_from_origin() << "\n";
-  // std::cout << price_usd.quantity_from_origin() + price_euro.quantity_from_origin() << "\n";  // does not compile
+  std::cout << price_usd.quantity_ref_from(zero) << " -> " << price_euro.quantity_ref_from(zero) << "\n";
+  // std::cout << price_usd.quantity_ref_from(zero) + price_euro.quantity_ref_from(zero) << "\n";  // does not compile
 }

--- a/example/currency.cpp
+++ b/example/currency.cpp
@@ -91,6 +91,6 @@ int main()
   quantity_point price_usd = zero + 100 * us_dollar;
   quantity_point price_euro = exchange_to<euro>(price_usd);
 
-  std::cout << price_usd.quantity_ref_from(zero) << " -> " << price_euro.quantity_ref_from(zero) << "\n";
-  // std::cout << price_usd.quantity_ref_from(zero) + price_euro.quantity_ref_from(zero) << "\n";  // does not compile
+  std::cout << price_usd.quantity_from(zero) << " -> " << price_euro.quantity_from(zero) << "\n";
+  // std::cout << price_usd.quantity_from(zero) + price_euro.quantity_from(zero) << "\n";  // does not compile
 }

--- a/example/glide_computer.cpp
+++ b/example/glide_computer.cpp
@@ -83,12 +83,12 @@ void print(const R& gliders)
     std::cout << "- Name: " << g.name << "\n";
     std::cout << "- Polar:\n";
     for (const auto& p : g.polar) {
-      const auto ratio = value_cast<one>(glide_ratio(g.polar[0]));
+      const auto ratio = glide_ratio(g.polar[0]).force_in(one);
       std::cout << MP_UNITS_STD_FMT::format("  * {:%.4Q %q} @ {:%.1Q %q} -> {:%.1Q %q} ({:%.1Q %q})\n", p.climb, p.v,
                                             ratio,
                                             // TODO is it possible to make ADL work below (we need another set of trig
                                             // functions for strong angle in a different namespace)
-                                            value_cast<si::degree>(isq::asin(1 / ratio)));
+                                            isq::asin(1 / ratio).force_in(si::degree));
     }
     std::cout << "\n";
   }

--- a/example/include/geographic.h
+++ b/example/include/geographic.h
@@ -138,7 +138,7 @@ struct MP_UNITS_STD_FMT::formatter<geographic::latitude<T>> :
   auto format(geographic::latitude<T> lat, FormatContext& ctx)
   {
     formatter<typename geographic::latitude<T>::quantity_type>::format(
-      is_gt_zero(lat) ? lat.quantity_from_origin() : -lat.quantity_from_origin(), ctx);
+      is_gt_zero(lat) ? lat.quantity_ref_from(geographic::equator) : -lat.quantity_ref_from(geographic::equator), ctx);
     MP_UNITS_STD_FMT::format_to(ctx.out(), "{}", is_gt_zero(lat) ? " N" : "S");
     return ctx.out();
   }
@@ -151,7 +151,9 @@ struct MP_UNITS_STD_FMT::formatter<geographic::longitude<T>> :
   auto format(geographic::longitude<T> lon, FormatContext& ctx)
   {
     formatter<typename geographic::longitude<T>::quantity_type>::format(
-      is_gt_zero(lon) ? lon.quantity_from_origin() : -lon.quantity_from_origin(), ctx);
+      is_gt_zero(lon) ? lon.quantity_ref_from(geographic::prime_meridian)
+                      : -lon.quantity_ref_from(geographic::prime_meridian),
+      ctx);
     MP_UNITS_STD_FMT::format_to(ctx.out(), "{}", is_gt_zero(lon) ? " E" : " W");
     return ctx.out();
   }
@@ -175,10 +177,10 @@ distance spherical_distance(position<T> from, position<T> to)
 
   using isq::sin, isq::cos, isq::asin, isq::acos;
 
-  const auto& from_lat = from.lat.quantity_from_origin();
-  const auto& from_lon = from.lon.quantity_from_origin();
-  const auto& to_lat = to.lat.quantity_from_origin();
-  const auto& to_lon = to.lon.quantity_from_origin();
+  const auto& from_lat = from.lat.quantity_ref_from(equator);
+  const auto& from_lon = from.lon.quantity_ref_from(prime_meridian);
+  const auto& to_lat = to.lat.quantity_ref_from(equator);
+  const auto& to_lon = to.lon.quantity_ref_from(prime_meridian);
 
   // https://en.wikipedia.org/wiki/Great-circle_distance#Formulae
   if constexpr (sizeof(T) >= 8) {

--- a/example/include/geographic.h
+++ b/example/include/geographic.h
@@ -138,7 +138,7 @@ struct MP_UNITS_STD_FMT::formatter<geographic::latitude<T>> :
   auto format(geographic::latitude<T> lat, FormatContext& ctx)
   {
     formatter<typename geographic::latitude<T>::quantity_type>::format(
-      is_gt_zero(lat) ? lat.quantity_ref_from(geographic::equator) : -lat.quantity_ref_from(geographic::equator), ctx);
+      is_gt_zero(lat) ? lat.quantity_from(geographic::equator) : -lat.quantity_from(geographic::equator), ctx);
     MP_UNITS_STD_FMT::format_to(ctx.out(), "{}", is_gt_zero(lat) ? " N" : "S");
     return ctx.out();
   }
@@ -151,8 +151,7 @@ struct MP_UNITS_STD_FMT::formatter<geographic::longitude<T>> :
   auto format(geographic::longitude<T> lon, FormatContext& ctx)
   {
     formatter<typename geographic::longitude<T>::quantity_type>::format(
-      is_gt_zero(lon) ? lon.quantity_ref_from(geographic::prime_meridian)
-                      : -lon.quantity_ref_from(geographic::prime_meridian),
+      is_gt_zero(lon) ? lon.quantity_from(geographic::prime_meridian) : -lon.quantity_from(geographic::prime_meridian),
       ctx);
     MP_UNITS_STD_FMT::format_to(ctx.out(), "{}", is_gt_zero(lon) ? " E" : " W");
     return ctx.out();
@@ -173,28 +172,29 @@ template<typename T>
 distance spherical_distance(position<T> from, position<T> to)
 {
   using namespace mp_units;
-  constexpr auto earth_radius = 6'371 * isq::radius[si::kilo<si::metre>];
+  constexpr quantity earth_radius = 6'371 * isq::radius[si::kilo<si::metre>];
 
   using isq::sin, isq::cos, isq::asin, isq::acos;
 
-  const auto& from_lat = from.lat.quantity_ref_from(equator);
-  const auto& from_lon = from.lon.quantity_ref_from(prime_meridian);
-  const auto& to_lat = to.lat.quantity_ref_from(equator);
-  const auto& to_lon = to.lon.quantity_ref_from(prime_meridian);
+  const quantity from_lat = from.lat.quantity_from(equator);
+  const quantity from_lon = from.lon.quantity_from(prime_meridian);
+  const quantity to_lat = to.lat.quantity_from(equator);
+  const quantity to_lon = to.lon.quantity_from(prime_meridian);
 
   // https://en.wikipedia.org/wiki/Great-circle_distance#Formulae
   if constexpr (sizeof(T) >= 8) {
     // spherical law of cosines
-    const auto central_angle = acos(sin(from_lat) * sin(to_lat) + cos(from_lat) * cos(to_lat) * cos(to_lon - from_lon));
+    const quantity central_angle =
+      acos(sin(from_lat) * sin(to_lat) + cos(from_lat) * cos(to_lat) * cos(to_lon - from_lon));
     // const auto central_angle = 2 * asin(sqrt(0.5 - cos(to_lat - from_lat) / 2 + cos(from_lat) * cos(to_lat) * (1
     // - cos(lon2_rad - from_lon)) / 2));
 
     return quantity_cast<isq::distance>(earth_radius * central_angle);
   } else {
     // the haversine formula
-    const auto sin_lat = sin((to_lat - from_lat) / 2);
-    const auto sin_lon = sin((to_lon - from_lon) / 2);
-    const auto central_angle = 2 * asin(sqrt(sin_lat * sin_lat + cos(from_lat) * cos(to_lat) * sin_lon * sin_lon));
+    const quantity sin_lat = sin((to_lat - from_lat) / 2);
+    const quantity sin_lon = sin((to_lon - from_lon) / 2);
+    const quantity central_angle = 2 * asin(sqrt(sin_lat * sin_lat + cos(from_lat) * cos(to_lat) * sin_lon * sin_lon));
 
     return quantity_cast<isq::distance>(earth_radius * central_angle);
   }

--- a/example/kalman_filter/kalman.h
+++ b/example/kalman_filter/kalman.h
@@ -212,7 +212,7 @@ struct MP_UNITS_STD_FMT::formatter<kalman::estimation<Q>> {
       if constexpr (mp_units::Quantity<Q>)
         return t;
       else
-        return t.quantity_from_origin();
+        return t.quantity_ref_from(t.point_origin);
     }(kalman::get<0>(e.state));
 
     std::string value_buffer;

--- a/example/kalman_filter/kalman_filter-example_6.cpp
+++ b/example/kalman_filter/kalman_filter-example_6.cpp
@@ -45,7 +45,7 @@ template<QuantityPoint QP, QuantityOf<dimensionless> K>
 void print(auto iteration, K gain, QP measured, kalman::estimation<QP> current, kalman::estimation<QP> next)
 {
   std::cout << MP_UNITS_STD_FMT::format("{:2} | {:7%.4Q} | {:10%.3Q %q} | {:>18.3} | {:>18.3}\n", iteration, gain,
-                                        measured.quantity_from_origin(), current, next);
+                                        measured.quantity_ref_from(QP::point_origin), current, next);
 }
 
 int main()

--- a/example/kalman_filter/kalman_filter-example_7.cpp
+++ b/example/kalman_filter/kalman_filter-example_7.cpp
@@ -45,7 +45,7 @@ template<QuantityPoint QP, QuantityOf<dimensionless> K>
 void print(auto iteration, K gain, QP measured, kalman::estimation<QP> current, kalman::estimation<QP> next)
 {
   std::cout << MP_UNITS_STD_FMT::format("{:2} | {:7%.4Q} | {:10%.3Q %q} | {:>18.3} | {:>18.3}\n", iteration, gain,
-                                        measured.quantity_from_origin(), current, next);
+                                        measured.quantity_ref_from(QP::point_origin), current, next);
 }
 
 int main()

--- a/example/kalman_filter/kalman_filter-example_8.cpp
+++ b/example/kalman_filter/kalman_filter-example_8.cpp
@@ -45,7 +45,7 @@ template<QuantityPoint QP, QuantityOf<dimensionless> K>
 void print(auto iteration, K gain, QP measured, kalman::estimation<QP> current, kalman::estimation<QP> next)
 {
   std::cout << MP_UNITS_STD_FMT::format("{:2} | {:7%.3Q} | {:10%.3Q %q} | {:>16.2} | {:>16.2}\n", iteration, gain,
-                                        measured.quantity_from_origin(), current, next);
+                                        measured.quantity_ref_from(QP::point_origin), current, next);
 }
 
 int main()

--- a/example/total_energy.cpp
+++ b/example/total_energy.cpp
@@ -80,7 +80,7 @@ void si_example()
             << "E = " << E3 << "\n";
 
   std::cout << "\n[converted from SI units back to GeV]\n"
-            << "E = " << value_cast<GeV>(E3) << "\n";
+            << "E = " << E3.force_in(GeV) << "\n";
 }
 
 void natural_example()

--- a/example/unmanned_aerial_vehicle.cpp
+++ b/example/unmanned_aerial_vehicle.cpp
@@ -97,8 +97,8 @@ template<earth_gravity_model M>
 hae_altitude<M> to_hae(msl_altitude msl, position<long double> pos)
 {
   const auto geoid_undulation =
-    isq::height(GeographicLibWhatsMyOffset(pos.lat.quantity_ref_from(equator).numerical_value_in(si::degree),
-                                           pos.lon.quantity_ref_from(prime_meridian).numerical_value_in(si::degree)) *
+    isq::height(GeographicLibWhatsMyOffset(pos.lat.quantity_from(equator).numerical_value_in(si::degree),
+                                           pos.lon.quantity_from(prime_meridian).numerical_value_in(si::degree)) *
                 si::metre);
   return height_above_ellipsoid<M> + (msl - mean_sea_level - geoid_undulation);
 }
@@ -115,7 +115,7 @@ using hal_altitude = quantity_point<isq::altitude[si::metre], height_above_launc
 template<class CharT, class Traits>
 std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, const hal_altitude& a)
 {
-  return os << a.quantity_ref_from(height_above_launch) << " HAL";
+  return os << a.quantity_from(height_above_launch) << " HAL";
 }
 
 template<>
@@ -123,7 +123,7 @@ struct MP_UNITS_STD_FMT::formatter<hal_altitude> : formatter<hal_altitude::quant
   template<typename FormatContext>
   auto format(const hal_altitude& a, FormatContext& ctx)
   {
-    formatter<hal_altitude::quantity_type>::format(a.quantity_ref_from(height_above_launch), ctx);
+    formatter<hal_altitude::quantity_type>::format(a.quantity_from(height_above_launch), ctx);
     return MP_UNITS_STD_FMT::format_to(ctx.out(), " HAL");
   }
 };

--- a/example/unmanned_aerial_vehicle.cpp
+++ b/example/unmanned_aerial_vehicle.cpp
@@ -97,8 +97,8 @@ template<earth_gravity_model M>
 hae_altitude<M> to_hae(msl_altitude msl, position<long double> pos)
 {
   const auto geoid_undulation =
-    isq::height(GeographicLibWhatsMyOffset(pos.lat.quantity_from_origin().numerical_value_in(si::degree),
-                                           pos.lon.quantity_from_origin().numerical_value_in(si::degree)) *
+    isq::height(GeographicLibWhatsMyOffset(pos.lat.quantity_ref_from(equator).numerical_value_in(si::degree),
+                                           pos.lon.quantity_ref_from(prime_meridian).numerical_value_in(si::degree)) *
                 si::metre);
   return height_above_ellipsoid<M> + (msl - mean_sea_level - geoid_undulation);
 }
@@ -115,7 +115,7 @@ using hal_altitude = quantity_point<isq::altitude[si::metre], height_above_launc
 template<class CharT, class Traits>
 std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, const hal_altitude& a)
 {
-  return os << a.quantity_from_origin() << " HAL";
+  return os << a.quantity_ref_from(height_above_launch) << " HAL";
 }
 
 template<>
@@ -123,7 +123,7 @@ struct MP_UNITS_STD_FMT::formatter<hal_altitude> : formatter<hal_altitude::quant
   template<typename FormatContext>
   auto format(const hal_altitude& a, FormatContext& ctx)
   {
-    formatter<hal_altitude::quantity_type>::format(a.quantity_from_origin(), ctx);
+    formatter<hal_altitude::quantity_type>::format(a.quantity_ref_from(height_above_launch), ctx);
     return MP_UNITS_STD_FMT::format_to(ctx.out(), " HAL");
   }
 };

--- a/src/core-fmt/include/mp-units/format.h
+++ b/src/core-fmt/include/mp-units/format.h
@@ -224,9 +224,9 @@ struct quantity_formatter {
   const quantity_format_specs<CharT>& specs;
   Locale loc;
 
-  explicit quantity_formatter(OutputIt o, quantity<Reference, Rep> q, const quantity_format_specs<CharT>& fspecs,
+  explicit quantity_formatter(OutputIt o, const quantity<Reference, Rep>& q, const quantity_format_specs<CharT>& fspecs,
                               Locale lc) :
-      out(o), val(std::move(q).numerical_value_ref_in(q.unit)), specs(fspecs), loc(std::move(lc))
+      out(o), val(q.numerical_value_ref_in(q.unit)), specs(fspecs), loc(std::move(lc))
   {
   }
 

--- a/src/core-fmt/include/mp-units/format.h
+++ b/src/core-fmt/include/mp-units/format.h
@@ -226,7 +226,7 @@ struct quantity_formatter {
 
   explicit quantity_formatter(OutputIt o, quantity<Reference, Rep> q, const quantity_format_specs<CharT>& fspecs,
                               Locale lc) :
-      out(o), val(std::move(q).numerical_value()), specs(fspecs), loc(std::move(lc))
+      out(o), val(std::move(q).numerical_value_ref_in(q.unit)), specs(fspecs), loc(std::move(lc))
   {
   }
 
@@ -396,7 +396,8 @@ private:
 
     if (begin == end || *begin == '}') {
       // default format should print value followed by the unit separated with 1 space
-      out = mp_units::detail::format_units_quantity_value<CharT>(out, q.numerical_value(), specs.rep, ctx.locale());
+      out = mp_units::detail::format_units_quantity_value<CharT>(out, q.numerical_value_ref_in(q.unit), specs.rep,
+                                                                 ctx.locale());
       if constexpr (mp_units::detail::has_unit_symbol(get_unit(Reference))) {
         if constexpr (mp_units::space_before_unit_symbol<get_unit(Reference)>) *out++ = CharT(' ');
         out = unit_symbol_to<CharT>(out, get_unit(Reference));

--- a/src/core-io/include/mp-units/ostream.h
+++ b/src/core-io/include/mp-units/ostream.h
@@ -36,9 +36,9 @@ void to_stream(std::basic_ostream<CharT, Traits>& os, const quantity<R, Rep>& q)
 {
   if constexpr (is_same_v<Rep, std::uint8_t> || is_same_v<Rep, std::int8_t>)
     // promote the value to int
-    os << +q.numerical_value();
+    os << +q.numerical_value_ref_in(q.unit);
   else
-    os << q.numerical_value();
+    os << q.numerical_value_ref_in(q.unit);
   if constexpr (has_unit_symbol(get_unit(R))) {
     if constexpr (space_before_unit_symbol<get_unit(R)>) os << " ";
     unit_symbol_to<CharT>(std::ostream_iterator<CharT>(os), get_unit(R));
@@ -49,7 +49,7 @@ void to_stream(std::basic_ostream<CharT, Traits>& os, const quantity<R, Rep>& q)
 
 template<typename CharT, typename Traits, auto R, typename Rep>
 std::basic_ostream<CharT, Traits>& operator<<(std::basic_ostream<CharT, Traits>& os, const quantity<R, Rep>& q)
-  requires requires { os << q.numerical_value(); }
+  requires requires { os << q.numerical_value_ref_in(q.unit); }
 {
   if (os.width()) {
     // std::setw() applies to the whole quantity output so it has to be first put into std::string

--- a/src/core/include/mp-units/bits/quantity_cast.h
+++ b/src/core/include/mp-units/bits/quantity_cast.h
@@ -51,9 +51,9 @@ template<QuantitySpec auto ToQS, typename Q>
 {
   if constexpr (detail::QuantityKindSpec<std::remove_const_t<decltype(ToQS)>> &&
                 AssociatedUnit<std::remove_const_t<decltype(Q::unit)>>)
-    return make_quantity<Q::unit>(std::forward<Q>(q).numerical_value());
+    return make_quantity<Q::unit>(std::forward<Q>(q).numerical_value_ref_in(q.unit));
   else
-    return make_quantity<reference<ToQS, Q::unit>{}>(std::forward<Q>(q).numerical_value());
+    return make_quantity<reference<ToQS, Q::unit>{}>(std::forward<Q>(q).numerical_value_ref_in(q.unit));
 }
 
 }  // namespace mp_units

--- a/src/core/include/mp-units/bits/quantity_cast.h
+++ b/src/core/include/mp-units/bits/quantity_cast.h
@@ -51,9 +51,9 @@ template<QuantitySpec auto ToQS, typename Q>
 {
   if constexpr (detail::QuantityKindSpec<std::remove_const_t<decltype(ToQS)>> &&
                 AssociatedUnit<std::remove_const_t<decltype(Q::unit)>>)
-    return make_quantity<Q::unit>(std::forward<Q>(q).numerical_value_ref_in(q.unit));
+    return make_quantity<Q::unit>(std::forward<Q>(q).numerical_value_);
   else
-    return make_quantity<reference<ToQS, Q::unit>{}>(std::forward<Q>(q).numerical_value_ref_in(q.unit));
+    return make_quantity<reference<ToQS, Q::unit>{}>(std::forward<Q>(q).numerical_value_);
 }
 
 }  // namespace mp_units

--- a/src/core/include/mp-units/bits/sudo_cast.h
+++ b/src/core/include/mp-units/bits/sudo_cast.h
@@ -63,10 +63,10 @@ template<Quantity To, typename From>
   if constexpr (q_unit == To::unit) {
     // no scaling of the number needed
     return make_quantity<To::reference>(static_cast<MP_UNITS_TYPENAME To::rep>(
-      std::forward<From>(q).numerical_value_ref_in(q_unit)));  // this is the only (and recommended) way to do
-                                                               // a truncating conversion on a number, so we are
-                                                               // using static_cast to suppress all the compiler
-                                                               // warnings on conversions
+      std::forward<From>(q).numerical_value_));  // this is the only (and recommended) way to do
+                                                 // a truncating conversion on a number, so we are
+                                                 // using static_cast to suppress all the compiler
+                                                 // warnings on conversions
   } else {
     // scale the number
     constexpr Magnitude auto c_mag = get_canonical_unit(q_unit).mag / get_canonical_unit(To::unit).mag;
@@ -78,9 +78,8 @@ template<Quantity To, typename From>
     using multiplier_type =
       conditional<treat_as_floating_point<c_rep_type>, std::common_type_t<c_mag_type, long double>, c_mag_type>;
     constexpr auto val = [](Magnitude auto m) { return get_value<multiplier_type>(m); };
-    return static_cast<MP_UNITS_TYPENAME To::rep>(
-             static_cast<c_rep_type>(std::forward<From>(q).numerical_value_ref_in(q_unit)) * val(num) / val(den) *
-             val(irr)) *
+    return static_cast<MP_UNITS_TYPENAME To::rep>(static_cast<c_rep_type>(std::forward<From>(q).numerical_value_) *
+                                                  val(num) / val(den) * val(irr)) *
            To::reference;
   }
 }

--- a/src/core/include/mp-units/bits/sudo_cast.h
+++ b/src/core/include/mp-units/bits/sudo_cast.h
@@ -63,10 +63,10 @@ template<Quantity To, typename From>
   if constexpr (q_unit == To::unit) {
     // no scaling of the number needed
     return make_quantity<To::reference>(static_cast<MP_UNITS_TYPENAME To::rep>(
-      std::forward<From>(q).numerical_value()));  // this is the only (and recommended) way to do
-                                                  // a truncating conversion on a number, so we are
-                                                  // using static_cast to suppress all the compiler
-                                                  // warnings on conversions
+      std::forward<From>(q).numerical_value_ref_in(q_unit)));  // this is the only (and recommended) way to do
+                                                               // a truncating conversion on a number, so we are
+                                                               // using static_cast to suppress all the compiler
+                                                               // warnings on conversions
   } else {
     // scale the number
     constexpr Magnitude auto c_mag = get_canonical_unit(q_unit).mag / get_canonical_unit(To::unit).mag;
@@ -78,8 +78,9 @@ template<Quantity To, typename From>
     using multiplier_type =
       conditional<treat_as_floating_point<c_rep_type>, std::common_type_t<c_mag_type, long double>, c_mag_type>;
     constexpr auto val = [](Magnitude auto m) { return get_value<multiplier_type>(m); };
-    return static_cast<MP_UNITS_TYPENAME To::rep>(static_cast<c_rep_type>(std::forward<From>(q).numerical_value()) *
-                                                  val(num) / val(den) * val(irr)) *
+    return static_cast<MP_UNITS_TYPENAME To::rep>(
+             static_cast<c_rep_type>(std::forward<From>(q).numerical_value_ref_in(q_unit)) * val(num) / val(den) *
+             val(irr)) *
            To::reference;
   }
 }

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -269,88 +269,97 @@ public:
   }
 
   // compound assignment operators
-  constexpr quantity& operator+=(const quantity& q)
-    requires requires(rep a, rep b) {
+  template<typename Q>
+    requires std::derived_from<std::remove_cvref_t<Q>, quantity> && requires(rep a, rep b) {
       {
         a += b
       } -> std::same_as<rep&>;
     }
+  friend constexpr decltype(auto) operator+=(Q&& lhs, const quantity& rhs)
   {
-    numerical_value_ += q.numerical_value_ref_in(unit);
-    return *this;
+    lhs.numerical_value_ += rhs.numerical_value_;
+    return std::forward<Q>(lhs);
   }
 
-  constexpr quantity& operator-=(const quantity& q)
-    requires requires(rep a, rep b) {
+  template<typename Q>
+    requires std::derived_from<std::remove_cvref_t<Q>, quantity> && requires(rep a, rep b) {
       {
         a -= b
       } -> std::same_as<rep&>;
     }
+  friend constexpr decltype(auto) operator-=(Q&& lhs, const quantity& rhs)
   {
-    numerical_value_ -= q.numerical_value_ref_in(unit);
-    return *this;
+    lhs.numerical_value_ -= rhs.numerical_value_;
+    return std::forward<Q>(lhs);
   }
 
-  constexpr quantity& operator%=(const quantity& q)
-    requires(!treat_as_floating_point<rep>) && requires(rep a, rep b) {
-      {
-        a %= b
-      } -> std::same_as<rep&>;
-    }
+  template<typename Q>
+    requires std::derived_from<std::remove_cvref_t<Q>, quantity> && (!treat_as_floating_point<rep>) &&
+             requires(rep a, rep b) {
+               {
+                 a %= b
+               } -> std::same_as<rep&>;
+             }
+  friend constexpr decltype(auto) operator%=(Q&& lhs, const quantity& rhs)
+
   {
-    gsl_ExpectsAudit(q != zero());
-    numerical_value_ %= q.numerical_value_ref_in(unit);
-    return *this;
+    gsl_ExpectsAudit(rhs != zero());
+    lhs.numerical_value_ %= rhs.numerical_value_;
+    return std::forward<Q>(lhs);
   }
 
-  template<typename Value>
-    requires(!Quantity<Value>) && requires(rep a, const Value b) {
-      {
-        a *= b
-      } -> std::same_as<rep&>;
-    }
-  constexpr quantity& operator*=(const Value& v)
+  template<typename Q, typename Value>
+    requires std::derived_from<std::remove_cvref_t<Q>, quantity> && (!Quantity<Value>) &&
+             requires(rep a, const Value b) {
+               {
+                 a *= b
+               } -> std::same_as<rep&>;
+             }
+  friend constexpr decltype(auto) operator*=(Q&& lhs, const Value& v)
   {
-    numerical_value_ *= v;
-    return *this;
+    lhs.numerical_value_ *= v;
+    return std::forward<Q>(lhs);
   }
 
-  template<QuantityOf<dimension_one> Q>
-    requires(Q::unit == ::mp_units::one) && requires(rep a, const typename Q::rep b) {
-      {
-        a *= b
-      } -> std::same_as<rep&>;
-    }
-  constexpr quantity& operator*=(const Q& rhs)
+  template<typename Q1, QuantityOf<dimension_one> Q2>
+    requires std::derived_from<std::remove_cvref_t<Q1>, quantity> && (Q2::unit == ::mp_units::one) &&
+             requires(rep a, const typename Q2::rep b) {
+               {
+                 a *= b
+               } -> std::same_as<rep&>;
+             }
+  friend constexpr decltype(auto) operator*=(Q1&& lhs, const Q2& rhs)
   {
-    numerical_value_ *= rhs.numerical_value_ref_in(::mp_units::one);
-    return *this;
+    lhs.numerical_value_ *= rhs.numerical_value_;
+    return std::forward<Q1>(lhs);
   }
 
-  template<typename Value>
-    requires(!Quantity<Value>) && requires(rep a, const Value b) {
-      {
-        a /= b
-      } -> std::same_as<rep&>;
-    }
-  constexpr quantity& operator/=(const Value& v)
+  template<typename Q, typename Value>
+    requires std::derived_from<std::remove_cvref_t<Q>, quantity> && (!Quantity<Value>) &&
+             requires(rep a, const Value b) {
+               {
+                 a /= b
+               } -> std::same_as<rep&>;
+             }
+  friend constexpr decltype(auto) operator/=(Q&& lhs, const Value& v)
   {
     gsl_ExpectsAudit(v != quantity_values<Value>::zero());
-    numerical_value_ /= v;
-    return *this;
+    lhs.numerical_value_ /= v;
+    return std::forward<Q>(lhs);
   }
 
-  template<QuantityOf<dimension_one> Q>
-    requires(Q::unit == ::mp_units::one) && requires(rep a, const typename Q::rep b) {
-      {
-        a /= b
-      } -> std::same_as<rep&>;
-    }
-  constexpr quantity& operator/=(const Q& rhs)
+  template<typename Q1, QuantityOf<dimension_one> Q2>
+    requires std::derived_from<std::remove_cvref_t<Q1>, quantity> && (Q2::unit == ::mp_units::one) &&
+             requires(rep a, const typename Q2::rep b) {
+               {
+                 a /= b
+               } -> std::same_as<rep&>;
+             }
+  friend constexpr decltype(auto) operator/=(Q1&& lhs, const Q2& rhs)
   {
     gsl_ExpectsAudit(rhs != rhs.zero());
-    numerical_value_ /= rhs.numerical_value_ref_in(::mp_units::one);
-    return *this;
+    lhs.numerical_value_ /= rhs.numerical_value_;
+    return std::forward<Q1>(lhs);
   }
 
 private:

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -198,10 +198,10 @@ public:
   }
 
   template<Unit U>
-    requires requires(quantity q) { value_cast<U{}>(q); }
+    requires requires(quantity q) { q.force_in(U{}); }
   [[nodiscard]] constexpr rep force_numerical_value_in(U) const noexcept
   {
-    return value_cast<U{}>(*this).numerical_value_in(U{});
+    return (*this).force_in(U{}).numerical_value_ref_in(U{});
   }
 
   // member unary operators

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -145,7 +145,7 @@ public:
 #ifdef __cpp_explicit_this_parameter
   template<typename Self, Unit U>
     requires(U{} == unit)
-  [[nodiscard]] constexpr auto&& value_ref_in(this Self&& self, U) noexcept
+  [[nodiscard]] constexpr auto&& numerical_value_ref_in(this Self&& self, U) noexcept
   {
     return std::forward<Self>(self).value_;
   }

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -85,7 +85,7 @@ using common_quantity_for = quantity<common_reference(Q1::reference, Q2::referen
 template<Reference auto R, RepresentationOf<get_quantity_spec(R).character> Rep = double>
 class quantity {
 public:
-  Rep value_;  // needs to be public for a structural type
+  Rep numerical_value_;  // needs to be public for a structural type
 
   // member types and values
   static constexpr Reference auto reference = R;
@@ -126,7 +126,7 @@ public:
 
   template<detail::QuantityConvertibleTo<quantity> Q>
   constexpr explicit(!std::convertible_to<typename Q::rep, Rep>) quantity(const Q& q) :
-      value_(detail::sudo_cast<quantity>(q).numerical_value_ref_in(unit))
+      numerical_value_(detail::sudo_cast<quantity>(q).numerical_value_ref_in(unit))
   {
   }
 
@@ -162,32 +162,32 @@ public:
     requires(U{} == unit)
   [[nodiscard]] constexpr auto&& numerical_value_ref_in(this Self&& self, U) noexcept
   {
-    return std::forward<Self>(self).value_;
+    return std::forward<Self>(self).numerical_value_;
   }
 #else
   template<Unit U>
     requires(U{} == unit)
   [[nodiscard]] constexpr rep& numerical_value_ref_in(U) & noexcept
   {
-    return value_;
+    return numerical_value_;
   }
   template<Unit U>
     requires(U{} == unit)
   [[nodiscard]] constexpr const rep& numerical_value_ref_in(U) const& noexcept
   {
-    return value_;
+    return numerical_value_;
   }
   template<Unit U>
     requires(U{} == unit)
   [[nodiscard]] constexpr rep&& numerical_value_ref_in(U) && noexcept
   {
-    return std::move(value_);
+    return std::move(numerical_value_);
   }
   template<Unit U>
     requires(U{} == unit)
   [[nodiscard]] constexpr const rep&& numerical_value_ref_in(U) const&& noexcept
   {
-    return std::move(value_);
+    return std::move(numerical_value_);
   }
 #endif
 
@@ -233,7 +233,7 @@ public:
       } -> std::same_as<rep&>;
     }
   {
-    ++value_;
+    ++numerical_value_;
     return *this;
   }
 
@@ -244,7 +244,7 @@ public:
       } -> std::common_with<rep>;
     }
   {
-    return make_quantity<reference>(value_++);
+    return make_quantity<reference>(numerical_value_++);
   }
 
   constexpr quantity& operator--()
@@ -254,7 +254,7 @@ public:
       } -> std::same_as<rep&>;
     }
   {
-    --value_;
+    --numerical_value_;
     return *this;
   }
 
@@ -265,7 +265,7 @@ public:
       } -> std::common_with<rep>;
     }
   {
-    return make_quantity<reference>(value_--);
+    return make_quantity<reference>(numerical_value_--);
   }
 
   // compound assignment operators
@@ -276,7 +276,7 @@ public:
       } -> std::same_as<rep&>;
     }
   {
-    value_ += q.numerical_value_ref_in(unit);
+    numerical_value_ += q.numerical_value_ref_in(unit);
     return *this;
   }
 
@@ -287,7 +287,7 @@ public:
       } -> std::same_as<rep&>;
     }
   {
-    value_ -= q.numerical_value_ref_in(unit);
+    numerical_value_ -= q.numerical_value_ref_in(unit);
     return *this;
   }
 
@@ -299,7 +299,7 @@ public:
     }
   {
     gsl_ExpectsAudit(q != zero());
-    value_ %= q.numerical_value_ref_in(unit);
+    numerical_value_ %= q.numerical_value_ref_in(unit);
     return *this;
   }
 
@@ -311,7 +311,7 @@ public:
     }
   constexpr quantity& operator*=(const Value& v)
   {
-    value_ *= v;
+    numerical_value_ *= v;
     return *this;
   }
 
@@ -323,7 +323,7 @@ public:
     }
   constexpr quantity& operator*=(const Q& rhs)
   {
-    value_ *= rhs.numerical_value_ref_in(::mp_units::one);
+    numerical_value_ *= rhs.numerical_value_ref_in(::mp_units::one);
     return *this;
   }
 
@@ -336,7 +336,7 @@ public:
   constexpr quantity& operator/=(const Value& v)
   {
     gsl_ExpectsAudit(v != quantity_values<Value>::zero());
-    value_ /= v;
+    numerical_value_ /= v;
     return *this;
   }
 
@@ -349,7 +349,7 @@ public:
   constexpr quantity& operator/=(const Q& rhs)
   {
     gsl_ExpectsAudit(rhs != rhs.zero());
-    value_ /= rhs.numerical_value_ref_in(::mp_units::one);
+    numerical_value_ /= rhs.numerical_value_ref_in(::mp_units::one);
     return *this;
   }
 
@@ -363,7 +363,7 @@ private:
 
   template<typename Value>
     requires std::constructible_from<rep, Value&&>
-  constexpr explicit quantity(Value&& v) : value_(std::forward<Value>(v))
+  constexpr explicit quantity(Value&& v) : numerical_value_(std::forward<Value>(v))
   {
   }
 };

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -184,6 +184,13 @@ public:
   }
 
   template<Unit U>
+    requires requires(quantity q) { value_cast<U{}>(q); }
+  [[nodiscard]] constexpr rep force_numerical_value_in(U) const noexcept
+  {
+    return value_cast<U{}>(*this).numerical_value_in(U{});
+  }
+
+  template<Unit U>
     requires detail::QuantityConvertibleTo<quantity, quantity<quantity_spec[U{}], Rep>>
   [[nodiscard]] constexpr quantity<quantity_spec[U{}], Rep> in(U) const
   {

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -141,6 +141,20 @@ public:
   quantity& operator=(const quantity&) = default;
   quantity& operator=(quantity&&) = default;
 
+  // conversions
+  template<Unit U>
+    requires detail::QuantityConvertibleTo<quantity, quantity<quantity_spec[U{}], Rep>>
+  [[nodiscard]] constexpr quantity<quantity_spec[U{}], Rep> in(U) const
+  {
+    return quantity<quantity_spec[U{}], Rep>{*this};
+  }
+  template<Unit U>
+    requires requires(quantity q) { value_cast<U{}>(q); }
+  [[nodiscard]] constexpr quantity<quantity_spec[U{}], Rep> force_in(U) const
+  {
+    return value_cast<U{}>(*this);
+  }
+
   // data access
 #ifdef __cpp_explicit_this_parameter
   template<typename Self, Unit U>
@@ -188,13 +202,6 @@ public:
   [[nodiscard]] constexpr rep force_numerical_value_in(U) const noexcept
   {
     return value_cast<U{}>(*this).numerical_value_in(U{});
-  }
-
-  template<Unit U>
-    requires detail::QuantityConvertibleTo<quantity, quantity<quantity_spec[U{}], Rep>>
-  [[nodiscard]] constexpr quantity<quantity_spec[U{}], Rep> in(U) const
-  {
-    return quantity<quantity_spec[U{}], Rep>{*this};
   }
 
   // member unary operators

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -148,6 +148,7 @@ public:
   {
     return quantity<quantity_spec[U{}], Rep>{*this};
   }
+
   template<Unit U>
     requires requires(quantity q) { value_cast<U{}>(q); }
   [[nodiscard]] constexpr quantity<quantity_spec[U{}], Rep> force_in(U) const

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -210,15 +210,16 @@ public:
     return make_quantity<reference>(-numerical_value_);
   }
 
-  constexpr quantity& operator++()
-    requires requires(rep v) {
+  template<typename Q>
+  friend constexpr decltype(auto) operator++(Q&& q)
+    requires std::derived_from<std::remove_cvref_t<Q>, quantity> && requires(rep v) {
       {
         ++v
       } -> std::same_as<rep&>;
     }
   {
-    ++numerical_value_;
-    return *this;
+    ++q.numerical_value_;
+    return std::forward<Q>(q);
   }
 
   [[nodiscard]] constexpr Quantity auto operator++(int)
@@ -231,15 +232,16 @@ public:
     return make_quantity<reference>(numerical_value_++);
   }
 
-  constexpr quantity& operator--()
-    requires requires(rep v) {
+  template<typename Q>
+  friend constexpr decltype(auto) operator--(Q&& q)
+    requires std::derived_from<std::remove_cvref_t<Q>, quantity> && requires(rep v) {
       {
         --v
       } -> std::same_as<rep&>;
     }
   {
-    --numerical_value_;
-    return *this;
+    --q.numerical_value_;
+    return std::forward<Q>(q);
   }
 
   [[nodiscard]] constexpr Quantity auto operator--(int)

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -183,10 +183,17 @@ public:
   }
 
   template<Unit U>
-    requires detail::QuantityConvertibleTo<quantity_type, quantity<::mp_units::reference<quantity_spec, U{}>{}, Rep>>
-  [[nodiscard]] constexpr quantity_point<::mp_units::reference<quantity_spec, U{}>{}, PO, Rep> in(U) const
+    requires detail::QuantityConvertibleTo<quantity_type, quantity<quantity_spec[U{}], Rep>>
+  [[nodiscard]] constexpr quantity_point<quantity_spec[U{}], PO, Rep> in(U) const
   {
     return make_quantity_point<PO>(quantity_ref_from(PO).in(U{}));
+  }
+
+  template<Unit U>
+    requires requires(quantity_type q) { value_cast<U{}>(q); }
+  [[nodiscard]] constexpr quantity_point<quantity_spec[U{}], PO, Rep> force_in(U) const
+  {
+    return make_quantity_point<PO>(quantity_ref_from(PO).force_in(U{}));
   }
 
   // member unary operators

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -183,11 +183,12 @@ public:
   }
 
   // member unary operators
-  constexpr quantity_point& operator++()
-    requires requires { ++quantity_from_origin_; }
+  template<typename QP>
+  friend constexpr decltype(auto) operator++(QP&& qp)
+    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> && requires { ++qp.quantity_from_origin_; }
   {
-    ++quantity_from_origin_;
-    return *this;
+    ++qp.quantity_from_origin_;
+    return std::forward<QP>(qp);
   }
 
   [[nodiscard]] constexpr quantity_point operator++(int)
@@ -196,11 +197,12 @@ public:
     return quantity_point(quantity_from_origin_++);
   }
 
-  constexpr quantity_point& operator--()
-    requires requires { --quantity_from_origin_; }
+  template<typename QP>
+  friend constexpr decltype(auto) operator--(QP&& qp)
+    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> && requires { --qp.quantity_from_origin_; }
   {
-    --quantity_from_origin_;
-    return *this;
+    --qp.quantity_from_origin_;
+    return std::forward<QP>(qp);
   }
 
   [[nodiscard]] constexpr quantity_point operator--(int)

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -224,18 +224,22 @@ public:
   }
 
   // compound assignment operators
-  constexpr quantity_point& operator+=(const quantity_type& q)
-    requires requires { quantity_from_origin_ += q; }
+  template<typename QP>
+    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> &&
+             requires(quantity_type q) { quantity_from_origin_ += q; }
+  friend constexpr decltype(auto) operator+=(QP&& qp, const quantity_type& q)
   {
-    quantity_from_origin_ += q;
-    return *this;
+    qp.quantity_from_origin_ += q;
+    return std::forward<QP>(qp);
   }
 
-  constexpr quantity_point& operator-=(const quantity_type& q)
-    requires requires { quantity_from_origin_ -= q; }
+  template<typename QP>
+    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> &&
+             requires(quantity_type q) { quantity_from_origin_ -= q; }
+  friend constexpr decltype(auto) operator-=(QP&& qp, const quantity_type& q)
   {
-    quantity_from_origin_ -= q;
-    return *this;
+    qp.quantity_from_origin_ -= q;
+    return std::forward<QP>(qp);
   }
 
 private:

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -146,34 +146,20 @@ public:
   }
 
   // data access
-#ifdef __cpp_explicit_this_parameter
-  template<typename Self, std::same_as<std::remove_const_t<decltype(PO)>> PO2>
-  [[nodiscard]] constexpr auto&& quantity_ref_from(this Self&& self, PO2) noexcept
-  {
-    return std::forward<Self>(self).quantity_from_origin_;
-  }
-#else
   template<std::same_as<std::remove_const_t<decltype(PO)>> PO2>
   [[nodiscard]] constexpr quantity_type& quantity_ref_from(PO2) & noexcept
   {
     return quantity_from_origin_;
   }
+
   template<std::same_as<std::remove_const_t<decltype(PO)>> PO2>
   [[nodiscard]] constexpr const quantity_type& quantity_ref_from(PO2) const& noexcept
   {
     return quantity_from_origin_;
   }
+
   template<std::same_as<std::remove_const_t<decltype(PO)>> PO2>
-  [[nodiscard]] constexpr quantity_type&& quantity_ref_from(PO2) && noexcept
-  {
-    return std::move(quantity_from_origin_);
-  }
-  template<std::same_as<std::remove_const_t<decltype(PO)>> PO2>
-  [[nodiscard]] constexpr const quantity_type&& quantity_ref_from(PO2) const&& noexcept
-  {
-    return std::move(quantity_from_origin_);
-  }
-#endif
+  constexpr const quantity_type&& quantity_ref_from(PO2) const&& noexcept = delete;
 
   template<PointOrigin PO2>
     requires requires { quantity_point{} - PO2{}; }

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -82,7 +82,7 @@ public:
   using rep = Rep;
   using quantity_type = quantity<reference, Rep>;
 
-  quantity_type q_;  // needs to be public for a structural type
+  quantity_type quantity_from_origin_;  // needs to be public for a structural type
 
   // static member functions
   [[nodiscard]] static constexpr quantity_point zero() noexcept
@@ -112,7 +112,7 @@ public:
     requires std::constructible_from<quantity_type, typename QP::quantity_type>
   // TODO add perfect forwarding
   constexpr explicit(!std::convertible_to<typename QP::quantity_type, quantity_type>) quantity_point(const QP& qp) :
-      q_([&] {
+      quantity_from_origin_([&] {
         if constexpr (is_same_v<std::remove_const_t<decltype(point_origin)>,
                                 std::remove_const_t<decltype(QP::point_origin)>>)
           return qp.quantity_ref_from(point_origin);
@@ -128,7 +128,8 @@ public:
              std::convertible_to<
                quantity<quantity_point_like_traits<QP>::reference, typename quantity_point_like_traits<QP>::rep>,
                quantity_type>
-  constexpr explicit quantity_point(const QP& qp) : q_(quantity_point_like_traits<QP>::quantity_from_origin(qp))
+  constexpr explicit quantity_point(const QP& qp) :
+      quantity_from_origin_(quantity_point_like_traits<QP>::quantity_from_origin(qp))
   {
   }
 
@@ -149,28 +150,28 @@ public:
   template<typename Self, std::same_as<std::remove_const_t<decltype(PO)>> PO2>
   [[nodiscard]] constexpr auto&& quantity_ref_from(this Self&& self, PO2) noexcept
   {
-    return std::forward<Self>(self).q_;
+    return std::forward<Self>(self).quantity_from_origin_;
   }
 #else
   template<std::same_as<std::remove_const_t<decltype(PO)>> PO2>
   [[nodiscard]] constexpr quantity_type& quantity_ref_from(PO2) & noexcept
   {
-    return q_;
+    return quantity_from_origin_;
   }
   template<std::same_as<std::remove_const_t<decltype(PO)>> PO2>
   [[nodiscard]] constexpr const quantity_type& quantity_ref_from(PO2) const& noexcept
   {
-    return q_;
+    return quantity_from_origin_;
   }
   template<std::same_as<std::remove_const_t<decltype(PO)>> PO2>
   [[nodiscard]] constexpr quantity_type&& quantity_ref_from(PO2) && noexcept
   {
-    return std::move(q_);
+    return std::move(quantity_from_origin_);
   }
   template<std::same_as<std::remove_const_t<decltype(PO)>> PO2>
   [[nodiscard]] constexpr const quantity_type&& quantity_ref_from(PO2) const&& noexcept
   {
-    return std::move(q_);
+    return std::move(quantity_from_origin_);
   }
 #endif
 
@@ -190,43 +191,43 @@ public:
 
   // member unary operators
   constexpr quantity_point& operator++()
-    requires requires { ++q_; }
+    requires requires { ++quantity_from_origin_; }
   {
-    ++q_;
+    ++quantity_from_origin_;
     return *this;
   }
 
   [[nodiscard]] constexpr quantity_point operator++(int)
-    requires requires { q_++; }
+    requires requires { quantity_from_origin_++; }
   {
-    return quantity_point(q_++);
+    return quantity_point(quantity_from_origin_++);
   }
 
   constexpr quantity_point& operator--()
-    requires requires { --q_; }
+    requires requires { --quantity_from_origin_; }
   {
-    --q_;
+    --quantity_from_origin_;
     return *this;
   }
 
   [[nodiscard]] constexpr quantity_point operator--(int)
-    requires requires { q_--; }
+    requires requires { quantity_from_origin_--; }
   {
-    return quantity_point(q_--);
+    return quantity_point(quantity_from_origin_--);
   }
 
   // compound assignment operators
   constexpr quantity_point& operator+=(const quantity_type& q)
-    requires requires { q_ += q; }
+    requires requires { quantity_from_origin_ += q; }
   {
-    q_ += q;
+    quantity_from_origin_ += q;
     return *this;
   }
 
   constexpr quantity_point& operator-=(const quantity_type& q)
-    requires requires { q_ -= q; }
+    requires requires { quantity_from_origin_ -= q; }
   {
-    q_ -= q;
+    quantity_from_origin_ -= q;
     return *this;
   }
 
@@ -242,7 +243,7 @@ private:
   template<Quantity Q>
     requires std::constructible_from<quantity_type, Q> &&
              ReferenceOf<std::remove_const_t<decltype(Q::reference)>, PO.quantity_spec>
-  constexpr explicit quantity_point(Q&& q) : q_(std::forward<Q>(q))
+  constexpr explicit quantity_point(Q&& q) : quantity_from_origin_(std::forward<Q>(q))
   {
   }
 };

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -174,6 +174,13 @@ public:
   }
 #endif
 
+  template<PointOrigin PO2>
+    requires requires { quantity_point{} - PO2{}; }
+  [[nodiscard]] constexpr Quantity auto quantity_from(PO2) const
+  {
+    return *this - PO2{};
+  }
+
   template<Unit U>
     requires detail::QuantityConvertibleTo<quantity_type, quantity<::mp_units::reference<quantity_spec, U{}>{}, Rep>>
   [[nodiscard]] constexpr quantity_point<::mp_units::reference<quantity_spec, U{}>{}, PO, Rep> in(U) const

--- a/src/core/include/mp-units/quantity_spec.h
+++ b/src/core/include/mp-units/quantity_spec.h
@@ -111,8 +111,7 @@ struct quantity_spec_interface {
     requires Quantity<std::remove_cvref_t<Q>> &&
              (explicitly_convertible(std::remove_reference_t<Q>::quantity_spec, self))
   {
-    return make_quantity<reference<self, std::remove_cvref_t<Q>::unit>{}>(
-      std::forward<Q>(q).numerical_value_ref_in(q.unit));
+    return make_quantity<reference<self, std::remove_cvref_t<Q>::unit>{}>(std::forward<Q>(q).numerical_value_);
   }
 #else
   template<typename Self_ = Self, UnitOf<Self_{}> U>
@@ -129,8 +128,7 @@ struct quantity_spec_interface {
              (explicitly_convertible(std::remove_reference_t<Q>::quantity_spec, Self_{}))
   [[nodiscard]] constexpr Quantity auto operator()(Q&& q) const
   {
-    return make_quantity<reference<Self{}, std::remove_cvref_t<Q>::unit>{}>(
-      std::forward<Q>(q).numerical_value_ref_in(q.unit));
+    return make_quantity<reference<Self{}, std::remove_cvref_t<Q>::unit>{}>(std::forward<Q>(q).numerical_value_);
   }
 #endif
 };
@@ -309,8 +307,7 @@ struct quantity_spec<Self, QS, Args...> : std::remove_const_t<decltype(QS)> {
              (explicitly_convertible(std::remove_reference_t<Q>::quantity_spec, Self_{}))
   [[nodiscard]] constexpr Quantity auto operator()(Q&& q) const
   {
-    return make_quantity<reference<Self{}, std::remove_cvref_t<Q>::unit>{}>(
-      std::forward<Q>(q).numerical_value_ref_in(q.unit));
+    return make_quantity<reference<Self{}, std::remove_cvref_t<Q>::unit>{}>(std::forward<Q>(q).numerical_value_);
   }
 #endif
 };

--- a/src/core/include/mp-units/quantity_spec.h
+++ b/src/core/include/mp-units/quantity_spec.h
@@ -111,7 +111,8 @@ struct quantity_spec_interface {
     requires Quantity<std::remove_cvref_t<Q>> &&
              (explicitly_convertible(std::remove_reference_t<Q>::quantity_spec, self))
   {
-    return make_quantity<reference<self, std::remove_cvref_t<Q>::unit>{}>(std::forward<Q>(q).numerical_value());
+    return make_quantity<reference<self, std::remove_cvref_t<Q>::unit>{}>(
+      std::forward<Q>(q).numerical_value_ref_in(q.unit));
   }
 #else
   template<typename Self_ = Self, UnitOf<Self_{}> U>
@@ -128,7 +129,8 @@ struct quantity_spec_interface {
              (explicitly_convertible(std::remove_reference_t<Q>::quantity_spec, Self_{}))
   [[nodiscard]] constexpr Quantity auto operator()(Q&& q) const
   {
-    return make_quantity<reference<Self{}, std::remove_cvref_t<Q>::unit>{}>(std::forward<Q>(q).numerical_value());
+    return make_quantity<reference<Self{}, std::remove_cvref_t<Q>::unit>{}>(
+      std::forward<Q>(q).numerical_value_ref_in(q.unit));
   }
 #endif
 };
@@ -307,7 +309,8 @@ struct quantity_spec<Self, QS, Args...> : std::remove_const_t<decltype(QS)> {
              (explicitly_convertible(std::remove_reference_t<Q>::quantity_spec, Self_{}))
   [[nodiscard]] constexpr Quantity auto operator()(Q&& q) const
   {
-    return make_quantity<reference<Self{}, std::remove_cvref_t<Q>::unit>{}>(std::forward<Q>(q).numerical_value());
+    return make_quantity<reference<Self{}, std::remove_cvref_t<Q>::unit>{}>(
+      std::forward<Q>(q).numerical_value_ref_in(q.unit));
   }
 #endif
 };

--- a/src/core/include/mp-units/unit.h
+++ b/src/core/include/mp-units/unit.h
@@ -402,7 +402,7 @@ using type_list_of_unit_less = expr_less<T1, T2, unit_less>;
  * Multiplication by `1` returns the same unit, otherwise `scaled_unit` is being returned.
  */
 template<Magnitude M, Unit U>
-[[nodiscard]] consteval Unit auto operator*(M mag, const U u)
+[[nodiscard]] MP_UNITS_CONSTEVAL Unit auto operator*(M mag, const U u)
 {
   if constexpr (mag == mp_units::mag<1>)
     return u;
@@ -418,7 +418,7 @@ template<Magnitude M, Unit U>
  * to the derived unit and the magnitude remains outside forming another scaled unit as a result of the operation.
  */
 template<Unit Lhs, Unit Rhs>
-[[nodiscard]] consteval Unit auto operator*(Lhs lhs, Rhs rhs)
+[[nodiscard]] MP_UNITS_CONSTEVAL Unit auto operator*(Lhs lhs, Rhs rhs)
 {
   if constexpr (detail::is_specialization_of_scaled_unit<Lhs> && detail::is_specialization_of_scaled_unit<Rhs>)
     return (Lhs::mag * Rhs::mag) * (Lhs::reference_unit * Rhs::reference_unit);
@@ -436,7 +436,7 @@ template<Unit Lhs, Unit Rhs>
  * to the derived unit and the magnitude remains outside forming another scaled unit as a result of the operation.
  */
 template<Unit Lhs, Unit Rhs>
-[[nodiscard]] consteval Unit auto operator/(Lhs lhs, Rhs rhs)
+[[nodiscard]] MP_UNITS_CONSTEVAL Unit auto operator/(Lhs lhs, Rhs rhs)
 {
   if constexpr (detail::is_specialization_of_scaled_unit<Lhs> && detail::is_specialization_of_scaled_unit<Rhs>)
     return (Lhs::mag / Rhs::mag) * (Lhs::reference_unit / Rhs::reference_unit);

--- a/src/utility/include/mp-units/chrono.h
+++ b/src/utility/include/mp-units/chrono.h
@@ -92,7 +92,7 @@ template<QuantityOf<isq::time> Q>
 {
   constexpr auto canonical = detail::get_canonical_unit(Q::unit);
   constexpr ratio r = as_ratio(canonical.mag);
-  return std::chrono::duration<typename Q::rep, std::ratio<r.num, r.den>>{q.numerical_value()};
+  return std::chrono::duration<typename Q::rep, std::ratio<r.num, r.den>>{q.numerical_value_ref_in(Q::unit)};
 }
 
 template<QuantityPointOf<isq::time> QP>

--- a/src/utility/include/mp-units/math.h
+++ b/src/utility/include/mp-units/math.h
@@ -116,8 +116,8 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
            requires { std::exp(q.numerical_value_ref_in(q.unit)); }
 {
   using std::exp;
-  return value_cast<get_unit(R)>(make_quantity<detail::clone_reference_with<one>(R)>(
-    static_cast<Rep>(exp(value_cast<one>(q).numerical_value_ref_in(q.unit)))));
+  return value_cast<get_unit(R)>(
+    make_quantity<detail::clone_reference_with<one>(R)>(static_cast<Rep>(exp(q.force_numerical_value_in(q.unit)))));
 }
 
 /**
@@ -178,8 +178,8 @@ template<Unit auto To, auto R, typename Rep>
       return make_quantity<detail::clone_reference_with<To>(R)>(
         static_cast<Rep>(floor(q.numerical_value_ref_in(q.unit))));
     } else {
-      return handle_signed_results(make_quantity<detail::clone_reference_with<To>(R)>(
-        static_cast<Rep>(floor(value_cast<To>(q).numerical_value_ref_in(To)))));
+      return handle_signed_results(
+        make_quantity<detail::clone_reference_with<To>(R)>(static_cast<Rep>(floor(q.force_numerical_value_in(To)))));
     }
   } else {
     if constexpr (To == get_unit(R)) {
@@ -218,8 +218,8 @@ template<Unit auto To, auto R, typename Rep>
       return make_quantity<detail::clone_reference_with<To>(R)>(
         static_cast<Rep>(ceil(q.numerical_value_ref_in(q.unit))));
     } else {
-      return handle_signed_results(make_quantity<detail::clone_reference_with<To>(R)>(
-        static_cast<Rep>(ceil(value_cast<To>(q).numerical_value_ref_in(To)))));
+      return handle_signed_results(
+        make_quantity<detail::clone_reference_with<To>(R)>(static_cast<Rep>(ceil(q.force_numerical_value_in(To)))));
     }
   } else {
     if constexpr (To == get_unit(R)) {
@@ -327,7 +327,7 @@ template<ReferenceOf<angular_measure> auto R, typename Rep>
   using std::sin;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(sin(value_cast<si::radian>(q).numerical_value_in(si::radian)));
+    using rep = decltype(sin(q.force_numerical_value_in(si::radian)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<one>(sin(value_cast<rep>(q).numerical_value_in(si::radian)));
   } else
@@ -342,7 +342,7 @@ template<ReferenceOf<angular_measure> auto R, typename Rep>
   using std::cos;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(cos(value_cast<si::radian>(q).numerical_value_in(si::radian)));
+    using rep = decltype(cos(q.force_numerical_value_in(si::radian)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<one>(cos(value_cast<rep>(q).numerical_value_in(si::radian)));
   } else
@@ -357,7 +357,7 @@ template<ReferenceOf<angular_measure> auto R, typename Rep>
   using std::tan;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(tan(value_cast<si::radian>(q).numerical_value_in(si::radian)));
+    using rep = decltype(tan(q.force_numerical_value_in(si::radian)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<one>(tan(value_cast<rep>(q).numerical_value_in(si::radian)));
   } else
@@ -372,7 +372,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::asin;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(asin(value_cast<one>(q).numerical_value_in(one)));
+    using rep = decltype(asin(q.force_numerical_value_in(one)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<si::radian>(asin(value_cast<rep>(q).numerical_value_in(one)));
   } else
@@ -387,7 +387,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::acos;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(acos(value_cast<one>(q).numerical_value()));
+    using rep = decltype(acos(q.force_numerical_value_in(one)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<si::radian>(acos(value_cast<rep>(q).numerical_value_in(one)));
   } else
@@ -402,7 +402,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::atan;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(atan(value_cast<one>(q).numerical_value_in(one)));
+    using rep = decltype(atan(q.force_numerical_value_in(one)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<si::radian>(atan(value_cast<rep>(q).numerical_value_in(one)));
   } else
@@ -421,7 +421,7 @@ template<ReferenceOf<angle> auto R, typename Rep>
   using std::sin;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(sin(value_cast<radian>(q).numerical_value_in(radian)));
+    using rep = decltype(sin(q.force_numerical_value_in(radian)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<one>(sin(value_cast<rep>(q).numerical_value_in(radian)));
   } else
@@ -436,7 +436,7 @@ template<ReferenceOf<angle> auto R, typename Rep>
   using std::cos;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(cos(value_cast<radian>(q).numerical_value_in(radian)));
+    using rep = decltype(cos(q.force_numerical_value_in(radian)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<one>(cos(value_cast<rep>(q).numerical_value_in(radian)));
   } else
@@ -451,7 +451,7 @@ template<ReferenceOf<angle> auto R, typename Rep>
   using std::tan;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(tan(value_cast<radian>(q).numerical_value_in(radian)));
+    using rep = decltype(tan(q.force_numerical_value_in(radian)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<one>(tan(value_cast<rep>(q).numerical_value_in(radian)));
   } else
@@ -466,7 +466,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::asin;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(asin(value_cast<one>(q).numerical_value_in(one)));
+    using rep = decltype(asin(q.force_numerical_value_in(one)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<radian>(asin(value_cast<rep>(q).numerical_value_in(one)));
   } else
@@ -481,7 +481,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::acos;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(acos(value_cast<one>(q).numerical_value_in(one)));
+    using rep = decltype(acos(q.force_numerical_value_in(one)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<radian>(acos(value_cast<rep>(q).numerical_value_in(one)));
   } else
@@ -496,7 +496,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::atan;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(atan(value_cast<one>(q).numerical_value_in(one)));
+    using rep = decltype(atan(q.force_numerical_value_in(one)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return make_quantity<radian>(atan(value_cast<rep>(q).numerical_value_in(one)));
   } else

--- a/src/utility/include/mp-units/math.h
+++ b/src/utility/include/mp-units/math.h
@@ -162,7 +162,7 @@ template<Unit auto To, auto R, typename Rep>
 
            requires { std::floor(q.numerical_value_ref_in(q.unit)); }) &&
           (To == get_unit(R) || requires {
-            ::mp_units::value_cast<To>(q);
+            q.force_in(To);
             quantity_values<Rep>::one();
           })
 {
@@ -183,9 +183,9 @@ template<Unit auto To, auto R, typename Rep>
     }
   } else {
     if constexpr (To == get_unit(R)) {
-      return value_cast<To>(q);
+      return q.force_in(To);
     } else {
-      return handle_signed_results(value_cast<To>(q));
+      return handle_signed_results(q.force_in(To));
     }
   }
 }
@@ -202,7 +202,7 @@ template<Unit auto To, auto R, typename Rep>
 
            requires { std::ceil(q.numerical_value_ref_in(q.unit)); }) &&
           (To == get_unit(R) || requires {
-            ::mp_units::value_cast<To>(q);
+            q.force_in(To);
             quantity_values<Rep>::one();
           })
 {
@@ -223,9 +223,9 @@ template<Unit auto To, auto R, typename Rep>
     }
   } else {
     if constexpr (To == get_unit(R)) {
-      return value_cast<To>(q);
+      return q.force_in(To);
     } else {
-      return handle_signed_results(value_cast<To>(q));
+      return handle_signed_results(q.force_in(To));
     }
   }
 }
@@ -254,7 +254,7 @@ template<Unit auto To, auto R, typename Rep>
       return make_quantity<detail::clone_reference_with<To>(R)>(
         static_cast<Rep>(round(q.numerical_value_ref_in(q.unit))));
     } else {
-      return value_cast<To>(q);
+      return q.force_in(To);
     }
   } else {
     const auto res_low = mp_units::floor<To>(q);

--- a/src/utility/include/mp-units/math.h
+++ b/src/utility/include/mp-units/math.h
@@ -159,7 +159,6 @@ template<Representation Rep, Reference R>
 template<Unit auto To, auto R, typename Rep>
 [[nodiscard]] constexpr quantity<detail::clone_reference_with<To>(R), Rep> floor(const quantity<R, Rep>& q) noexcept
   requires((!treat_as_floating_point<Rep>) || requires { floor(q.numerical_value_ref_in(q.unit)); } ||
-
            requires { std::floor(q.numerical_value_ref_in(q.unit)); }) &&
           (To == get_unit(R) || requires {
             q.force_in(To);
@@ -199,7 +198,6 @@ template<Unit auto To, auto R, typename Rep>
 template<Unit auto To, auto R, typename Rep>
 [[nodiscard]] constexpr quantity<detail::clone_reference_with<To>(R), Rep> ceil(const quantity<R, Rep>& q) noexcept
   requires((!treat_as_floating_point<Rep>) || requires { ceil(q.numerical_value_ref_in(q.unit)); } ||
-
            requires { std::ceil(q.numerical_value_ref_in(q.unit)); }) &&
           (To == get_unit(R) || requires {
             q.force_in(To);
@@ -241,7 +239,6 @@ template<Unit auto To, auto R, typename Rep>
 template<Unit auto To, auto R, typename Rep>
 [[nodiscard]] constexpr quantity<detail::clone_reference_with<To>(R), Rep> round(const quantity<R, Rep>& q) noexcept
   requires((!treat_as_floating_point<Rep>) || requires { round(q.numerical_value_ref_in(q.unit)); } ||
-
            requires { std::round(q.numerical_value_ref_in(q.unit)); }) &&
           (To == get_unit(R) || requires {
             ::mp_units::floor<To>(q);
@@ -284,7 +281,6 @@ template<auto R1, typename Rep1, auto R2, typename Rep2>
   requires requires { common_reference(R1, R2); } &&
            (
              requires { hypot(x.numerical_value_ref_in(x.unit), y.numerical_value_ref_in(y.unit)); } ||
-
              requires { std::hypot(x.numerical_value_ref_in(x.unit), y.numerical_value_ref_in(y.unit)); })
 {
   constexpr auto ref = common_reference(R1, R2);

--- a/src/utility/include/mp-units/random.h
+++ b/src/utility/include/mp-units/random.h
@@ -35,7 +35,7 @@ static std::vector<typename Q::rep> i_qty_to_rep(InputIt first, InputIt last)
   std::vector<typename Q::rep> intervals_rep;
   intervals_rep.reserve(static_cast<size_t>(std::distance(first, last)));
   for (auto itr = first; itr != last; ++itr) {
-    intervals_rep.push_back(itr->numerical_value());
+    intervals_rep.push_back(itr->numerical_value_ref_in(Q::unit));
   }
   return intervals_rep;
 }
@@ -46,7 +46,7 @@ static std::vector<typename Q::rep> bl_qty_to_rep(std::initializer_list<Q>& bl)
   std::vector<typename Q::rep> bl_rep;
   bl_rep.reserve(bl.size());
   for (const Q& qty : bl) {
-    bl_rep.push_back(qty.numerical_value());
+    bl_rep.push_back(qty.numerical_value_ref_in(Q::unit));
   }
   return bl_rep;
 }
@@ -88,7 +88,10 @@ struct uniform_int_distribution : public std::uniform_int_distribution<typename 
   using base = MP_UNITS_TYPENAME std::uniform_int_distribution<rep>;
 
   uniform_int_distribution() : base() {}
-  uniform_int_distribution(const Q& a, const Q& b) : base(a.numerical_value(), b.numerical_value()) {}
+  uniform_int_distribution(const Q& a, const Q& b) :
+      base(a.numerical_value_ref_in(Q::unit), b.numerical_value_ref_in(Q::unit))
+  {
+  }
 
   template<typename Generator>
   Q operator()(Generator& g)
@@ -110,7 +113,10 @@ struct uniform_real_distribution : public std::uniform_real_distribution<typenam
   using base = MP_UNITS_TYPENAME std::uniform_real_distribution<rep>;
 
   uniform_real_distribution() : base() {}
-  uniform_real_distribution(const Q& a, const Q& b) : base(a.numerical_value(), b.numerical_value()) {}
+  uniform_real_distribution(const Q& a, const Q& b) :
+      base(a.numerical_value_ref_in(Q::unit), b.numerical_value_ref_in(Q::unit))
+  {
+  }
 
   template<typename Generator>
   Q operator()(Generator& g)
@@ -132,7 +138,7 @@ struct binomial_distribution : public std::binomial_distribution<typename Q::rep
   using base = MP_UNITS_TYPENAME std::binomial_distribution<rep>;
 
   binomial_distribution() : base() {}
-  binomial_distribution(const Q& t, double p) : base(t.numerical_value(), p) {}
+  binomial_distribution(const Q& t, double p) : base(t.numerical_value_ref_in(Q::unit), p) {}
 
   template<typename Generator>
   Q operator()(Generator& g)
@@ -153,7 +159,7 @@ struct negative_binomial_distribution : public std::negative_binomial_distributi
   using base = MP_UNITS_TYPENAME std::negative_binomial_distribution<rep>;
 
   negative_binomial_distribution() : base() {}
-  negative_binomial_distribution(const Q& k, double p) : base(k.numerical_value(), p) {}
+  negative_binomial_distribution(const Q& k, double p) : base(k.numerical_value_ref_in(Q::unit), p) {}
 
   template<typename Generator>
   Q operator()(Generator& g)
@@ -269,7 +275,7 @@ struct extreme_value_distribution : public std::extreme_value_distribution<typen
   using base = MP_UNITS_TYPENAME std::extreme_value_distribution<rep>;
 
   extreme_value_distribution() : base() {}
-  extreme_value_distribution(const Q& a, const rep& b) : base(a.numerical_value(), b) {}
+  extreme_value_distribution(const Q& a, const rep& b) : base(a.numerical_value_ref_in(Q::unit), b) {}
 
   template<typename Generator>
   Q operator()(Generator& g)
@@ -290,7 +296,10 @@ struct normal_distribution : public std::normal_distribution<typename Q::rep> {
   using base = MP_UNITS_TYPENAME std::normal_distribution<rep>;
 
   normal_distribution() : base() {}
-  normal_distribution(const Q& mean, const Q& stddev) : base(mean.numerical_value(), stddev.numerical_value()) {}
+  normal_distribution(const Q& mean, const Q& stddev) :
+      base(mean.numerical_value_ref_in(Q::unit), stddev.numerical_value_ref_in(Q::unit))
+  {
+  }
 
   template<typename Generator>
   Q operator()(Generator& g)
@@ -312,7 +321,10 @@ struct lognormal_distribution : public std::lognormal_distribution<typename Q::r
   using base = MP_UNITS_TYPENAME std::lognormal_distribution<rep>;
 
   lognormal_distribution() : base() {}
-  lognormal_distribution(const Q& m, const Q& s) : base(m.numerical_value(), s.numerical_value()) {}
+  lognormal_distribution(const Q& m, const Q& s) :
+      base(m.numerical_value_ref_in(Q::unit), s.numerical_value_ref_in(Q::unit))
+  {
+  }
 
   template<typename Generator>
   Q operator()(Generator& g)
@@ -353,7 +365,10 @@ struct cauchy_distribution : public std::cauchy_distribution<typename Q::rep> {
   using base = MP_UNITS_TYPENAME std::cauchy_distribution<rep>;
 
   cauchy_distribution() : base() {}
-  cauchy_distribution(const Q& a, const Q& b) : base(a.numerical_value(), b.numerical_value()) {}
+  cauchy_distribution(const Q& a, const Q& b) :
+      base(a.numerical_value_ref_in(Q::unit), b.numerical_value_ref_in(Q::unit))
+  {
+  }
 
   template<typename Generator>
   Q operator()(Generator& g)
@@ -470,7 +485,8 @@ public:
 
   template<typename UnaryOperation>
   piecewise_constant_distribution(std::size_t nw, const Q& xmin, const Q& xmax, UnaryOperation fw) :
-      base(nw, xmin.numerical_value(), xmax.numerical_value(), [fw](rep val) { return fw(val * Q::reference); })
+      base(nw, xmin.numerical_value_ref_in(Q::unit), xmax.numerical_value_ref_in(Q::unit),
+           [fw](rep val) { return fw(val * Q::reference); })
   {
   }
 
@@ -528,7 +544,8 @@ public:
 
   template<typename UnaryOperation>
   piecewise_linear_distribution(std::size_t nw, const Q& xmin, const Q& xmax, UnaryOperation fw) :
-      base(nw, xmin.numerical_value(), xmax.numerical_value(), [fw](rep val) { return fw(val * Q::reference); })
+      base(nw, xmin.numerical_value_ref_in(Q::unit), xmax.numerical_value_ref_in(Q::unit),
+           [fw](rep val) { return fw(val * Q::reference); })
   {
   }
 

--- a/test/unit_test/runtime/almost_equals.h
+++ b/test/unit_test/runtime/almost_equals.h
@@ -36,8 +36,8 @@ struct AlmostEqualsMatcher : Catch::Matchers::MatcherGenericBase {
   {
     using std::abs;
     using common = std::common_type_t<T, U>;
-    const auto x = common(target_).numerical_value_ref_in(common::unit);
-    const auto y = common(other).numerical_value_ref_in(common::unit);
+    const auto x = common(target_).numerical_value_in(common::unit);
+    const auto y = common(other).numerical_value_in(common::unit);
     const auto maxXYOne = std::max({typename T::rep{1}, abs(x), abs(y)});
     return abs(x - y) <= std::numeric_limits<typename T::rep>::epsilon() * maxXYOne;
   }

--- a/test/unit_test/runtime/almost_equals.h
+++ b/test/unit_test/runtime/almost_equals.h
@@ -36,8 +36,8 @@ struct AlmostEqualsMatcher : Catch::Matchers::MatcherGenericBase {
   {
     using std::abs;
     using common = std::common_type_t<T, U>;
-    const auto x = common(target_).numerical_value();
-    const auto y = common(other).numerical_value();
+    const auto x = common(target_).numerical_value_ref_in(common::unit);
+    const auto y = common(other).numerical_value_ref_in(common::unit);
     const auto maxXYOne = std::max({typename T::rep{1}, abs(x), abs(y)});
     return abs(x - y) <= std::numeric_limits<typename T::rep>::epsilon() * maxXYOne;
   }

--- a/test/unit_test/runtime/distribution_test.cpp
+++ b/test/unit_test/runtime/distribution_test.cpp
@@ -560,7 +560,9 @@ TEST_CASE("piecewise_constant_distribution")
 
     auto stl_dist = std::piecewise_constant_distribution<rep>(intervals_rep, [](rep val) { return val; });
     auto units_dist =
-      mp_units::piecewise_constant_distribution<q>(intervals_qty, [](q qty) { return qty.numerical_value(); });
+
+      mp_units::piecewise_constant_distribution<q>(intervals_qty,
+                                                   [](q qty) { return qty.numerical_value_ref_in(qty.unit); });
 
     CHECK(units_dist.intervals() == intervals_qty_vec);
     CHECK(units_dist.densities() == stl_dist.densities());
@@ -573,8 +575,8 @@ TEST_CASE("piecewise_constant_distribution")
     constexpr q xmin_qty = 1.0 * isq::length[si::metre], xmax_qty = 3.0 * isq::length[si::metre];
 
     auto stl_dist = std::piecewise_constant_distribution<rep>(nw, xmin_rep, xmax_rep, [](rep val) { return val; });
-    auto units_dist =
-      mp_units::piecewise_constant_distribution<q>(nw, xmin_qty, xmax_qty, [](q qty) { return qty.numerical_value(); });
+    auto units_dist = mp_units::piecewise_constant_distribution<q>(
+      nw, xmin_qty, xmax_qty, [](q qty) { return qty.numerical_value_ref_in(qty.unit); });
 
     CHECK(units_dist.intervals() == intervals_qty_vec);
     CHECK(units_dist.densities() == stl_dist.densities());
@@ -628,7 +630,9 @@ TEST_CASE("piecewise_linear_distribution")
 
     auto stl_dist = std::piecewise_linear_distribution<rep>(intervals_rep, [](rep val) { return val; });
     auto units_dist =
-      mp_units::piecewise_linear_distribution<q>(intervals_qty, [](q qty) { return qty.numerical_value(); });
+
+      mp_units::piecewise_linear_distribution<q>(intervals_qty,
+                                                 [](q qty) { return qty.numerical_value_ref_in(qty.unit); });
 
     CHECK(units_dist.intervals() == intervals_qty_vec);
     CHECK(units_dist.densities() == stl_dist.densities());
@@ -641,8 +645,8 @@ TEST_CASE("piecewise_linear_distribution")
     constexpr q xmin_qty = 1.0 * isq::length[si::metre], xmax_qty = 3.0 * isq::length[si::metre];
 
     auto stl_dist = std::piecewise_linear_distribution<rep>(nw, xmin_rep, xmax_rep, [](rep val) { return val; });
-    auto units_dist =
-      mp_units::piecewise_linear_distribution<q>(nw, xmin_qty, xmax_qty, [](q qty) { return qty.numerical_value(); });
+    auto units_dist = mp_units::piecewise_linear_distribution<q>(
+      nw, xmin_qty, xmax_qty, [](q qty) { return qty.numerical_value_ref_in(qty.unit); });
 
     CHECK(units_dist.intervals() == intervals_qty_vec);
     CHECK(units_dist.densities() == stl_dist.densities());

--- a/test/unit_test/runtime/distribution_test.cpp
+++ b/test/unit_test/runtime/distribution_test.cpp
@@ -559,10 +559,8 @@ TEST_CASE("piecewise_constant_distribution")
                                               3.0 * isq::length[si::metre]};
 
     auto stl_dist = std::piecewise_constant_distribution<rep>(intervals_rep, [](rep val) { return val; });
-    auto units_dist =
-
-      mp_units::piecewise_constant_distribution<q>(intervals_qty,
-                                                   [](q qty) { return qty.numerical_value_ref_in(qty.unit); });
+    auto units_dist = mp_units::piecewise_constant_distribution<q>(
+      intervals_qty, [](q qty) { return qty.numerical_value_ref_in(qty.unit); });
 
     CHECK(units_dist.intervals() == intervals_qty_vec);
     CHECK(units_dist.densities() == stl_dist.densities());
@@ -629,10 +627,8 @@ TEST_CASE("piecewise_linear_distribution")
                                               3.0 * isq::length[si::metre]};
 
     auto stl_dist = std::piecewise_linear_distribution<rep>(intervals_rep, [](rep val) { return val; });
-    auto units_dist =
-
-      mp_units::piecewise_linear_distribution<q>(intervals_qty,
-                                                 [](q qty) { return qty.numerical_value_ref_in(qty.unit); });
+    auto units_dist = mp_units::piecewise_linear_distribution<q>(
+      intervals_qty, [](q qty) { return qty.numerical_value_ref_in(qty.unit); });
 
     CHECK(units_dist.intervals() == intervals_qty_vec);
     CHECK(units_dist.densities() == stl_dist.densities());

--- a/test/unit_test/runtime/linear_algebra_test.cpp
+++ b/test/unit_test/runtime/linear_algebra_test.cpp
@@ -93,7 +93,7 @@ TEST_CASE("vector quantity", "[la]")
     SECTION("truncating")
     {
       const auto v = vector<int>{1001, 1002, 1003} * isq::position_vector[m];
-      CHECK(value_cast<km>(v).numerical_value_ref_in(km) == vector<int>{1, 1, 1});
+      CHECK(v.force_numerical_value_in(km) == vector<int>{1, 1, 1});
     }
   }
 

--- a/test/unit_test/runtime/linear_algebra_test.cpp
+++ b/test/unit_test/runtime/linear_algebra_test.cpp
@@ -118,14 +118,14 @@ TEST_CASE("vector quantity", "[la]")
 
     SECTION("integral")
     {
-      SECTION("scalar on LHS") { CHECK((2 * v).numerical_value_ref_in(m) == vector<int>{2, 4, 6}); }
-      SECTION("scalar on RHS") { CHECK((v * 2).numerical_value_ref_in(m) == vector<int>{2, 4, 6}); }
+      SECTION("scalar on LHS") { CHECK((2 * v).numerical_value_ == vector<int>{2, 4, 6}); }
+      SECTION("scalar on RHS") { CHECK((v * 2).numerical_value_ == vector<int>{2, 4, 6}); }
     }
 
     SECTION("floating-point")
     {
-      SECTION("scalar on LHS") { CHECK((0.5 * v).numerical_value_ref_in(m) == vector<double>{0.5, 1., 1.5}); }
-      SECTION("scalar on RHS") { CHECK((v * 0.5).numerical_value_ref_in(m) == vector<double>{0.5, 1., 1.5}); }
+      SECTION("scalar on LHS") { CHECK((0.5 * v).numerical_value_ == vector<double>{0.5, 1., 1.5}); }
+      SECTION("scalar on RHS") { CHECK((v * 0.5).numerical_value_ == vector<double>{0.5, 1., 1.5}); }
     }
   }
 
@@ -133,8 +133,8 @@ TEST_CASE("vector quantity", "[la]")
   {
     const auto v = vector<int>{2, 4, 6} * isq::position_vector[m];
 
-    SECTION("integral") { CHECK((v / 2).numerical_value_ref_in(m) == vector<int>{1, 2, 3}); }
-    SECTION("floating-point") { CHECK((v / 0.5).numerical_value_ref_in(m) == vector<double>{4., 8., 12.}); }
+    SECTION("integral") { CHECK((v / 2).numerical_value_ == vector<int>{1, 2, 3}); }
+    SECTION("floating-point") { CHECK((v / 0.5).numerical_value_ == vector<double>{4., 8., 12.}); }
   }
 
   SECTION("add")
@@ -144,12 +144,12 @@ TEST_CASE("vector quantity", "[la]")
     SECTION("same unit")
     {
       const auto u = vector<int>{3, 2, 1} * isq::position_vector[m];
-      CHECK((v + u).numerical_value_ref_in(m) == vector<int>{4, 4, 4});
+      CHECK((v + u).numerical_value_ == vector<int>{4, 4, 4});
     }
     SECTION("different units")
     {
       const auto u = vector<int>{3, 2, 1} * isq::position_vector[km];
-      CHECK((v + u).numerical_value_ref_in(m) == vector<int>{3001, 2002, 1003});
+      CHECK((v + u).numerical_value_ == vector<int>{3001, 2002, 1003});
     }
   }
 
@@ -160,12 +160,12 @@ TEST_CASE("vector quantity", "[la]")
     SECTION("same unit")
     {
       const auto u = vector<int>{3, 2, 1} * isq::position_vector[m];
-      CHECK((v - u).numerical_value_ref_in(m) == vector<int>{-2, 0, 2});
+      CHECK((v - u).numerical_value_ == vector<int>{-2, 0, 2});
     }
     SECTION("different units")
     {
       const auto u = vector<int>{3, 2, 1} * isq::position_vector[km];
-      CHECK((v - u).numerical_value_ref_in(m) == vector<int>{-2999, -1998, -997});
+      CHECK((v - u).numerical_value_ == vector<int>{-2999, -1998, -997});
     }
   }
 
@@ -179,18 +179,18 @@ TEST_CASE("vector quantity", "[la]")
 
       SECTION("derived_quantity_spec")
       {
-        SECTION("scalar on LHS") { CHECK((mass * v).numerical_value_ref_in(N * s) == vector<int>{2, 4, 6}); }
-        SECTION("scalar on RHS") { CHECK((v * mass).numerical_value_ref_in(N * s) == vector<int>{2, 4, 6}); }
+        SECTION("scalar on LHS") { CHECK((mass * v).numerical_value_ == vector<int>{2, 4, 6}); }
+        SECTION("scalar on RHS") { CHECK((v * mass).numerical_value_ == vector<int>{2, 4, 6}); }
       }
       SECTION("quantity_cast to momentum")
       {
         SECTION("scalar on LHS")
         {
-          CHECK(quantity_cast<isq::momentum>(mass * v).numerical_value_ref_in(N * s) == vector<int>{2, 4, 6});
+          CHECK(quantity_cast<isq::momentum>(mass * v).numerical_value_ == vector<int>{2, 4, 6});
         }
         SECTION("scalar on RHS")
         {
-          CHECK(quantity_cast<isq::momentum>(v * mass).numerical_value_ref_in(N * s) == vector<int>{2, 4, 6});
+          CHECK(quantity_cast<isq::momentum>(v * mass).numerical_value_ == vector<int>{2, 4, 6});
         }
       }
       SECTION("quantity of momentum")
@@ -198,12 +198,12 @@ TEST_CASE("vector quantity", "[la]")
         SECTION("scalar on LHS")
         {
           const quantity<isq::momentum[N * s], vector<int>> momentum = mass * v;
-          CHECK(momentum.numerical_value_ref_in(N * s) == vector<int>{2, 4, 6});
+          CHECK(momentum.numerical_value_ == vector<int>{2, 4, 6});
         }
         SECTION("scalar on RHS")
         {
           const quantity<isq::momentum[N * s], vector<int>> momentum = v * mass;
-          CHECK(momentum.numerical_value_ref_in(N * s) == vector<int>{2, 4, 6});
+          CHECK(momentum.numerical_value_ == vector<int>{2, 4, 6});
         }
       }
     }
@@ -214,18 +214,18 @@ TEST_CASE("vector quantity", "[la]")
 
       SECTION("derived_quantity_spec")
       {
-        SECTION("scalar on LHS") { CHECK((mass * v).numerical_value_ref_in(N * s) == vector<double>{0.5, 1., 1.5}); }
-        SECTION("scalar on RHS") { CHECK((v * mass).numerical_value_ref_in(N * s) == vector<double>{0.5, 1., 1.5}); }
+        SECTION("scalar on LHS") { CHECK((mass * v).numerical_value_ == vector<double>{0.5, 1., 1.5}); }
+        SECTION("scalar on RHS") { CHECK((v * mass).numerical_value_ == vector<double>{0.5, 1., 1.5}); }
       }
       SECTION("quantity_cast to momentum")
       {
         SECTION("scalar on LHS")
         {
-          CHECK(quantity_cast<isq::momentum>(mass * v).numerical_value_ref_in(N * s) == vector<double>{0.5, 1., 1.5});
+          CHECK(quantity_cast<isq::momentum>(mass * v).numerical_value_ == vector<double>{0.5, 1., 1.5});
         }
         SECTION("scalar on RHS")
         {
-          CHECK(quantity_cast<isq::momentum>(v * mass).numerical_value_ref_in(N * s) == vector<double>{0.5, 1., 1.5});
+          CHECK(quantity_cast<isq::momentum>(v * mass).numerical_value_ == vector<double>{0.5, 1., 1.5});
         }
       }
       SECTION("quantity of momentum")
@@ -233,12 +233,12 @@ TEST_CASE("vector quantity", "[la]")
         SECTION("scalar on LHS")
         {
           const quantity<isq::momentum[N * s], vector<double>> momentum = mass * v;
-          CHECK(momentum.numerical_value_ref_in(N * s) == vector<double>{0.5, 1., 1.5});
+          CHECK(momentum.numerical_value_ == vector<double>{0.5, 1., 1.5});
         }
         SECTION("scalar on RHS")
         {
           const quantity<isq::momentum[N * s], vector<double>> momentum = v * mass;
-          CHECK(momentum.numerical_value_ref_in(N * s) == vector<double>{0.5, 1., 1.5});
+          CHECK(momentum.numerical_value_ == vector<double>{0.5, 1., 1.5});
         }
       }
     }
@@ -252,15 +252,15 @@ TEST_CASE("vector quantity", "[la]")
     {
       const auto dur = 2 * isq::duration[h];
 
-      SECTION("derived_quantity_spec") { CHECK((pos / dur).numerical_value_ref_in(km / h) == vector<int>{15, 10, 5}); }
+      SECTION("derived_quantity_spec") { CHECK((pos / dur).numerical_value_ == vector<int>{15, 10, 5}); }
       SECTION("quantity_cast to velocity")
       {
-        CHECK(quantity_cast<isq::velocity>(pos / dur).numerical_value_ref_in(km / h) == vector<int>{15, 10, 5});
+        CHECK(quantity_cast<isq::velocity>(pos / dur).numerical_value_ == vector<int>{15, 10, 5});
       }
       SECTION("quantity of velocity")
       {
         const quantity<isq::velocity[km / h], vector<int>> v = pos / dur;
-        CHECK(v.numerical_value_ref_in(km / h) == vector<int>{15, 10, 5});
+        CHECK(v.numerical_value_ == vector<int>{15, 10, 5});
       }
     }
 
@@ -268,18 +268,15 @@ TEST_CASE("vector quantity", "[la]")
     {
       const auto dur = 0.5 * isq::duration[h];
 
-      SECTION("derived_quantity_spec")
-      {
-        CHECK((pos / dur).numerical_value_ref_in(km / h) == vector<double>{60, 40, 20});
-      }
+      SECTION("derived_quantity_spec") { CHECK((pos / dur).numerical_value_ == vector<double>{60, 40, 20}); }
       SECTION("quantity_cast to velocity")
       {
-        CHECK(quantity_cast<isq::velocity>(pos / dur).numerical_value_ref_in(km / h) == vector<double>{60, 40, 20});
+        CHECK(quantity_cast<isq::velocity>(pos / dur).numerical_value_ == vector<double>{60, 40, 20});
       }
       SECTION("quantity of velocity")
       {
         const quantity<isq::velocity[km / h], vector<double>> v = pos / dur;
-        CHECK(v.numerical_value_ref_in(km / h) == vector<double>{60, 40, 20});
+        CHECK(v.numerical_value_ == vector<double>{60, 40, 20});
       }
     }
   }

--- a/test/unit_test/runtime/math_test.cpp
+++ b/test/unit_test/runtime/math_test.cpp
@@ -90,13 +90,12 @@ TEST_CASE("numeric_limits functions", "[limits]")
 {
   SECTION("'epsilon' works as expected using default floating type")
   {
-    REQUIRE(epsilon<double>(isq::length[m]).numerical_value_ref_in(m) ==
+    REQUIRE(epsilon<double>(isq::length[m]).numerical_value_ ==
             std::numeric_limits<decltype(1. * isq::length[m])::rep>::epsilon());
   }
   SECTION("'epsilon' works as expected using integers")
   {
-    REQUIRE(epsilon<int>(isq::length[m]).numerical_value_ref_in(m) ==
-
+    REQUIRE(epsilon<int>(isq::length[m]).numerical_value_ ==
             std::numeric_limits<decltype(1 * isq::length[m])::rep>::epsilon());
   }
 }

--- a/test/unit_test/runtime/math_test.cpp
+++ b/test/unit_test/runtime/math_test.cpp
@@ -90,12 +90,13 @@ TEST_CASE("numeric_limits functions", "[limits]")
 {
   SECTION("'epsilon' works as expected using default floating type")
   {
-    REQUIRE(epsilon<double>(isq::length[m]).numerical_value() ==
+    REQUIRE(epsilon<double>(isq::length[m]).numerical_value_ref_in(m) ==
             std::numeric_limits<decltype(1. * isq::length[m])::rep>::epsilon());
   }
   SECTION("'epsilon' works as expected using integers")
   {
-    REQUIRE(epsilon<int>(isq::length[m]).numerical_value() ==
+    REQUIRE(epsilon<int>(isq::length[m]).numerical_value_ref_in(m) ==
+
             std::numeric_limits<decltype(1 * isq::length[m])::rep>::epsilon());
   }
 }

--- a/test/unit_test/static/quantity_point_test.cpp
+++ b/test/unit_test/static/quantity_point_test.cpp
@@ -241,19 +241,26 @@ static_assert(
 // static member functions
 ////////////////////////////
 
-static_assert(quantity_point<isq::height[m], mean_sea_level>::zero().quantity_from_origin().numerical_value_ref_in(m) ==
-              0);
-static_assert(quantity_point<isq::height[m], mean_sea_level>::min().quantity_from_origin().numerical_value_ref_in(m) ==
-              std::numeric_limits<double>::lowest());
-static_assert(quantity_point<isq::height[m], mean_sea_level>::max().quantity_from_origin().numerical_value_ref_in(m) ==
-              std::numeric_limits<double>::max());
+static_assert(
+  quantity_point<isq::height[m], mean_sea_level>::zero().quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+  0);
+static_assert(
+  quantity_point<isq::height[m], mean_sea_level>::min().quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+  std::numeric_limits<double>::lowest());
+static_assert(
+  quantity_point<isq::height[m], mean_sea_level>::max().quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+  std::numeric_limits<double>::max());
 
 static_assert(
-  quantity_point<isq::height[m], ground_level, int>::zero().quantity_from_origin().numerical_value_ref_in(m) == 0);
-static_assert(quantity_point<isq::height[m], ground_level, int>::min().quantity_from_origin().numerical_value_ref_in(
-                m) == std::numeric_limits<int>::lowest());
-static_assert(quantity_point<isq::height[m], ground_level, int>::max().quantity_from_origin().numerical_value_ref_in(
-                m) == std::numeric_limits<int>::max());
+
+  quantity_point<isq::height[m], ground_level, int>::zero().quantity_ref_from(ground_level).numerical_value_ref_in(m) ==
+  0);
+static_assert(
+  quantity_point<isq::height[m], ground_level, int>::min().quantity_ref_from(ground_level).numerical_value_ref_in(m) ==
+  std::numeric_limits<int>::lowest());
+static_assert(
+  quantity_point<isq::height[m], ground_level, int>::max().quantity_ref_from(ground_level).numerical_value_ref_in(m) ==
+  std::numeric_limits<int>::max());
 
 
 //////////////////////////////
@@ -539,36 +546,42 @@ static_assert(
 // obtaining a relative quantity
 //////////////////////////////////
 
-static_assert((mean_sea_level + 42 * m).quantity_from_origin() == 42 * m);
-static_assert((mean_sea_level + isq::height(42 * m)).quantity_from_origin() == 42 * m);
+static_assert((mean_sea_level + 42 * m).quantity_ref_from(mean_sea_level) == 42 * m);
+static_assert((mean_sea_level + isq::height(42 * m)).quantity_ref_from(mean_sea_level) == 42 * m);
 
-static_assert((zero + 1 * one).quantity_from_origin() == 1 * one);
-static_assert((zero + dimensionless(1 * one)).quantity_from_origin() == 1 * one);
+static_assert((zero + 1 * one).quantity_ref_from(zero) == 1 * one);
+static_assert((zero + dimensionless(1 * one)).quantity_ref_from(zero) == 1 * one);
 
-static_assert((mean_sea_level + 42 * m).quantity_from_origin() == 42 * m);
-static_assert((ground_level + 42 * m).quantity_from_origin() == 42 * m);
-static_assert((tower_peak + 42 * m).quantity_from_origin() == 42 * m);
+static_assert((mean_sea_level + 42 * m).quantity_ref_from(mean_sea_level) == 42 * m);
+static_assert((ground_level + 42 * m).quantity_ref_from(ground_level) == 42 * m);
+static_assert((tower_peak + 42 * m).quantity_ref_from(tower_peak) == 42 * m);
 
-static_assert(quantity_point<isq::height[m], mean_sea_level>(ground_level + 42 * m).quantity_from_origin() == 84 * m);
-static_assert(quantity_point<isq::height[m], mean_sea_level>(tower_peak + 42 * m).quantity_from_origin() == 126 * m);
+static_assert(quantity_point<isq::height[m], mean_sea_level>(ground_level + 42 * m).quantity_ref_from(mean_sea_level) ==
+              84 * m);
+static_assert(quantity_point<isq::height[m], mean_sea_level>(tower_peak + 42 * m).quantity_ref_from(mean_sea_level) ==
+              126 * m);
 
-static_assert(quantity_point<isq::height[m], ground_level>(mean_sea_level + 84 * m).quantity_from_origin() == 42 * m);
-static_assert(quantity_point<isq::height[m], ground_level>(tower_peak + 42 * m).quantity_from_origin() == 84 * m);
+static_assert(quantity_point<isq::height[m], ground_level>(mean_sea_level + 84 * m).quantity_ref_from(ground_level) ==
+              42 * m);
+static_assert(quantity_point<isq::height[m], ground_level>(tower_peak + 42 * m).quantity_ref_from(ground_level) ==
+              84 * m);
 
-static_assert(quantity_point<isq::height[m], tower_peak>(mean_sea_level + 42 * m).quantity_from_origin() == -42 * m);
-static_assert(quantity_point<isq::height[m], tower_peak>(ground_level + 84 * m).quantity_from_origin() == 42 * m);
+static_assert(quantity_point<isq::height[m], tower_peak>(mean_sea_level + 42 * m).quantity_ref_from(tower_peak) ==
+              -42 * m);
+static_assert(quantity_point<isq::height[m], tower_peak>(ground_level + 84 * m).quantity_ref_from(tower_peak) ==
+              42 * m);
 
-static_assert((mean_sea_level + 42 * m).point_for(mean_sea_level).quantity_from_origin() == 42 * m);
-static_assert((ground_level + 42 * m).point_for(mean_sea_level).quantity_from_origin() == 84 * m);
-static_assert((tower_peak + 42 * m).point_for(mean_sea_level).quantity_from_origin() == 126 * m);
+static_assert((mean_sea_level + 42 * m).point_for(mean_sea_level).quantity_ref_from(mean_sea_level) == 42 * m);
+static_assert((ground_level + 42 * m).point_for(mean_sea_level).quantity_ref_from(mean_sea_level) == 84 * m);
+static_assert((tower_peak + 42 * m).point_for(mean_sea_level).quantity_ref_from(mean_sea_level) == 126 * m);
 
-static_assert((ground_level + 84 * m).point_for(ground_level).quantity_from_origin() == 84 * m);
-static_assert((mean_sea_level + 84 * m).point_for(ground_level).quantity_from_origin() == 42 * m);
-static_assert((tower_peak + 42 * m).point_for(ground_level).quantity_from_origin() == 84 * m);
+static_assert((ground_level + 84 * m).point_for(ground_level).quantity_ref_from(ground_level) == 84 * m);
+static_assert((mean_sea_level + 84 * m).point_for(ground_level).quantity_ref_from(ground_level) == 42 * m);
+static_assert((tower_peak + 42 * m).point_for(ground_level).quantity_ref_from(ground_level) == 84 * m);
 
-static_assert((tower_peak + 42 * m).point_for(tower_peak).quantity_from_origin() == 42 * m);
-static_assert((mean_sea_level + 42 * m).point_for(tower_peak).quantity_from_origin() == -42 * m);
-static_assert((ground_level + 84 * m).point_for(tower_peak).quantity_from_origin() == 42 * m);
+static_assert((tower_peak + 42 * m).point_for(tower_peak).quantity_ref_from(tower_peak) == 42 * m);
+static_assert((mean_sea_level + 42 * m).point_for(tower_peak).quantity_ref_from(tower_peak) == -42 * m);
+static_assert((ground_level + 84 * m).point_for(tower_peak).quantity_ref_from(tower_peak) == 42 * m);
 
 static_assert(is_of_type<(ground_level + isq::height(short(42) * m)).point_for(mean_sea_level),
                          quantity_point<isq::height[m], mean_sea_level, int>>);
@@ -578,15 +591,15 @@ static_assert(is_of_type<(ground_level + isq::height(short(42) * m)).point_for(m
 // converting to a different unit
 ///////////////////////////////////
 
-static_assert((mean_sea_level + 2. * km).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
-static_assert((mean_sea_level + 2. * km).in(m).quantity_from_origin().numerical_value_ref_in(m) == 2000.);
-static_assert((mean_sea_level + 2000. * m).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
-static_assert((ground_level + 2. * km).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
-static_assert((ground_level + 2. * km).in(m).quantity_from_origin().numerical_value_ref_in(m) == 2000.);
-static_assert((ground_level + 2000. * m).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
-static_assert((tower_peak + 2. * km).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
-static_assert((tower_peak + 2. * km).in(m).quantity_from_origin().numerical_value_ref_in(m) == 2000.);
-static_assert((tower_peak + 2000. * m).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
+static_assert((mean_sea_level + 2. * km).in(km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(km) == 2.);
+static_assert((mean_sea_level + 2. * km).in(m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2000.);
+static_assert((mean_sea_level + 2000. * m).in(km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(km) == 2.);
+static_assert((ground_level + 2. * km).in(km).quantity_ref_from(ground_level).numerical_value_ref_in(km) == 2.);
+static_assert((ground_level + 2. * km).in(m).quantity_ref_from(ground_level).numerical_value_ref_in(m) == 2000.);
+static_assert((ground_level + 2000. * m).in(km).quantity_ref_from(ground_level).numerical_value_ref_in(km) == 2.);
+static_assert((tower_peak + 2. * km).in(km).quantity_ref_from(tower_peak).numerical_value_ref_in(km) == 2.);
+static_assert((tower_peak + 2. * km).in(m).quantity_ref_from(tower_peak).numerical_value_ref_in(m) == 2000.);
+static_assert((tower_peak + 2000. * m).in(km).quantity_ref_from(tower_peak).numerical_value_ref_in(km) == 2.);
 
 #if MP_UNITS_COMP_GCC != 10 || MP_UNITS_COMP_GCC_MINOR > 2
 template<template<auto, auto, typename> typename QP>
@@ -618,18 +631,18 @@ static_assert(([]() {
                 quantity_point l1{mean_sea_level + 1 * m}, l2{mean_sea_level + 2 * m};
                 return l2 = l1;
               }())
-                .quantity_from_origin() == 1 * m);
+                .quantity_ref_from(mean_sea_level) == 1 * m);
 static_assert(([]() {
                 const quantity_point l1{mean_sea_level + 1 * m};
                 quantity_point l2{mean_sea_level + 2 * m};
                 return l2 = l1;
               }())
-                .quantity_from_origin() == 1 * m);
+                .quantity_ref_from(mean_sea_level) == 1 * m);
 static_assert(([]() {
                 quantity_point l1{mean_sea_level + 1 * m}, l2{mean_sea_level + 2 * m};
                 return l2 = std::move(l1);
               }())
-                .quantity_from_origin() == 1 * m);
+                .quantity_ref_from(mean_sea_level) == 1 * m);
 
 
 ////////////////////
@@ -659,14 +672,14 @@ static_assert([](auto v) {
 ////////////////////////
 
 // same type
-static_assert((mean_sea_level + 1 * m += 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 2);
-static_assert((mean_sea_level + 2 * m -= 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1);
+static_assert((mean_sea_level + 1 * m += 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2);
+static_assert((mean_sea_level + 2 * m -= 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1);
 
 // different types
-static_assert((mean_sea_level + 2.5 * m += 3 * m).quantity_from_origin().numerical_value_ref_in(m) == 5.5);
-static_assert((mean_sea_level + 123 * m += 1 * km).quantity_from_origin().numerical_value_ref_in(m) == 1123);
-static_assert((mean_sea_level + 5.5 * m -= 3 * m).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
-static_assert((mean_sea_level + 1123 * m -= 1 * km).quantity_from_origin().numerical_value_ref_in(m) == 123);
+static_assert((mean_sea_level + 2.5 * m += 3 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 5.5);
+static_assert((mean_sea_level + 123 * m += 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1123);
+static_assert((mean_sea_level + 5.5 * m -= 3 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
+static_assert((mean_sea_level + 1123 * m -= 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 123);
 
 
 template<template<auto, auto, typename> typename QP>
@@ -938,29 +951,29 @@ static_assert(is_of_type<(1 * m + tower_peak) - (1 * m + other_ground_level), qu
 
 // check for integral types promotion
 static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) + std::uint8_t(0) * m)
-                                   .quantity_from_origin()
+                                   .quantity_ref_from(mean_sea_level)
                                    .numerical_value_ref_in(m)),
                         int&&>);
 static_assert(is_same_v<decltype((std::uint8_t(0) * m + (mean_sea_level + std::uint8_t(0) * m))
-                                   .quantity_from_origin()
+                                   .quantity_ref_from(mean_sea_level)
                                    .numerical_value_ref_in(m)),
                         int&&>);
 static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(0) * m)
-                                   .quantity_from_origin()
+                                   .quantity_ref_from(mean_sea_level)
                                    .numerical_value_ref_in(m)),
                         int&&>);
 static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(0) * m))
                                    .numerical_value_ref_in(m)),
                         int&&>);
-static_assert(
-  ((mean_sea_level + std::uint8_t(128) * m) + std::uint8_t(128) * m).quantity_from_origin().numerical_value_ref_in(m) ==
-  std::uint8_t(128) + std::uint8_t(128));
-static_assert(
-  (std::uint8_t(128) * m + (mean_sea_level + std::uint8_t(128) * m)).quantity_from_origin().numerical_value_ref_in(m) ==
-  std::uint8_t(128) + std::uint8_t(128));
-static_assert(
-  ((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(1) * m).quantity_from_origin().numerical_value_ref_in(m) ==
-  std::uint8_t(0) - std::uint8_t(1));
+static_assert(((mean_sea_level + std::uint8_t(128) * m) + std::uint8_t(128) * m)
+                .quantity_ref_from(mean_sea_level)
+                .numerical_value_ref_in(m) == std::uint8_t(128) + std::uint8_t(128));
+static_assert((std::uint8_t(128) * m + (mean_sea_level + std::uint8_t(128) * m))
+                .quantity_ref_from(mean_sea_level)
+                .numerical_value_ref_in(m) == std::uint8_t(128) + std::uint8_t(128));
+static_assert(((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(1) * m)
+                .quantity_ref_from(mean_sea_level)
+                .numerical_value_ref_in(m) == std::uint8_t(0) - std::uint8_t(1));
 static_assert(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(1) * m))
                 .numerical_value_ref_in(m) == std::uint8_t(0) - std::uint8_t(1));
 
@@ -1016,32 +1029,42 @@ static_assert(is_of_type<(mean_sea_level + 1 * km) - (mean_sea_level + 1. * m), 
 static_assert(is_of_type<(mean_sea_level + 1. * km) - (mean_sea_level + 1. * m), quantity<si::metre, double>>);
 
 
-static_assert(((mean_sea_level + 1 * m) + 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 2);
-static_assert((1 * m + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value_ref_in(m) == 2);
-static_assert(((mean_sea_level + 1 * m) + 1 * km).quantity_from_origin().numerical_value_ref_in(m) == 1001);
-static_assert((1 * m + (mean_sea_level + 1 * km)).quantity_from_origin().numerical_value_ref_in(m) == 1001);
-static_assert(((mean_sea_level + 1 * km) + 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1001);
-static_assert((1 * km + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value_ref_in(m) == 1001);
-static_assert(((mean_sea_level + 2 * m) - 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1);
-static_assert(((mean_sea_level + 1 * km) - 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 999);
+static_assert(((mean_sea_level + 1 * m) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2);
+static_assert((1 * m + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2);
+static_assert(((mean_sea_level + 1 * m) + 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1001);
+static_assert((1 * m + (mean_sea_level + 1 * km)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1001);
+static_assert(((mean_sea_level + 1 * km) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1001);
+static_assert((1 * km + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1001);
+static_assert(((mean_sea_level + 2 * m) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1);
+static_assert(((mean_sea_level + 1 * km) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 999);
 
-static_assert(((mean_sea_level + 1.5 * m) + 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
-static_assert((1.5 * m + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
-static_assert(((mean_sea_level + 1.5 * m) + 1 * km).quantity_from_origin().numerical_value_ref_in(m) == 1001.5);
-static_assert((1.5 * m + (mean_sea_level + 1 * km)).quantity_from_origin().numerical_value_ref_in(m) == 1001.5);
-static_assert(((mean_sea_level + 1.5 * km) + 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1501);
-static_assert((1.5 * km + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value_ref_in(m) == 1501);
-static_assert(((mean_sea_level + 2.5 * m) - 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1.5);
-static_assert(((mean_sea_level + 1.5 * km) - 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1499);
+static_assert(((mean_sea_level + 1.5 * m) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
+static_assert((1.5 * m + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
+static_assert(((mean_sea_level + 1.5 * m) + 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              1001.5);
+static_assert((1.5 * m + (mean_sea_level + 1 * km)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              1001.5);
+static_assert(((mean_sea_level + 1.5 * km) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              1501);
+static_assert((1.5 * km + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              1501);
+static_assert(((mean_sea_level + 2.5 * m) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1.5);
+static_assert(((mean_sea_level + 1.5 * km) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              1499);
 
-static_assert(((mean_sea_level + 1 * m) + 1.5 * m).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
-static_assert((1 * m + (mean_sea_level + 1.5 * m)).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
-static_assert(((mean_sea_level + 1 * m) + 1.5 * km).quantity_from_origin().numerical_value_ref_in(m) == 1501);
-static_assert((1 * m + (mean_sea_level + 1.5 * km)).quantity_from_origin().numerical_value_ref_in(m) == 1501);
-static_assert(((mean_sea_level + 1 * km) + 1.5 * m).quantity_from_origin().numerical_value_ref_in(m) == 1001.5);
-static_assert((1 * km + (mean_sea_level + 1.5 * m)).quantity_from_origin().numerical_value_ref_in(m) == 1001.5);
-static_assert(((mean_sea_level + 2 * m) - 1.5 * m).quantity_from_origin().numerical_value_ref_in(m) == 0.5);
-static_assert(((mean_sea_level + 1 * km) - 1.5 * m).quantity_from_origin().numerical_value_ref_in(m) == 998.5);
+static_assert(((mean_sea_level + 1 * m) + 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
+static_assert((1 * m + (mean_sea_level + 1.5 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
+static_assert(((mean_sea_level + 1 * m) + 1.5 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              1501);
+static_assert((1 * m + (mean_sea_level + 1.5 * km)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              1501);
+static_assert(((mean_sea_level + 1 * km) + 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              1001.5);
+static_assert((1 * km + (mean_sea_level + 1.5 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              1001.5);
+static_assert(((mean_sea_level + 2 * m) - 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 0.5);
+static_assert(((mean_sea_level + 1 * km) - 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+              998.5);
 
 static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 1);
 static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 999);
@@ -1061,15 +1084,15 @@ static_assert((ground_level + 42 * m) - (other_ground_level + 42 * m) == -81 * m
 static_assert((other_ground_level + 42 * m) - (tower_peak + 42 * m) == 39 * m);
 static_assert((tower_peak + 42 * m) - (other_ground_level + 42 * m) == -39 * m);
 
-static_assert((mean_sea_level + 42 * m).quantity_from_origin() == 42 * m);
-static_assert((42 * m + mean_sea_level).quantity_from_origin() == 42 * m);
-static_assert((mean_sea_level - 42 * m).quantity_from_origin() == -42 * m);
-static_assert((ground_level + 42 * m).quantity_from_origin() == 42 * m);
-static_assert((42 * m + ground_level).quantity_from_origin() == 42 * m);
-static_assert((ground_level - 42 * m).quantity_from_origin() == -42 * m);
-static_assert((tower_peak + 42 * m).quantity_from_origin() == 42 * m);
-static_assert((42 * m + tower_peak).quantity_from_origin() == 42 * m);
-static_assert((tower_peak - 42 * m).quantity_from_origin() == -42 * m);
+static_assert((mean_sea_level + 42 * m).quantity_ref_from(mean_sea_level) == 42 * m);
+static_assert((42 * m + mean_sea_level).quantity_ref_from(mean_sea_level) == 42 * m);
+static_assert((mean_sea_level - 42 * m).quantity_ref_from(mean_sea_level) == -42 * m);
+static_assert((ground_level + 42 * m).quantity_ref_from(ground_level) == 42 * m);
+static_assert((42 * m + ground_level).quantity_ref_from(ground_level) == 42 * m);
+static_assert((ground_level - 42 * m).quantity_ref_from(ground_level) == -42 * m);
+static_assert((tower_peak + 42 * m).quantity_ref_from(tower_peak) == 42 * m);
+static_assert((42 * m + tower_peak).quantity_ref_from(tower_peak) == 42 * m);
+static_assert((tower_peak - 42 * m).quantity_ref_from(tower_peak) == -42 * m);
 
 static_assert((mean_sea_level + 42 * m) - ground_level == 0 * m);
 static_assert((ground_level + 42 * m) - mean_sea_level == 84 * m);
@@ -1109,17 +1132,17 @@ inline constexpr struct zero_m_per_s : absolute_point_origin<kind_of<isq::speed>
 
 // commutativity and associativity
 static_assert(((zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])) + 5 * isq::speed[m / s])
-                .quantity_from_origin() == 10 * isq::speed[m / s]);
+                .quantity_ref_from(zero_m_per_s) == 10 * isq::speed[m / s]);
 static_assert((10 * isq::height[m] / (2 * isq::time[s]) + (zero_m_per_s + 5 * isq::speed[m / s]))
-                .quantity_from_origin() == 10 * isq::speed[m / s]);
+                .quantity_ref_from(zero_m_per_s) == 10 * isq::speed[m / s]);
 static_assert(((zero_m_per_s + 5 * isq::speed[m / s]) + 10 * isq::height[m] / (2 * isq::time[s]))
-                .quantity_from_origin() == 10 * isq::speed[m / s]);
+                .quantity_ref_from(zero_m_per_s) == 10 * isq::speed[m / s]);
 static_assert((5 * isq::speed[m / s] + (zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])))
-                .quantity_from_origin() == 10 * isq::speed[m / s]);
+                .quantity_ref_from(zero_m_per_s) == 10 * isq::speed[m / s]);
 static_assert(((zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])) - 5 * isq::speed[m / s])
-                .quantity_from_origin() == 0 * isq::speed[m / s]);
+                .quantity_ref_from(zero_m_per_s) == 0 * isq::speed[m / s]);
 static_assert(((zero_m_per_s + 5 * isq::speed[m / s]) - 10 * isq::height[m] / (2 * isq::time[s]))
-                .quantity_from_origin() == 0 * isq::speed[m / s]);
+                .quantity_ref_from(zero_m_per_s) == 0 * isq::speed[m / s]);
 static_assert((zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])) - (zero_m_per_s + 5 * isq::speed[m / s]) ==
               0 * isq::speed[m / s]);
 static_assert((zero_m_per_s + 5 * isq::speed[m / s]) - (zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])) ==
@@ -1151,17 +1174,17 @@ static_assert(
 inline constexpr struct zero_Hz : absolute_point_origin<kind_of<isq::frequency>> {
 } zero_Hz;
 
-static_assert(((zero_Hz + 10 / (2 * isq::period_duration[s])) + 5 * isq::frequency[Hz]).quantity_from_origin() ==
+static_assert(((zero_Hz + 10 / (2 * isq::period_duration[s])) + 5 * isq::frequency[Hz]).quantity_ref_from(zero_Hz) ==
               10 * isq::frequency[Hz]);
-static_assert((10 / (2 * isq::period_duration[s]) + (zero_Hz + 5 * isq::frequency[Hz])).quantity_from_origin() ==
+static_assert((10 / (2 * isq::period_duration[s]) + (zero_Hz + 5 * isq::frequency[Hz])).quantity_ref_from(zero_Hz) ==
               10 * isq::frequency[Hz]);
-static_assert(((zero_Hz + 5 * isq::frequency[Hz]) + 10 / (2 * isq::period_duration[s])).quantity_from_origin() ==
+static_assert(((zero_Hz + 5 * isq::frequency[Hz]) + 10 / (2 * isq::period_duration[s])).quantity_ref_from(zero_Hz) ==
               10 * isq::frequency[Hz]);
-static_assert((5 * isq::frequency[Hz] + (zero_Hz + 10 / (2 * isq::period_duration[s]))).quantity_from_origin() ==
+static_assert((5 * isq::frequency[Hz] + (zero_Hz + 10 / (2 * isq::period_duration[s]))).quantity_ref_from(zero_Hz) ==
               10 * isq::frequency[Hz]);
-static_assert(((zero_Hz + 10 / (2 * isq::period_duration[s])) - 5 * isq::frequency[Hz]).quantity_from_origin() ==
+static_assert(((zero_Hz + 10 / (2 * isq::period_duration[s])) - 5 * isq::frequency[Hz]).quantity_ref_from(zero_Hz) ==
               0 * isq::frequency[Hz]);
-static_assert(((zero_Hz + 5 * isq::frequency[Hz]) - 10 / (2 * isq::period_duration[s])).quantity_from_origin() ==
+static_assert(((zero_Hz + 5 * isq::frequency[Hz]) - 10 / (2 * isq::period_duration[s])).quantity_ref_from(zero_Hz) ==
               0 * isq::frequency[Hz]);
 static_assert((zero_Hz + 10 / (2 * isq::period_duration[s])) - (zero_Hz + 5 * isq::frequency[Hz]) ==
               0 * isq::frequency[Hz]);

--- a/test/unit_test/static/quantity_point_test.cpp
+++ b/test/unit_test/static/quantity_point_test.cpp
@@ -241,17 +241,19 @@ static_assert(
 // static member functions
 ////////////////////////////
 
-static_assert(quantity_point<isq::height[m], mean_sea_level>::zero().quantity_from_origin().numerical_value() == 0);
-static_assert(quantity_point<isq::height[m], mean_sea_level>::min().quantity_from_origin().numerical_value() ==
+static_assert(quantity_point<isq::height[m], mean_sea_level>::zero().quantity_from_origin().numerical_value_ref_in(m) ==
+              0);
+static_assert(quantity_point<isq::height[m], mean_sea_level>::min().quantity_from_origin().numerical_value_ref_in(m) ==
               std::numeric_limits<double>::lowest());
-static_assert(quantity_point<isq::height[m], mean_sea_level>::max().quantity_from_origin().numerical_value() ==
+static_assert(quantity_point<isq::height[m], mean_sea_level>::max().quantity_from_origin().numerical_value_ref_in(m) ==
               std::numeric_limits<double>::max());
 
-static_assert(quantity_point<isq::height[m], ground_level, int>::zero().quantity_from_origin().numerical_value() == 0);
-static_assert(quantity_point<isq::height[m], ground_level, int>::min().quantity_from_origin().numerical_value() ==
-              std::numeric_limits<int>::lowest());
-static_assert(quantity_point<isq::height[m], ground_level, int>::max().quantity_from_origin().numerical_value() ==
-              std::numeric_limits<int>::max());
+static_assert(
+  quantity_point<isq::height[m], ground_level, int>::zero().quantity_from_origin().numerical_value_ref_in(m) == 0);
+static_assert(quantity_point<isq::height[m], ground_level, int>::min().quantity_from_origin().numerical_value_ref_in(
+                m) == std::numeric_limits<int>::lowest());
+static_assert(quantity_point<isq::height[m], ground_level, int>::max().quantity_from_origin().numerical_value_ref_in(
+                m) == std::numeric_limits<int>::max());
 
 
 //////////////////////////////
@@ -576,15 +578,15 @@ static_assert(is_of_type<(ground_level + isq::height(short(42) * m)).point_for(m
 // converting to a different unit
 ///////////////////////////////////
 
-static_assert((mean_sea_level + 2. * km).in(km).quantity_from_origin().numerical_value() == 2.);
-static_assert((mean_sea_level + 2. * km).in(m).quantity_from_origin().numerical_value() == 2000.);
-static_assert((mean_sea_level + 2000. * m).in(km).quantity_from_origin().numerical_value() == 2.);
-static_assert((ground_level + 2. * km).in(km).quantity_from_origin().numerical_value() == 2.);
-static_assert((ground_level + 2. * km).in(m).quantity_from_origin().numerical_value() == 2000.);
-static_assert((ground_level + 2000. * m).in(km).quantity_from_origin().numerical_value() == 2.);
-static_assert((tower_peak + 2. * km).in(km).quantity_from_origin().numerical_value() == 2.);
-static_assert((tower_peak + 2. * km).in(m).quantity_from_origin().numerical_value() == 2000.);
-static_assert((tower_peak + 2000. * m).in(km).quantity_from_origin().numerical_value() == 2.);
+static_assert((mean_sea_level + 2. * km).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
+static_assert((mean_sea_level + 2. * km).in(m).quantity_from_origin().numerical_value_ref_in(m) == 2000.);
+static_assert((mean_sea_level + 2000. * m).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
+static_assert((ground_level + 2. * km).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
+static_assert((ground_level + 2. * km).in(m).quantity_from_origin().numerical_value_ref_in(m) == 2000.);
+static_assert((ground_level + 2000. * m).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
+static_assert((tower_peak + 2. * km).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
+static_assert((tower_peak + 2. * km).in(m).quantity_from_origin().numerical_value_ref_in(m) == 2000.);
+static_assert((tower_peak + 2000. * m).in(km).quantity_from_origin().numerical_value_ref_in(km) == 2.);
 
 #if MP_UNITS_COMP_GCC != 10 || MP_UNITS_COMP_GCC_MINOR > 2
 template<template<auto, auto, typename> typename QP>
@@ -657,14 +659,14 @@ static_assert([](auto v) {
 ////////////////////////
 
 // same type
-static_assert((mean_sea_level + 1 * m += 1 * m).quantity_from_origin().numerical_value() == 2);
-static_assert((mean_sea_level + 2 * m -= 1 * m).quantity_from_origin().numerical_value() == 1);
+static_assert((mean_sea_level + 1 * m += 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 2);
+static_assert((mean_sea_level + 2 * m -= 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1);
 
 // different types
-static_assert((mean_sea_level + 2.5 * m += 3 * m).quantity_from_origin().numerical_value() == 5.5);
-static_assert((mean_sea_level + 123 * m += 1 * km).quantity_from_origin().numerical_value() == 1123);
-static_assert((mean_sea_level + 5.5 * m -= 3 * m).quantity_from_origin().numerical_value() == 2.5);
-static_assert((mean_sea_level + 1123 * m -= 1 * km).quantity_from_origin().numerical_value() == 123);
+static_assert((mean_sea_level + 2.5 * m += 3 * m).quantity_from_origin().numerical_value_ref_in(m) == 5.5);
+static_assert((mean_sea_level + 123 * m += 1 * km).quantity_from_origin().numerical_value_ref_in(m) == 1123);
+static_assert((mean_sea_level + 5.5 * m -= 3 * m).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
+static_assert((mean_sea_level + 1123 * m -= 1 * km).quantity_from_origin().numerical_value_ref_in(m) == 123);
 
 
 template<template<auto, auto, typename> typename QP>
@@ -935,31 +937,32 @@ static_assert(is_of_type<(1 * m + tower_peak) - (1 * m + other_ground_level), qu
 
 
 // check for integral types promotion
-static_assert(
-  is_same_v<
-    decltype(((mean_sea_level + std::uint8_t(0) * m) + std::uint8_t(0) * m).quantity_from_origin().numerical_value()),
-    int&&>);
-static_assert(
-  is_same_v<
-    decltype((std::uint8_t(0) * m + (mean_sea_level + std::uint8_t(0) * m)).quantity_from_origin().numerical_value()),
-    int&&>);
-static_assert(
-  is_same_v<
-    decltype(((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(0) * m).quantity_from_origin().numerical_value()),
-    int&&>);
+static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) + std::uint8_t(0) * m)
+                                   .quantity_from_origin()
+                                   .numerical_value_ref_in(m)),
+                        int&&>);
+static_assert(is_same_v<decltype((std::uint8_t(0) * m + (mean_sea_level + std::uint8_t(0) * m))
+                                   .quantity_from_origin()
+                                   .numerical_value_ref_in(m)),
+                        int&&>);
+static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(0) * m)
+                                   .quantity_from_origin()
+                                   .numerical_value_ref_in(m)),
+                        int&&>);
 static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(0) * m))
-                                   .numerical_value()),
+                                   .numerical_value_ref_in(m)),
                         int&&>);
 static_assert(
-  ((mean_sea_level + std::uint8_t(128) * m) + std::uint8_t(128) * m).quantity_from_origin().numerical_value() ==
+  ((mean_sea_level + std::uint8_t(128) * m) + std::uint8_t(128) * m).quantity_from_origin().numerical_value_ref_in(m) ==
   std::uint8_t(128) + std::uint8_t(128));
 static_assert(
-  (std::uint8_t(128) * m + (mean_sea_level + std::uint8_t(128) * m)).quantity_from_origin().numerical_value() ==
+  (std::uint8_t(128) * m + (mean_sea_level + std::uint8_t(128) * m)).quantity_from_origin().numerical_value_ref_in(m) ==
   std::uint8_t(128) + std::uint8_t(128));
-static_assert(((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(1) * m).quantity_from_origin().numerical_value() ==
-              std::uint8_t(0) - std::uint8_t(1));
-static_assert(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(1) * m)).numerical_value() ==
-              std::uint8_t(0) - std::uint8_t(1));
+static_assert(
+  ((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(1) * m).quantity_from_origin().numerical_value_ref_in(m) ==
+  std::uint8_t(0) - std::uint8_t(1));
+static_assert(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(1) * m))
+                .numerical_value_ref_in(m) == std::uint8_t(0) - std::uint8_t(1));
 
 // different representation types
 static_assert(is_of_type<(mean_sea_level + 1. * m) + 1 * m, quantity_point<si::metre, mean_sea_level, double>>);
@@ -1013,39 +1016,39 @@ static_assert(is_of_type<(mean_sea_level + 1 * km) - (mean_sea_level + 1. * m), 
 static_assert(is_of_type<(mean_sea_level + 1. * km) - (mean_sea_level + 1. * m), quantity<si::metre, double>>);
 
 
-static_assert(((mean_sea_level + 1 * m) + 1 * m).quantity_from_origin().numerical_value() == 2);
-static_assert((1 * m + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value() == 2);
-static_assert(((mean_sea_level + 1 * m) + 1 * km).quantity_from_origin().numerical_value() == 1001);
-static_assert((1 * m + (mean_sea_level + 1 * km)).quantity_from_origin().numerical_value() == 1001);
-static_assert(((mean_sea_level + 1 * km) + 1 * m).quantity_from_origin().numerical_value() == 1001);
-static_assert((1 * km + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value() == 1001);
-static_assert(((mean_sea_level + 2 * m) - 1 * m).quantity_from_origin().numerical_value() == 1);
-static_assert(((mean_sea_level + 1 * km) - 1 * m).quantity_from_origin().numerical_value() == 999);
+static_assert(((mean_sea_level + 1 * m) + 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 2);
+static_assert((1 * m + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value_ref_in(m) == 2);
+static_assert(((mean_sea_level + 1 * m) + 1 * km).quantity_from_origin().numerical_value_ref_in(m) == 1001);
+static_assert((1 * m + (mean_sea_level + 1 * km)).quantity_from_origin().numerical_value_ref_in(m) == 1001);
+static_assert(((mean_sea_level + 1 * km) + 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1001);
+static_assert((1 * km + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value_ref_in(m) == 1001);
+static_assert(((mean_sea_level + 2 * m) - 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1);
+static_assert(((mean_sea_level + 1 * km) - 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 999);
 
-static_assert(((mean_sea_level + 1.5 * m) + 1 * m).quantity_from_origin().numerical_value() == 2.5);
-static_assert((1.5 * m + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value() == 2.5);
-static_assert(((mean_sea_level + 1.5 * m) + 1 * km).quantity_from_origin().numerical_value() == 1001.5);
-static_assert((1.5 * m + (mean_sea_level + 1 * km)).quantity_from_origin().numerical_value() == 1001.5);
-static_assert(((mean_sea_level + 1.5 * km) + 1 * m).quantity_from_origin().numerical_value() == 1501);
-static_assert((1.5 * km + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value() == 1501);
-static_assert(((mean_sea_level + 2.5 * m) - 1 * m).quantity_from_origin().numerical_value() == 1.5);
-static_assert(((mean_sea_level + 1.5 * km) - 1 * m).quantity_from_origin().numerical_value() == 1499);
+static_assert(((mean_sea_level + 1.5 * m) + 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
+static_assert((1.5 * m + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
+static_assert(((mean_sea_level + 1.5 * m) + 1 * km).quantity_from_origin().numerical_value_ref_in(m) == 1001.5);
+static_assert((1.5 * m + (mean_sea_level + 1 * km)).quantity_from_origin().numerical_value_ref_in(m) == 1001.5);
+static_assert(((mean_sea_level + 1.5 * km) + 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1501);
+static_assert((1.5 * km + (mean_sea_level + 1 * m)).quantity_from_origin().numerical_value_ref_in(m) == 1501);
+static_assert(((mean_sea_level + 2.5 * m) - 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1.5);
+static_assert(((mean_sea_level + 1.5 * km) - 1 * m).quantity_from_origin().numerical_value_ref_in(m) == 1499);
 
-static_assert(((mean_sea_level + 1 * m) + 1.5 * m).quantity_from_origin().numerical_value() == 2.5);
-static_assert((1 * m + (mean_sea_level + 1.5 * m)).quantity_from_origin().numerical_value() == 2.5);
-static_assert(((mean_sea_level + 1 * m) + 1.5 * km).quantity_from_origin().numerical_value() == 1501);
-static_assert((1 * m + (mean_sea_level + 1.5 * km)).quantity_from_origin().numerical_value() == 1501);
-static_assert(((mean_sea_level + 1 * km) + 1.5 * m).quantity_from_origin().numerical_value() == 1001.5);
-static_assert((1 * km + (mean_sea_level + 1.5 * m)).quantity_from_origin().numerical_value() == 1001.5);
-static_assert(((mean_sea_level + 2 * m) - 1.5 * m).quantity_from_origin().numerical_value() == 0.5);
-static_assert(((mean_sea_level + 1 * km) - 1.5 * m).quantity_from_origin().numerical_value() == 998.5);
+static_assert(((mean_sea_level + 1 * m) + 1.5 * m).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
+static_assert((1 * m + (mean_sea_level + 1.5 * m)).quantity_from_origin().numerical_value_ref_in(m) == 2.5);
+static_assert(((mean_sea_level + 1 * m) + 1.5 * km).quantity_from_origin().numerical_value_ref_in(m) == 1501);
+static_assert((1 * m + (mean_sea_level + 1.5 * km)).quantity_from_origin().numerical_value_ref_in(m) == 1501);
+static_assert(((mean_sea_level + 1 * km) + 1.5 * m).quantity_from_origin().numerical_value_ref_in(m) == 1001.5);
+static_assert((1 * km + (mean_sea_level + 1.5 * m)).quantity_from_origin().numerical_value_ref_in(m) == 1001.5);
+static_assert(((mean_sea_level + 2 * m) - 1.5 * m).quantity_from_origin().numerical_value_ref_in(m) == 0.5);
+static_assert(((mean_sea_level + 1 * km) - 1.5 * m).quantity_from_origin().numerical_value_ref_in(m) == 998.5);
 
-static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1 * m)).numerical_value() == 1);
-static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1 * m)).numerical_value() == 999);
-static_assert(((mean_sea_level + 2.5 * m) - (mean_sea_level + 1 * m)).numerical_value() == 1.5);
-static_assert(((mean_sea_level + 1.5 * km) - (mean_sea_level + 1 * m)).numerical_value() == 1499);
-static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1.5 * m)).numerical_value() == 0.5);
-static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1.5 * m)).numerical_value() == 998.5);
+static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 1);
+static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 999);
+static_assert(((mean_sea_level + 2.5 * m) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 1.5);
+static_assert(((mean_sea_level + 1.5 * km) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 1499);
+static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1.5 * m)).numerical_value_ref_in(m) == 0.5);
+static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1.5 * m)).numerical_value_ref_in(m) == 998.5);
 
 static_assert((mean_sea_level + 42 * m) - (ground_level + 42 * m) == -42 * m);
 static_assert((ground_level + 42 * m) - (mean_sea_level + 42 * m) == 42 * m);

--- a/test/unit_test/static/quantity_point_test.cpp
+++ b/test/unit_test/static/quantity_point_test.cpp
@@ -242,24 +242,22 @@ static_assert(
 ////////////////////////////
 
 static_assert(
-  quantity_point<isq::height[m], mean_sea_level>::zero().quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-  0);
+  quantity_point<isq::height[m], mean_sea_level>::zero().quantity_ref_from(mean_sea_level).numerical_value_ == 0);
 static_assert(
-  quantity_point<isq::height[m], mean_sea_level>::min().quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+  quantity_point<isq::height[m], mean_sea_level>::min().quantity_ref_from(mean_sea_level).numerical_value_ ==
   std::numeric_limits<double>::lowest());
 static_assert(
-  quantity_point<isq::height[m], mean_sea_level>::max().quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
+  quantity_point<isq::height[m], mean_sea_level>::max().quantity_ref_from(mean_sea_level).numerical_value_ ==
   std::numeric_limits<double>::max());
 
 static_assert(
 
-  quantity_point<isq::height[m], ground_level, int>::zero().quantity_ref_from(ground_level).numerical_value_ref_in(m) ==
-  0);
+  quantity_point<isq::height[m], ground_level, int>::zero().quantity_ref_from(ground_level).numerical_value_ == 0);
 static_assert(
-  quantity_point<isq::height[m], ground_level, int>::min().quantity_ref_from(ground_level).numerical_value_ref_in(m) ==
+  quantity_point<isq::height[m], ground_level, int>::min().quantity_ref_from(ground_level).numerical_value_ ==
   std::numeric_limits<int>::lowest());
 static_assert(
-  quantity_point<isq::height[m], ground_level, int>::max().quantity_ref_from(ground_level).numerical_value_ref_in(m) ==
+  quantity_point<isq::height[m], ground_level, int>::max().quantity_ref_from(ground_level).numerical_value_ ==
   std::numeric_limits<int>::max());
 
 
@@ -591,15 +589,15 @@ static_assert(is_of_type<(ground_level + isq::height(short(42) * m)).point_for(m
 // converting to a different unit
 ///////////////////////////////////
 
-static_assert((mean_sea_level + 2. * km).in(km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(km) == 2.);
-static_assert((mean_sea_level + 2. * km).in(m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2000.);
-static_assert((mean_sea_level + 2000. * m).in(km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(km) == 2.);
-static_assert((ground_level + 2. * km).in(km).quantity_ref_from(ground_level).numerical_value_ref_in(km) == 2.);
-static_assert((ground_level + 2. * km).in(m).quantity_ref_from(ground_level).numerical_value_ref_in(m) == 2000.);
-static_assert((ground_level + 2000. * m).in(km).quantity_ref_from(ground_level).numerical_value_ref_in(km) == 2.);
-static_assert((tower_peak + 2. * km).in(km).quantity_ref_from(tower_peak).numerical_value_ref_in(km) == 2.);
-static_assert((tower_peak + 2. * km).in(m).quantity_ref_from(tower_peak).numerical_value_ref_in(m) == 2000.);
-static_assert((tower_peak + 2000. * m).in(km).quantity_ref_from(tower_peak).numerical_value_ref_in(km) == 2.);
+static_assert((mean_sea_level + 2. * km).in(km).quantity_ref_from(mean_sea_level).numerical_value_ == 2.);
+static_assert((mean_sea_level + 2. * km).in(m).quantity_ref_from(mean_sea_level).numerical_value_ == 2000.);
+static_assert((mean_sea_level + 2000. * m).in(km).quantity_ref_from(mean_sea_level).numerical_value_ == 2.);
+static_assert((ground_level + 2. * km).in(km).quantity_ref_from(ground_level).numerical_value_ == 2.);
+static_assert((ground_level + 2. * km).in(m).quantity_ref_from(ground_level).numerical_value_ == 2000.);
+static_assert((ground_level + 2000. * m).in(km).quantity_ref_from(ground_level).numerical_value_ == 2.);
+static_assert((tower_peak + 2. * km).in(km).quantity_ref_from(tower_peak).numerical_value_ == 2.);
+static_assert((tower_peak + 2. * km).in(m).quantity_ref_from(tower_peak).numerical_value_ == 2000.);
+static_assert((tower_peak + 2000. * m).in(km).quantity_ref_from(tower_peak).numerical_value_ == 2.);
 
 #if MP_UNITS_COMP_GCC != 10 || MP_UNITS_COMP_GCC_MINOR > 2
 template<template<auto, auto, typename> typename QP>
@@ -672,14 +670,14 @@ static_assert([](auto v) {
 ////////////////////////
 
 // same type
-static_assert((mean_sea_level + 1 * m += 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2);
-static_assert((mean_sea_level + 2 * m -= 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1);
+static_assert((mean_sea_level + 1 * m += 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2);
+static_assert((mean_sea_level + 2 * m -= 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1);
 
 // different types
-static_assert((mean_sea_level + 2.5 * m += 3 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 5.5);
-static_assert((mean_sea_level + 123 * m += 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1123);
-static_assert((mean_sea_level + 5.5 * m -= 3 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
-static_assert((mean_sea_level + 1123 * m -= 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 123);
+static_assert((mean_sea_level + 2.5 * m += 3 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 5.5);
+static_assert((mean_sea_level + 123 * m += 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 1123);
+static_assert((mean_sea_level + 5.5 * m -= 3 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
+static_assert((mean_sea_level + 1123 * m -= 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 123);
 
 
 template<template<auto, auto, typename> typename QP>
@@ -952,30 +950,30 @@ static_assert(is_of_type<(1 * m + tower_peak) - (1 * m + other_ground_level), qu
 // check for integral types promotion
 static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) + std::uint8_t(0) * m)
                                    .quantity_ref_from(mean_sea_level)
-                                   .numerical_value_ref_in(m)),
-                        int&&>);
+                                   .numerical_value_),
+                        int>);
 static_assert(is_same_v<decltype((std::uint8_t(0) * m + (mean_sea_level + std::uint8_t(0) * m))
                                    .quantity_ref_from(mean_sea_level)
-                                   .numerical_value_ref_in(m)),
-                        int&&>);
+                                   .numerical_value_),
+                        int>);
 static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(0) * m)
                                    .quantity_ref_from(mean_sea_level)
-                                   .numerical_value_ref_in(m)),
-                        int&&>);
-static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(0) * m))
-                                   .numerical_value_ref_in(m)),
-                        int&&>);
+                                   .numerical_value_),
+                        int>);
+static_assert(
+  is_same_v<
+    decltype(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(0) * m)).numerical_value_), int>);
 static_assert(((mean_sea_level + std::uint8_t(128) * m) + std::uint8_t(128) * m)
                 .quantity_ref_from(mean_sea_level)
-                .numerical_value_ref_in(m) == std::uint8_t(128) + std::uint8_t(128));
+                .numerical_value_ == std::uint8_t(128) + std::uint8_t(128));
 static_assert((std::uint8_t(128) * m + (mean_sea_level + std::uint8_t(128) * m))
                 .quantity_ref_from(mean_sea_level)
-                .numerical_value_ref_in(m) == std::uint8_t(128) + std::uint8_t(128));
-static_assert(((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(1) * m)
-                .quantity_ref_from(mean_sea_level)
-                .numerical_value_ref_in(m) == std::uint8_t(0) - std::uint8_t(1));
-static_assert(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(1) * m))
-                .numerical_value_ref_in(m) == std::uint8_t(0) - std::uint8_t(1));
+                .numerical_value_ == std::uint8_t(128) + std::uint8_t(128));
+static_assert(
+  ((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(1) * m).quantity_ref_from(mean_sea_level).numerical_value_ ==
+  std::uint8_t(0) - std::uint8_t(1));
+static_assert(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(1) * m)).numerical_value_ ==
+              std::uint8_t(0) - std::uint8_t(1));
 
 // different representation types
 static_assert(is_of_type<(mean_sea_level + 1. * m) + 1 * m, quantity_point<si::metre, mean_sea_level, double>>);
@@ -1029,49 +1027,39 @@ static_assert(is_of_type<(mean_sea_level + 1 * km) - (mean_sea_level + 1. * m), 
 static_assert(is_of_type<(mean_sea_level + 1. * km) - (mean_sea_level + 1. * m), quantity<si::metre, double>>);
 
 
-static_assert(((mean_sea_level + 1 * m) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2);
-static_assert((1 * m + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2);
-static_assert(((mean_sea_level + 1 * m) + 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1001);
-static_assert((1 * m + (mean_sea_level + 1 * km)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1001);
-static_assert(((mean_sea_level + 1 * km) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1001);
-static_assert((1 * km + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1001);
-static_assert(((mean_sea_level + 2 * m) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1);
-static_assert(((mean_sea_level + 1 * km) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 999);
+static_assert(((mean_sea_level + 1 * m) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2);
+static_assert((1 * m + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 2);
+static_assert(((mean_sea_level + 1 * m) + 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 1001);
+static_assert((1 * m + (mean_sea_level + 1 * km)).quantity_ref_from(mean_sea_level).numerical_value_ == 1001);
+static_assert(((mean_sea_level + 1 * km) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1001);
+static_assert((1 * km + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 1001);
+static_assert(((mean_sea_level + 2 * m) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1);
+static_assert(((mean_sea_level + 1 * km) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 999);
 
-static_assert(((mean_sea_level + 1.5 * m) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
-static_assert((1.5 * m + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
-static_assert(((mean_sea_level + 1.5 * m) + 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              1001.5);
-static_assert((1.5 * m + (mean_sea_level + 1 * km)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              1001.5);
-static_assert(((mean_sea_level + 1.5 * km) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              1501);
-static_assert((1.5 * km + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              1501);
-static_assert(((mean_sea_level + 2.5 * m) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 1.5);
-static_assert(((mean_sea_level + 1.5 * km) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              1499);
+static_assert(((mean_sea_level + 1.5 * m) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
+static_assert((1.5 * m + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
+static_assert(((mean_sea_level + 1.5 * m) + 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 1001.5);
+static_assert((1.5 * m + (mean_sea_level + 1 * km)).quantity_ref_from(mean_sea_level).numerical_value_ == 1001.5);
+static_assert(((mean_sea_level + 1.5 * km) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1501);
+static_assert((1.5 * km + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 1501);
+static_assert(((mean_sea_level + 2.5 * m) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1.5);
+static_assert(((mean_sea_level + 1.5 * km) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1499);
 
-static_assert(((mean_sea_level + 1 * m) + 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
-static_assert((1 * m + (mean_sea_level + 1.5 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 2.5);
-static_assert(((mean_sea_level + 1 * m) + 1.5 * km).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              1501);
-static_assert((1 * m + (mean_sea_level + 1.5 * km)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              1501);
-static_assert(((mean_sea_level + 1 * km) + 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              1001.5);
-static_assert((1 * km + (mean_sea_level + 1.5 * m)).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              1001.5);
-static_assert(((mean_sea_level + 2 * m) - 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) == 0.5);
-static_assert(((mean_sea_level + 1 * km) - 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ref_in(m) ==
-              998.5);
+static_assert(((mean_sea_level + 1 * m) + 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
+static_assert((1 * m + (mean_sea_level + 1.5 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
+static_assert(((mean_sea_level + 1 * m) + 1.5 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 1501);
+static_assert((1 * m + (mean_sea_level + 1.5 * km)).quantity_ref_from(mean_sea_level).numerical_value_ == 1501);
+static_assert(((mean_sea_level + 1 * km) + 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1001.5);
+static_assert((1 * km + (mean_sea_level + 1.5 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 1001.5);
+static_assert(((mean_sea_level + 2 * m) - 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 0.5);
+static_assert(((mean_sea_level + 1 * km) - 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 998.5);
 
-static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 1);
-static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 999);
-static_assert(((mean_sea_level + 2.5 * m) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 1.5);
-static_assert(((mean_sea_level + 1.5 * km) - (mean_sea_level + 1 * m)).numerical_value_ref_in(m) == 1499);
-static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1.5 * m)).numerical_value_ref_in(m) == 0.5);
-static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1.5 * m)).numerical_value_ref_in(m) == 998.5);
+static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1 * m)).numerical_value_ == 1);
+static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1 * m)).numerical_value_ == 999);
+static_assert(((mean_sea_level + 2.5 * m) - (mean_sea_level + 1 * m)).numerical_value_ == 1.5);
+static_assert(((mean_sea_level + 1.5 * km) - (mean_sea_level + 1 * m)).numerical_value_ == 1499);
+static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1.5 * m)).numerical_value_ == 0.5);
+static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1.5 * m)).numerical_value_ == 998.5);
 
 static_assert((mean_sea_level + 42 * m) - (ground_level + 42 * m) == -42 * m);
 static_assert((ground_level + 42 * m) - (mean_sea_level + 42 * m) == 42 * m);

--- a/test/unit_test/static/quantity_point_test.cpp
+++ b/test/unit_test/static/quantity_point_test.cpp
@@ -241,24 +241,19 @@ static_assert(
 // static member functions
 ////////////////////////////
 
-static_assert(
-  quantity_point<isq::height[m], mean_sea_level>::zero().quantity_ref_from(mean_sea_level).numerical_value_ == 0);
-static_assert(
-  quantity_point<isq::height[m], mean_sea_level>::min().quantity_ref_from(mean_sea_level).numerical_value_ ==
-  std::numeric_limits<double>::lowest());
-static_assert(
-  quantity_point<isq::height[m], mean_sea_level>::max().quantity_ref_from(mean_sea_level).numerical_value_ ==
-  std::numeric_limits<double>::max());
+static_assert(quantity_point<isq::height[m], mean_sea_level>::zero().quantity_from_origin_.numerical_value_ == 0);
+static_assert(quantity_point<isq::height[m], mean_sea_level>::min().quantity_from_origin_.numerical_value_ ==
+              std::numeric_limits<double>::lowest());
+static_assert(quantity_point<isq::height[m], mean_sea_level>::max().quantity_from_origin_.numerical_value_ ==
+              std::numeric_limits<double>::max());
 
 static_assert(
 
-  quantity_point<isq::height[m], ground_level, int>::zero().quantity_ref_from(ground_level).numerical_value_ == 0);
-static_assert(
-  quantity_point<isq::height[m], ground_level, int>::min().quantity_ref_from(ground_level).numerical_value_ ==
-  std::numeric_limits<int>::lowest());
-static_assert(
-  quantity_point<isq::height[m], ground_level, int>::max().quantity_ref_from(ground_level).numerical_value_ ==
-  std::numeric_limits<int>::max());
+  quantity_point<isq::height[m], ground_level, int>::zero().quantity_from_origin_.numerical_value_ == 0);
+static_assert(quantity_point<isq::height[m], ground_level, int>::min().quantity_from_origin_.numerical_value_ ==
+              std::numeric_limits<int>::lowest());
+static_assert(quantity_point<isq::height[m], ground_level, int>::max().quantity_from_origin_.numerical_value_ ==
+              std::numeric_limits<int>::max());
 
 
 //////////////////////////////
@@ -544,42 +539,36 @@ static_assert(
 // obtaining a relative quantity
 //////////////////////////////////
 
-static_assert((mean_sea_level + 42 * m).quantity_ref_from(mean_sea_level) == 42 * m);
-static_assert((mean_sea_level + isq::height(42 * m)).quantity_ref_from(mean_sea_level) == 42 * m);
+static_assert((mean_sea_level + 42 * m).quantity_from_origin_ == 42 * m);
+static_assert((mean_sea_level + isq::height(42 * m)).quantity_from_origin_ == 42 * m);
 
-static_assert((zero + 1 * one).quantity_ref_from(zero) == 1 * one);
-static_assert((zero + dimensionless(1 * one)).quantity_ref_from(zero) == 1 * one);
+static_assert((zero + 1 * one).quantity_from_origin_ == 1 * one);
+static_assert((zero + dimensionless(1 * one)).quantity_from_origin_ == 1 * one);
 
-static_assert((mean_sea_level + 42 * m).quantity_ref_from(mean_sea_level) == 42 * m);
-static_assert((ground_level + 42 * m).quantity_ref_from(ground_level) == 42 * m);
-static_assert((tower_peak + 42 * m).quantity_ref_from(tower_peak) == 42 * m);
+static_assert((mean_sea_level + 42 * m).quantity_from_origin_ == 42 * m);
+static_assert((ground_level + 42 * m).quantity_from_origin_ == 42 * m);
+static_assert((tower_peak + 42 * m).quantity_from_origin_ == 42 * m);
 
-static_assert(quantity_point<isq::height[m], mean_sea_level>(ground_level + 42 * m).quantity_ref_from(mean_sea_level) ==
-              84 * m);
-static_assert(quantity_point<isq::height[m], mean_sea_level>(tower_peak + 42 * m).quantity_ref_from(mean_sea_level) ==
-              126 * m);
+static_assert(quantity_point<isq::height[m], mean_sea_level>(ground_level + 42 * m).quantity_from_origin_ == 84 * m);
+static_assert(quantity_point<isq::height[m], mean_sea_level>(tower_peak + 42 * m).quantity_from_origin_ == 126 * m);
 
-static_assert(quantity_point<isq::height[m], ground_level>(mean_sea_level + 84 * m).quantity_ref_from(ground_level) ==
-              42 * m);
-static_assert(quantity_point<isq::height[m], ground_level>(tower_peak + 42 * m).quantity_ref_from(ground_level) ==
-              84 * m);
+static_assert(quantity_point<isq::height[m], ground_level>(mean_sea_level + 84 * m).quantity_from_origin_ == 42 * m);
+static_assert(quantity_point<isq::height[m], ground_level>(tower_peak + 42 * m).quantity_from_origin_ == 84 * m);
 
-static_assert(quantity_point<isq::height[m], tower_peak>(mean_sea_level + 42 * m).quantity_ref_from(tower_peak) ==
-              -42 * m);
-static_assert(quantity_point<isq::height[m], tower_peak>(ground_level + 84 * m).quantity_ref_from(tower_peak) ==
-              42 * m);
+static_assert(quantity_point<isq::height[m], tower_peak>(mean_sea_level + 42 * m).quantity_from_origin_ == -42 * m);
+static_assert(quantity_point<isq::height[m], tower_peak>(ground_level + 84 * m).quantity_from_origin_ == 42 * m);
 
-static_assert((mean_sea_level + 42 * m).point_for(mean_sea_level).quantity_ref_from(mean_sea_level) == 42 * m);
-static_assert((ground_level + 42 * m).point_for(mean_sea_level).quantity_ref_from(mean_sea_level) == 84 * m);
-static_assert((tower_peak + 42 * m).point_for(mean_sea_level).quantity_ref_from(mean_sea_level) == 126 * m);
+static_assert((mean_sea_level + 42 * m).point_for(mean_sea_level).quantity_from_origin_ == 42 * m);
+static_assert((ground_level + 42 * m).point_for(mean_sea_level).quantity_from_origin_ == 84 * m);
+static_assert((tower_peak + 42 * m).point_for(mean_sea_level).quantity_from_origin_ == 126 * m);
 
-static_assert((ground_level + 84 * m).point_for(ground_level).quantity_ref_from(ground_level) == 84 * m);
-static_assert((mean_sea_level + 84 * m).point_for(ground_level).quantity_ref_from(ground_level) == 42 * m);
-static_assert((tower_peak + 42 * m).point_for(ground_level).quantity_ref_from(ground_level) == 84 * m);
+static_assert((ground_level + 84 * m).point_for(ground_level).quantity_from_origin_ == 84 * m);
+static_assert((mean_sea_level + 84 * m).point_for(ground_level).quantity_from_origin_ == 42 * m);
+static_assert((tower_peak + 42 * m).point_for(ground_level).quantity_from_origin_ == 84 * m);
 
-static_assert((tower_peak + 42 * m).point_for(tower_peak).quantity_ref_from(tower_peak) == 42 * m);
-static_assert((mean_sea_level + 42 * m).point_for(tower_peak).quantity_ref_from(tower_peak) == -42 * m);
-static_assert((ground_level + 84 * m).point_for(tower_peak).quantity_ref_from(tower_peak) == 42 * m);
+static_assert((tower_peak + 42 * m).point_for(tower_peak).quantity_from_origin_ == 42 * m);
+static_assert((mean_sea_level + 42 * m).point_for(tower_peak).quantity_from_origin_ == -42 * m);
+static_assert((ground_level + 84 * m).point_for(tower_peak).quantity_from_origin_ == 42 * m);
 
 static_assert(is_of_type<(ground_level + isq::height(short(42) * m)).point_for(mean_sea_level),
                          quantity_point<isq::height[m], mean_sea_level, int>>);
@@ -589,15 +578,15 @@ static_assert(is_of_type<(ground_level + isq::height(short(42) * m)).point_for(m
 // converting to a different unit
 ///////////////////////////////////
 
-static_assert((mean_sea_level + 2. * km).in(km).quantity_ref_from(mean_sea_level).numerical_value_ == 2.);
-static_assert((mean_sea_level + 2. * km).in(m).quantity_ref_from(mean_sea_level).numerical_value_ == 2000.);
-static_assert((mean_sea_level + 2000. * m).in(km).quantity_ref_from(mean_sea_level).numerical_value_ == 2.);
-static_assert((ground_level + 2. * km).in(km).quantity_ref_from(ground_level).numerical_value_ == 2.);
-static_assert((ground_level + 2. * km).in(m).quantity_ref_from(ground_level).numerical_value_ == 2000.);
-static_assert((ground_level + 2000. * m).in(km).quantity_ref_from(ground_level).numerical_value_ == 2.);
-static_assert((tower_peak + 2. * km).in(km).quantity_ref_from(tower_peak).numerical_value_ == 2.);
-static_assert((tower_peak + 2. * km).in(m).quantity_ref_from(tower_peak).numerical_value_ == 2000.);
-static_assert((tower_peak + 2000. * m).in(km).quantity_ref_from(tower_peak).numerical_value_ == 2.);
+static_assert((mean_sea_level + 2. * km).in(km).quantity_from_origin_.numerical_value_ == 2.);
+static_assert((mean_sea_level + 2. * km).in(m).quantity_from_origin_.numerical_value_ == 2000.);
+static_assert((mean_sea_level + 2000. * m).in(km).quantity_from_origin_.numerical_value_ == 2.);
+static_assert((ground_level + 2. * km).in(km).quantity_from_origin_.numerical_value_ == 2.);
+static_assert((ground_level + 2. * km).in(m).quantity_from_origin_.numerical_value_ == 2000.);
+static_assert((ground_level + 2000. * m).in(km).quantity_from_origin_.numerical_value_ == 2.);
+static_assert((tower_peak + 2. * km).in(km).quantity_from_origin_.numerical_value_ == 2.);
+static_assert((tower_peak + 2. * km).in(m).quantity_from_origin_.numerical_value_ == 2000.);
+static_assert((tower_peak + 2000. * m).in(km).quantity_from_origin_.numerical_value_ == 2.);
 
 #if MP_UNITS_COMP_GCC != 10 || MP_UNITS_COMP_GCC_MINOR > 2
 template<template<auto, auto, typename> typename QP>
@@ -629,18 +618,18 @@ static_assert(([]() {
                 quantity_point l1{mean_sea_level + 1 * m}, l2{mean_sea_level + 2 * m};
                 return l2 = l1;
               }())
-                .quantity_ref_from(mean_sea_level) == 1 * m);
+                .quantity_from_origin_ == 1 * m);
 static_assert(([]() {
                 const quantity_point l1{mean_sea_level + 1 * m};
                 quantity_point l2{mean_sea_level + 2 * m};
                 return l2 = l1;
               }())
-                .quantity_ref_from(mean_sea_level) == 1 * m);
+                .quantity_from_origin_ == 1 * m);
 static_assert(([]() {
                 quantity_point l1{mean_sea_level + 1 * m}, l2{mean_sea_level + 2 * m};
                 return l2 = std::move(l1);
               }())
-                .quantity_ref_from(mean_sea_level) == 1 * m);
+                .quantity_from_origin_ == 1 * m);
 
 
 ////////////////////
@@ -670,14 +659,14 @@ static_assert([](auto v) {
 ////////////////////////
 
 // same type
-static_assert((mean_sea_level + 1 * m += 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2);
-static_assert((mean_sea_level + 2 * m -= 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1);
+static_assert((mean_sea_level + 1 * m += 1 * m).quantity_from_origin_.numerical_value_ == 2);
+static_assert((mean_sea_level + 2 * m -= 1 * m).quantity_from_origin_.numerical_value_ == 1);
 
 // different types
-static_assert((mean_sea_level + 2.5 * m += 3 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 5.5);
-static_assert((mean_sea_level + 123 * m += 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 1123);
-static_assert((mean_sea_level + 5.5 * m -= 3 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
-static_assert((mean_sea_level + 1123 * m -= 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 123);
+static_assert((mean_sea_level + 2.5 * m += 3 * m).quantity_from_origin_.numerical_value_ == 5.5);
+static_assert((mean_sea_level + 123 * m += 1 * km).quantity_from_origin_.numerical_value_ == 1123);
+static_assert((mean_sea_level + 5.5 * m -= 3 * m).quantity_from_origin_.numerical_value_ == 2.5);
+static_assert((mean_sea_level + 1123 * m -= 1 * km).quantity_from_origin_.numerical_value_ == 123);
 
 
 template<template<auto, auto, typename> typename QP>
@@ -949,29 +938,23 @@ static_assert(is_of_type<(1 * m + tower_peak) - (1 * m + other_ground_level), qu
 
 // check for integral types promotion
 static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) + std::uint8_t(0) * m)
-                                   .quantity_ref_from(mean_sea_level)
-                                   .numerical_value_),
+                                   .quantity_from_origin_.numerical_value_),
                         int>);
 static_assert(is_same_v<decltype((std::uint8_t(0) * m + (mean_sea_level + std::uint8_t(0) * m))
-                                   .quantity_ref_from(mean_sea_level)
-                                   .numerical_value_),
+                                   .quantity_from_origin_.numerical_value_),
                         int>);
 static_assert(is_same_v<decltype(((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(0) * m)
-                                   .quantity_ref_from(mean_sea_level)
-                                   .numerical_value_),
+                                   .quantity_from_origin_.numerical_value_),
                         int>);
 static_assert(
   is_same_v<
     decltype(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(0) * m)).numerical_value_), int>);
 static_assert(((mean_sea_level + std::uint8_t(128) * m) + std::uint8_t(128) * m)
-                .quantity_ref_from(mean_sea_level)
-                .numerical_value_ == std::uint8_t(128) + std::uint8_t(128));
+                .quantity_from_origin_.numerical_value_ == std::uint8_t(128) + std::uint8_t(128));
 static_assert((std::uint8_t(128) * m + (mean_sea_level + std::uint8_t(128) * m))
-                .quantity_ref_from(mean_sea_level)
-                .numerical_value_ == std::uint8_t(128) + std::uint8_t(128));
-static_assert(
-  ((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(1) * m).quantity_ref_from(mean_sea_level).numerical_value_ ==
-  std::uint8_t(0) - std::uint8_t(1));
+                .quantity_from_origin_.numerical_value_ == std::uint8_t(128) + std::uint8_t(128));
+static_assert(((mean_sea_level + std::uint8_t(0) * m) - std::uint8_t(1) * m).quantity_from_origin_.numerical_value_ ==
+              std::uint8_t(0) - std::uint8_t(1));
 static_assert(((mean_sea_level + std::uint8_t(0) * m) - (mean_sea_level + std::uint8_t(1) * m)).numerical_value_ ==
               std::uint8_t(0) - std::uint8_t(1));
 
@@ -1027,32 +1010,32 @@ static_assert(is_of_type<(mean_sea_level + 1 * km) - (mean_sea_level + 1. * m), 
 static_assert(is_of_type<(mean_sea_level + 1. * km) - (mean_sea_level + 1. * m), quantity<si::metre, double>>);
 
 
-static_assert(((mean_sea_level + 1 * m) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2);
-static_assert((1 * m + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 2);
-static_assert(((mean_sea_level + 1 * m) + 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 1001);
-static_assert((1 * m + (mean_sea_level + 1 * km)).quantity_ref_from(mean_sea_level).numerical_value_ == 1001);
-static_assert(((mean_sea_level + 1 * km) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1001);
-static_assert((1 * km + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 1001);
-static_assert(((mean_sea_level + 2 * m) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1);
-static_assert(((mean_sea_level + 1 * km) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 999);
+static_assert(((mean_sea_level + 1 * m) + 1 * m).quantity_from_origin_.numerical_value_ == 2);
+static_assert((1 * m + (mean_sea_level + 1 * m)).quantity_from_origin_.numerical_value_ == 2);
+static_assert(((mean_sea_level + 1 * m) + 1 * km).quantity_from_origin_.numerical_value_ == 1001);
+static_assert((1 * m + (mean_sea_level + 1 * km)).quantity_from_origin_.numerical_value_ == 1001);
+static_assert(((mean_sea_level + 1 * km) + 1 * m).quantity_from_origin_.numerical_value_ == 1001);
+static_assert((1 * km + (mean_sea_level + 1 * m)).quantity_from_origin_.numerical_value_ == 1001);
+static_assert(((mean_sea_level + 2 * m) - 1 * m).quantity_from_origin_.numerical_value_ == 1);
+static_assert(((mean_sea_level + 1 * km) - 1 * m).quantity_from_origin_.numerical_value_ == 999);
 
-static_assert(((mean_sea_level + 1.5 * m) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
-static_assert((1.5 * m + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
-static_assert(((mean_sea_level + 1.5 * m) + 1 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 1001.5);
-static_assert((1.5 * m + (mean_sea_level + 1 * km)).quantity_ref_from(mean_sea_level).numerical_value_ == 1001.5);
-static_assert(((mean_sea_level + 1.5 * km) + 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1501);
-static_assert((1.5 * km + (mean_sea_level + 1 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 1501);
-static_assert(((mean_sea_level + 2.5 * m) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1.5);
-static_assert(((mean_sea_level + 1.5 * km) - 1 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1499);
+static_assert(((mean_sea_level + 1.5 * m) + 1 * m).quantity_from_origin_.numerical_value_ == 2.5);
+static_assert((1.5 * m + (mean_sea_level + 1 * m)).quantity_from_origin_.numerical_value_ == 2.5);
+static_assert(((mean_sea_level + 1.5 * m) + 1 * km).quantity_from_origin_.numerical_value_ == 1001.5);
+static_assert((1.5 * m + (mean_sea_level + 1 * km)).quantity_from_origin_.numerical_value_ == 1001.5);
+static_assert(((mean_sea_level + 1.5 * km) + 1 * m).quantity_from_origin_.numerical_value_ == 1501);
+static_assert((1.5 * km + (mean_sea_level + 1 * m)).quantity_from_origin_.numerical_value_ == 1501);
+static_assert(((mean_sea_level + 2.5 * m) - 1 * m).quantity_from_origin_.numerical_value_ == 1.5);
+static_assert(((mean_sea_level + 1.5 * km) - 1 * m).quantity_from_origin_.numerical_value_ == 1499);
 
-static_assert(((mean_sea_level + 1 * m) + 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
-static_assert((1 * m + (mean_sea_level + 1.5 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 2.5);
-static_assert(((mean_sea_level + 1 * m) + 1.5 * km).quantity_ref_from(mean_sea_level).numerical_value_ == 1501);
-static_assert((1 * m + (mean_sea_level + 1.5 * km)).quantity_ref_from(mean_sea_level).numerical_value_ == 1501);
-static_assert(((mean_sea_level + 1 * km) + 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 1001.5);
-static_assert((1 * km + (mean_sea_level + 1.5 * m)).quantity_ref_from(mean_sea_level).numerical_value_ == 1001.5);
-static_assert(((mean_sea_level + 2 * m) - 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 0.5);
-static_assert(((mean_sea_level + 1 * km) - 1.5 * m).quantity_ref_from(mean_sea_level).numerical_value_ == 998.5);
+static_assert(((mean_sea_level + 1 * m) + 1.5 * m).quantity_from_origin_.numerical_value_ == 2.5);
+static_assert((1 * m + (mean_sea_level + 1.5 * m)).quantity_from_origin_.numerical_value_ == 2.5);
+static_assert(((mean_sea_level + 1 * m) + 1.5 * km).quantity_from_origin_.numerical_value_ == 1501);
+static_assert((1 * m + (mean_sea_level + 1.5 * km)).quantity_from_origin_.numerical_value_ == 1501);
+static_assert(((mean_sea_level + 1 * km) + 1.5 * m).quantity_from_origin_.numerical_value_ == 1001.5);
+static_assert((1 * km + (mean_sea_level + 1.5 * m)).quantity_from_origin_.numerical_value_ == 1001.5);
+static_assert(((mean_sea_level + 2 * m) - 1.5 * m).quantity_from_origin_.numerical_value_ == 0.5);
+static_assert(((mean_sea_level + 1 * km) - 1.5 * m).quantity_from_origin_.numerical_value_ == 998.5);
 
 static_assert(((mean_sea_level + 2 * m) - (mean_sea_level + 1 * m)).numerical_value_ == 1);
 static_assert(((mean_sea_level + 1 * km) - (mean_sea_level + 1 * m)).numerical_value_ == 999);
@@ -1072,15 +1055,15 @@ static_assert((ground_level + 42 * m) - (other_ground_level + 42 * m) == -81 * m
 static_assert((other_ground_level + 42 * m) - (tower_peak + 42 * m) == 39 * m);
 static_assert((tower_peak + 42 * m) - (other_ground_level + 42 * m) == -39 * m);
 
-static_assert((mean_sea_level + 42 * m).quantity_ref_from(mean_sea_level) == 42 * m);
-static_assert((42 * m + mean_sea_level).quantity_ref_from(mean_sea_level) == 42 * m);
-static_assert((mean_sea_level - 42 * m).quantity_ref_from(mean_sea_level) == -42 * m);
-static_assert((ground_level + 42 * m).quantity_ref_from(ground_level) == 42 * m);
-static_assert((42 * m + ground_level).quantity_ref_from(ground_level) == 42 * m);
-static_assert((ground_level - 42 * m).quantity_ref_from(ground_level) == -42 * m);
-static_assert((tower_peak + 42 * m).quantity_ref_from(tower_peak) == 42 * m);
-static_assert((42 * m + tower_peak).quantity_ref_from(tower_peak) == 42 * m);
-static_assert((tower_peak - 42 * m).quantity_ref_from(tower_peak) == -42 * m);
+static_assert((mean_sea_level + 42 * m).quantity_from_origin_ == 42 * m);
+static_assert((42 * m + mean_sea_level).quantity_from_origin_ == 42 * m);
+static_assert((mean_sea_level - 42 * m).quantity_from_origin_ == -42 * m);
+static_assert((ground_level + 42 * m).quantity_from_origin_ == 42 * m);
+static_assert((42 * m + ground_level).quantity_from_origin_ == 42 * m);
+static_assert((ground_level - 42 * m).quantity_from_origin_ == -42 * m);
+static_assert((tower_peak + 42 * m).quantity_from_origin_ == 42 * m);
+static_assert((42 * m + tower_peak).quantity_from_origin_ == 42 * m);
+static_assert((tower_peak - 42 * m).quantity_from_origin_ == -42 * m);
 
 static_assert((mean_sea_level + 42 * m) - ground_level == 0 * m);
 static_assert((ground_level + 42 * m) - mean_sea_level == 84 * m);
@@ -1131,17 +1114,17 @@ inline constexpr struct zero_m_per_s : absolute_point_origin<kind_of<isq::speed>
 
 // commutativity and associativity
 static_assert(((zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])) + 5 * isq::speed[m / s])
-                .quantity_ref_from(zero_m_per_s) == 10 * isq::speed[m / s]);
+                .quantity_from_origin_ == 10 * isq::speed[m / s]);
 static_assert((10 * isq::height[m] / (2 * isq::time[s]) + (zero_m_per_s + 5 * isq::speed[m / s]))
-                .quantity_ref_from(zero_m_per_s) == 10 * isq::speed[m / s]);
+                .quantity_from_origin_ == 10 * isq::speed[m / s]);
 static_assert(((zero_m_per_s + 5 * isq::speed[m / s]) + 10 * isq::height[m] / (2 * isq::time[s]))
-                .quantity_ref_from(zero_m_per_s) == 10 * isq::speed[m / s]);
+                .quantity_from_origin_ == 10 * isq::speed[m / s]);
 static_assert((5 * isq::speed[m / s] + (zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])))
-                .quantity_ref_from(zero_m_per_s) == 10 * isq::speed[m / s]);
+                .quantity_from_origin_ == 10 * isq::speed[m / s]);
 static_assert(((zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])) - 5 * isq::speed[m / s])
-                .quantity_ref_from(zero_m_per_s) == 0 * isq::speed[m / s]);
+                .quantity_from_origin_ == 0 * isq::speed[m / s]);
 static_assert(((zero_m_per_s + 5 * isq::speed[m / s]) - 10 * isq::height[m] / (2 * isq::time[s]))
-                .quantity_ref_from(zero_m_per_s) == 0 * isq::speed[m / s]);
+                .quantity_from_origin_ == 0 * isq::speed[m / s]);
 static_assert((zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])) - (zero_m_per_s + 5 * isq::speed[m / s]) ==
               0 * isq::speed[m / s]);
 static_assert((zero_m_per_s + 5 * isq::speed[m / s]) - (zero_m_per_s + 10 * isq::height[m] / (2 * isq::time[s])) ==
@@ -1173,17 +1156,17 @@ static_assert(
 inline constexpr struct zero_Hz : absolute_point_origin<kind_of<isq::frequency>> {
 } zero_Hz;
 
-static_assert(((zero_Hz + 10 / (2 * isq::period_duration[s])) + 5 * isq::frequency[Hz]).quantity_ref_from(zero_Hz) ==
+static_assert(((zero_Hz + 10 / (2 * isq::period_duration[s])) + 5 * isq::frequency[Hz]).quantity_from_origin_ ==
               10 * isq::frequency[Hz]);
-static_assert((10 / (2 * isq::period_duration[s]) + (zero_Hz + 5 * isq::frequency[Hz])).quantity_ref_from(zero_Hz) ==
+static_assert((10 / (2 * isq::period_duration[s]) + (zero_Hz + 5 * isq::frequency[Hz])).quantity_from_origin_ ==
               10 * isq::frequency[Hz]);
-static_assert(((zero_Hz + 5 * isq::frequency[Hz]) + 10 / (2 * isq::period_duration[s])).quantity_ref_from(zero_Hz) ==
+static_assert(((zero_Hz + 5 * isq::frequency[Hz]) + 10 / (2 * isq::period_duration[s])).quantity_from_origin_ ==
               10 * isq::frequency[Hz]);
-static_assert((5 * isq::frequency[Hz] + (zero_Hz + 10 / (2 * isq::period_duration[s]))).quantity_ref_from(zero_Hz) ==
+static_assert((5 * isq::frequency[Hz] + (zero_Hz + 10 / (2 * isq::period_duration[s]))).quantity_from_origin_ ==
               10 * isq::frequency[Hz]);
-static_assert(((zero_Hz + 10 / (2 * isq::period_duration[s])) - 5 * isq::frequency[Hz]).quantity_ref_from(zero_Hz) ==
+static_assert(((zero_Hz + 10 / (2 * isq::period_duration[s])) - 5 * isq::frequency[Hz]).quantity_from_origin_ ==
               0 * isq::frequency[Hz]);
-static_assert(((zero_Hz + 5 * isq::frequency[Hz]) - 10 / (2 * isq::period_duration[s])).quantity_ref_from(zero_Hz) ==
+static_assert(((zero_Hz + 5 * isq::frequency[Hz]) - 10 / (2 * isq::period_duration[s])).quantity_from_origin_ ==
               0 * isq::frequency[Hz]);
 static_assert((zero_Hz + 10 / (2 * isq::period_duration[s])) - (zero_Hz + 5 * isq::frequency[Hz]) ==
               0 * isq::frequency[Hz]);

--- a/test/unit_test/static/quantity_point_test.cpp
+++ b/test/unit_test/static/quantity_point_test.cpp
@@ -1105,6 +1105,17 @@ static_assert((ground_level + 42 * m) - other_ground_level == -39 * m);
 static_assert((other_ground_level + 42 * m) - tower_peak == 81 * m);
 static_assert((tower_peak + 42 * m) - other_ground_level == 3 * m);
 
+static_assert((mean_sea_level + 42 * m).quantity_from(ground_level) == 0 * m);
+static_assert((ground_level + 42 * m).quantity_from(mean_sea_level) == 84 * m);
+static_assert((tower_peak + 42 * m).quantity_from(ground_level) == 84 * m);
+static_assert((ground_level + 42 * m).quantity_from(tower_peak) == 0 * m);
+static_assert((tower_peak + 42 * m).quantity_from(mean_sea_level) == 126 * m);
+static_assert((mean_sea_level + 42 * m).quantity_from(tower_peak) == -42 * m);
+static_assert((other_ground_level + 42 * m).quantity_from(ground_level) == 123 * m);
+static_assert((ground_level + 42 * m).quantity_from(other_ground_level) == -39 * m);
+static_assert((other_ground_level + 42 * m).quantity_from(tower_peak) == 81 * m);
+static_assert((tower_peak + 42 * m).quantity_from(other_ground_level) == 3 * m);
+
 static_assert(mean_sea_level - (ground_level + 42 * m) == -84 * m);
 static_assert(ground_level - (mean_sea_level + 42 * m) == 0 * m);
 static_assert(tower_peak - (ground_level + 42 * m) == 0 * m);

--- a/test/unit_test/static/quantity_test.cpp
+++ b/test/unit_test/static/quantity_test.cpp
@@ -112,15 +112,14 @@ static_assert(is_same_v<quantity<isq::length[m], int>::rep, int>);
 // static member functions
 ////////////////////////////
 
-static_assert(quantity<isq::length[m], int>::zero().numerical_value_ref_in(m) == 0);
-static_assert(quantity<isq::length[m], int>::one().numerical_value_ref_in(m) == 1);
-static_assert(quantity<isq::length[m], int>::min().numerical_value_ref_in(m) == std::numeric_limits<int>::lowest());
-static_assert(quantity<isq::length[m], int>::max().numerical_value_ref_in(m) == std::numeric_limits<int>::max());
-static_assert(quantity<isq::length[m], double>::zero().numerical_value_ref_in(m) == 0.0);
-static_assert(quantity<isq::length[m], double>::one().numerical_value_ref_in(m) == 1.0);
-static_assert(quantity<isq::length[m], double>::min().numerical_value_ref_in(m) ==
-              std::numeric_limits<double>::lowest());
-static_assert(quantity<isq::length[m], double>::max().numerical_value_ref_in(m) == std::numeric_limits<double>::max());
+static_assert(quantity<isq::length[m], int>::zero().numerical_value_ == 0);
+static_assert(quantity<isq::length[m], int>::one().numerical_value_ == 1);
+static_assert(quantity<isq::length[m], int>::min().numerical_value_ == std::numeric_limits<int>::lowest());
+static_assert(quantity<isq::length[m], int>::max().numerical_value_ == std::numeric_limits<int>::max());
+static_assert(quantity<isq::length[m], double>::zero().numerical_value_ == 0.0);
+static_assert(quantity<isq::length[m], double>::one().numerical_value_ == 1.0);
+static_assert(quantity<isq::length[m], double>::min().numerical_value_ == std::numeric_limits<double>::lowest());
+static_assert(quantity<isq::length[m], double>::max().numerical_value_ == std::numeric_limits<double>::max());
 
 
 //////////////////////////////
@@ -191,10 +190,10 @@ static_assert(std::convertible_to<quantity<isq::length[m], int>, quantity<isq::l
 // obtaining a number
 ///////////////////////
 
-static_assert(quantity<isq::length[m], int>(123 * m).numerical_value_ref_in(m) == 123);
-static_assert(quantity<isq::length[m], int>(2 * km).numerical_value_ref_in(m) == 2000);
-static_assert(quantity<isq::length[km], int>(2 * km).numerical_value_ref_in(km) == 2);
-static_assert(quantity<isq::length[km]>(1500 * m).numerical_value_ref_in(km) == 1.5);
+static_assert(quantity<isq::length[m], int>(123 * m).numerical_value_ == 123);
+static_assert(quantity<isq::length[m], int>(2 * km).numerical_value_ == 2000);
+static_assert(quantity<isq::length[km], int>(2 * km).numerical_value_ == 2);
+static_assert(quantity<isq::length[km]>(1500 * m).numerical_value_ == 1.5);
 
 
 ///////////////////////////////////
@@ -205,11 +204,11 @@ static_assert(is_of_type<(2. * km).in(m), quantity<si::metre>>);
 static_assert(is_of_type<isq::length(2. * km).in(m), quantity<isq::length[m]>>);
 static_assert(is_of_type<isq::height(2. * km).in(m), quantity<isq::height[m]>>);
 
-static_assert(quantity<isq::length[km]>(2. * km).in(km).numerical_value_ref_in(km) == 2.);
-static_assert(quantity<isq::length[km]>(2. * km).in(m).numerical_value_ref_in(m) == 2000.);
-static_assert(quantity<isq::length[m]>(2000. * m).in(km).numerical_value_ref_in(km) == 2.);
-static_assert(quantity<isq::length[km], int>(2 * km).in(km).numerical_value_ref_in(km) == 2);
-static_assert(quantity<isq::length[km], int>(2 * km).in(m).numerical_value_ref_in(m) == 2000);
+static_assert(quantity<isq::length[km]>(2. * km).in(km).numerical_value_ == 2.);
+static_assert(quantity<isq::length[km]>(2. * km).in(m).numerical_value_ == 2000.);
+static_assert(quantity<isq::length[m]>(2000. * m).in(km).numerical_value_ == 2.);
+static_assert(quantity<isq::length[km], int>(2 * km).in(km).numerical_value_ == 2);
+static_assert(quantity<isq::length[km], int>(2 * km).in(m).numerical_value_ == 2000);
 
 #if MP_UNITS_COMP_GCC != 10 || MP_UNITS_COMP_GCC_MINOR > 2
 template<template<auto, typename> typename Q>
@@ -309,28 +308,28 @@ static_assert([] {
   auto l1(1 * m), l2(2 * m);
   return l2 = l1;
 }()
-                .numerical_value_ref_in(m) == 1);
+                .numerical_value_ == 1);
 static_assert([] {
   const auto l1(1 * m);
   auto l2(2 * m);
   return l2 = l1;
 }()
-                .numerical_value_ref_in(m) == 1);
+                .numerical_value_ == 1);
 static_assert([]() {
   auto l1(1 * m), l2(2 * m);
   return l2 = std::move(l1);
 }()
-                .numerical_value_ref_in(m) == 1);
+                .numerical_value_ == 1);
 
 
 ////////////////////
 // unary operators
 ////////////////////
 
-static_assert((+123 * m).numerical_value_ref_in(m) == 123);
-static_assert((-123 * m).numerical_value_ref_in(m) == -123);
-static_assert((+(-123 * m)).numerical_value_ref_in(m) == -123);
-static_assert((-(-123 * m)).numerical_value_ref_in(m) == 123);
+static_assert((+123 * m).numerical_value_ == 123);
+static_assert((-123 * m).numerical_value_ == -123);
+static_assert((+(-123 * m)).numerical_value_ == -123);
+static_assert((-(-123 * m)).numerical_value_ == 123);
 
 static_assert([](auto v) {
   auto vv = v++;
@@ -349,7 +348,7 @@ static_assert([](auto v) {
   return std::pair(v, vv);
 }(123 * m) == std::pair(122 * m, 122 * m));
 
-static_assert(is_same_v<decltype((+(short{0} * m)).numerical_value_ref_in(m)), int&&>);
+static_assert(is_same_v<decltype((+(short{0} * m)).numerical_value_), int>);
 
 
 ////////////////////////
@@ -357,30 +356,31 @@ static_assert(is_same_v<decltype((+(short{0} * m)).numerical_value_ref_in(m)), i
 ////////////////////////
 
 // same type
-static_assert((1 * m += 1 * m).numerical_value_ref_in(m) == 2);
-static_assert((2 * m -= 1 * m).numerical_value_ref_in(m) == 1);
-static_assert((1 * m *= 2).numerical_value_ref_in(m) == 2);
-static_assert((2 * m /= 2).numerical_value_ref_in(m) == 1);
-static_assert((1 * m *= 2 * one).numerical_value_ref_in(m) == 2);
-static_assert((2 * m /= 2 * one).numerical_value_ref_in(m) == 1);
-static_assert((7 * m %= 2 * m).numerical_value_ref_in(m) == 1);
+static_assert((1 * m += 1 * m).numerical_value_ == 2);
+static_assert((2 * m -= 1 * m).numerical_value_ == 1);
+static_assert((1 * m *= 2).numerical_value_ == 2);
+static_assert((2 * m /= 2).numerical_value_ == 1);
+static_assert((1 * m *= 2 * one).numerical_value_ == 2);
+static_assert((2 * m /= 2 * one).numerical_value_ == 1);
+static_assert((7 * m %= 2 * m).numerical_value_ == 1);
 
 // different types
-static_assert((2.5 * m += 3 * m).numerical_value_ref_in(m) == 5.5);
-static_assert((123 * m += 1 * km).numerical_value_ref_in(m) == 1123);
-static_assert((5.5 * m -= 3 * m).numerical_value_ref_in(m) == 2.5);
-static_assert((1123 * m -= 1 * km).numerical_value_ref_in(m) == 123);
-static_assert((2.5 * m *= 3).numerical_value_ref_in(m) == 7.5);
-static_assert((7.5 * m /= 3).numerical_value_ref_in(m) == 2.5);
-static_assert((2.5 * m *= 3 * one).numerical_value_ref_in(m) == 7.5);
-static_assert((7.5 * m /= 3 * one).numerical_value_ref_in(m) == 2.5);
-static_assert((3500 * m %= 1 * km).numerical_value_ref_in(m) == 500);
+static_assert((2.5 * m += 3 * m).numerical_value_ == 5.5);
+static_assert((123 * m += 1 * km).numerical_value_ == 1123);
+static_assert((5.5 * m -= 3 * m).numerical_value_ == 2.5);
+static_assert((1123 * m -= 1 * km).numerical_value_ == 123);
+static_assert((2.5 * m *= 3).numerical_value_ == 7.5);
+static_assert((7.5 * m /= 3).numerical_value_ == 2.5);
+static_assert((2.5 * m *= 3 * one).numerical_value_ == 7.5);
+static_assert((7.5 * m /= 3 * one).numerical_value_ == 2.5);
+static_assert((3500 * m %= 1 * km).numerical_value_ == 500);
 
-// static_assert((std::uint8_t(255) * m %= 256 * m).numerical_value_ref_in(m) != [] { std::uint8_t ui(255); return ui %=
-// 256;
+// static_assert((std::uint8_t(255) * m %= 256 * m).numerical_value_ == [] {
+//   std::uint8_t ui(255);
+//   return ui %= 256;
 // }());  // UB
 // TODO: Fix
-static_assert((std::uint8_t(255) * m %= 257 * m).numerical_value_ref_in(m) != [] {
+static_assert((std::uint8_t(255) * m %= 257 * m).numerical_value_ != [] {
   std::uint8_t ui(255);
   return ui %= 257;
 }());
@@ -390,10 +390,10 @@ static_assert((std::uint8_t(255) * m %= 257 * m).numerical_value_ref_in(m) != []
 #ifndef MP_UNITS_COMP_MSVC
 // next two lines trigger conversions warnings
 // (warning disabled in CMake for this file)
-static_assert((22 * m *= 33.33).numerical_value_ref_in(m) == 733);
-static_assert((22 * m /= 3.33).numerical_value_ref_in(m) == 6);
-static_assert((22 * m *= 33.33 * one).numerical_value_ref_in(m) == 733);
-static_assert((22 * m /= 3.33 * one).numerical_value_ref_in(m) == 6);
+static_assert((22 * m *= 33.33).numerical_value_ == 733);
+static_assert((22 * m /= 3.33).numerical_value_ == 6);
+static_assert((22 * m *= 33.33 * one).numerical_value_ == 733);
+static_assert((22 * m /= 3.33 * one).numerical_value_ == 6);
 #endif
 
 template<template<auto, typename> typename Q>
@@ -518,15 +518,14 @@ static_assert(is_of_type<1 * km % (300 * m), quantity<si::metre, int>>);
 static_assert(is_of_type<4 * one % (2 * one), quantity<one, int>>);
 
 // check for integral types promotion
-static_assert(is_same_v<decltype((std::uint8_t(0) * m + std::uint8_t(0) * m).numerical_value_ref_in(m)), int&&>);
-static_assert(is_same_v<decltype((std::uint8_t(0) * m - std::uint8_t(0) * m).numerical_value_ref_in(m)), int&&>);
-static_assert((std::uint8_t(128) * m + std::uint8_t(128) * m).numerical_value_ref_in(m) ==
+static_assert(is_same_v<decltype(std::uint8_t(0) * m + std::uint8_t(0) * m)::rep, int>);
+static_assert(is_same_v<decltype(std::uint8_t(0) * m - std::uint8_t(0) * m)::rep, int>);
+static_assert((std::uint8_t(128) * m + std::uint8_t(128) * m).numerical_value_ ==
               std::uint8_t(128) + std::uint8_t(128));
-static_assert((std::uint8_t(0) * m - std::uint8_t(1) * m).numerical_value_ref_in(m) ==
-              std::uint8_t(0) - std::uint8_t(1));
+static_assert((std::uint8_t(0) * m - std::uint8_t(1) * m).numerical_value_ == std::uint8_t(0) - std::uint8_t(1));
 
-static_assert(is_same_v<decltype(((std::uint8_t(0) * m) % (std::uint8_t(0) * m)).numerical_value_ref_in(m)),
-                        decltype(std::uint8_t(0) % std::uint8_t(0))&&>);
+static_assert(
+  is_same_v<decltype((std::uint8_t(0) * m) % (std::uint8_t(0) * m))::rep, decltype(std::uint8_t(0) % std::uint8_t(0))>);
 
 // different representation types
 static_assert(is_of_type<1. * m + 1 * m, quantity<si::metre, double>>);
@@ -599,67 +598,67 @@ static_assert(is_of_type<1 * m / (1 * s), quantity<derived_unit<struct si::metre
 static_assert(is_of_type<1 * m / (1 * min), quantity<derived_unit<struct si::metre, per<struct si::minute>>{}, int>>);
 static_assert(is_of_type<1 * min / (1 * m), quantity<derived_unit<struct si::minute, per<struct si::metre>>{}, int>>);
 
-static_assert((1 * m + 1 * m).numerical_value_ref_in(m) == 2);
-static_assert((1 * m + 1 * km).numerical_value_ref_in(m) == 1001);
-static_assert((1 * km + 1 * m).numerical_value_ref_in(m) == 1001);
-static_assert((2 * m - 1 * m).numerical_value_ref_in(m) == 1);
-static_assert((1 * km - 1 * m).numerical_value_ref_in(m) == 999);
-static_assert((2 * m * 2).numerical_value_ref_in(m) == 4);
-static_assert((2 * m * (2 * one)).numerical_value_ref_in(m) == 4);
-static_assert((2 * m * (2 * percent)).numerical_value_ref_in(m * percent) == 4);
-static_assert((3 * 3 * m).numerical_value_ref_in(m) == 9);
-static_assert(((3 * one) * (3 * m)).numerical_value_ref_in(m) == 9);
-static_assert(((3 * percent) * (3 * m)).numerical_value_ref_in(m * percent) == 9);
-static_assert((4 * m / 2).numerical_value_ref_in(m) == 2);
-static_assert((4 * m / (2 * one)).numerical_value_ref_in(m) == 2);
-static_assert((4 * m / (2 * percent)).numerical_value_ref_in(m / percent) == 2);
-static_assert((4 * km / (2 * m)).numerical_value_ref_in(km / m) == 2);
-static_assert((4000 * m / (2 * m)).numerical_value_ref_in(one) == 2000);
+static_assert((1 * m + 1 * m).numerical_value_ == 2);
+static_assert((1 * m + 1 * km).numerical_value_ == 1001);
+static_assert((1 * km + 1 * m).numerical_value_ == 1001);
+static_assert((2 * m - 1 * m).numerical_value_ == 1);
+static_assert((1 * km - 1 * m).numerical_value_ == 999);
+static_assert((2 * m * 2).numerical_value_ == 4);
+static_assert((2 * m * (2 * one)).numerical_value_ == 4);
+static_assert((2 * m * (2 * percent)).numerical_value_ == 4);
+static_assert((3 * 3 * m).numerical_value_ == 9);
+static_assert(((3 * one) * (3 * m)).numerical_value_ == 9);
+static_assert(((3 * percent) * (3 * m)).numerical_value_ == 9);
+static_assert((4 * m / 2).numerical_value_ == 2);
+static_assert((4 * m / (2 * one)).numerical_value_ == 2);
+static_assert((4 * m / (2 * percent)).numerical_value_ == 2);
+static_assert((4 * km / (2 * m)).numerical_value_ == 2);
+static_assert((4000 * m / (2 * m)).numerical_value_ == 2000);
 
-static_assert((1.5 * m + 1 * m).numerical_value_ref_in(m) == 2.5);
-static_assert((1.5 * m + 1 * km).numerical_value_ref_in(m) == 1001.5);
-static_assert((1.5 * km + 1 * m).numerical_value_ref_in(m) == 1501);
-static_assert((2.5 * m - 1 * m).numerical_value_ref_in(m) == 1.5);
-static_assert((1.5 * km - 1 * m).numerical_value_ref_in(m) == 1499);
-static_assert((2.5 * m * 2).numerical_value_ref_in(m) == 5);
-static_assert((2.5 * m * (2 * one)).numerical_value_ref_in(m) == 5);
-static_assert((2.5 * m * (2 * percent)).numerical_value_ref_in(m * percent) == 5);
-static_assert((2.5L * (2 * m)).numerical_value_ref_in(m) == 5);
-static_assert((2.5L * one * (2 * m)).numerical_value_ref_in(m) == 5);
-static_assert((2.5L * percent * (2 * m)).numerical_value_ref_in(m * percent) == 5);
-static_assert((5. * m / 2).numerical_value_ref_in(m) == 2.5);
-static_assert((5. * m / (2 * one)).numerical_value_ref_in(m) == 2.5);
-static_assert((5. * m / (2 * percent)).numerical_value_ref_in(m / percent) == 2.5);
-static_assert((5. * km / (2 * m)).numerical_value_ref_in(km / m) == 2.5);
-static_assert((5000. * m / (2 * m)).numerical_value_ref_in(one) == 2500);
+static_assert((1.5 * m + 1 * m).numerical_value_ == 2.5);
+static_assert((1.5 * m + 1 * km).numerical_value_ == 1001.5);
+static_assert((1.5 * km + 1 * m).numerical_value_ == 1501);
+static_assert((2.5 * m - 1 * m).numerical_value_ == 1.5);
+static_assert((1.5 * km - 1 * m).numerical_value_ == 1499);
+static_assert((2.5 * m * 2).numerical_value_ == 5);
+static_assert((2.5 * m * (2 * one)).numerical_value_ == 5);
+static_assert((2.5 * m * (2 * percent)).numerical_value_ == 5);
+static_assert((2.5L * (2 * m)).numerical_value_ == 5);
+static_assert((2.5L * one * (2 * m)).numerical_value_ == 5);
+static_assert((2.5L * percent * (2 * m)).numerical_value_ == 5);
+static_assert((5. * m / 2).numerical_value_ == 2.5);
+static_assert((5. * m / (2 * one)).numerical_value_ == 2.5);
+static_assert((5. * m / (2 * percent)).numerical_value_ == 2.5);
+static_assert((5. * km / (2 * m)).numerical_value_ == 2.5);
+static_assert((5000. * m / (2 * m)).numerical_value_ == 2500);
 
-static_assert((1 * m + 1.5 * m).numerical_value_ref_in(m) == 2.5);
-static_assert((1 * m + 1.5 * km).numerical_value_ref_in(m) == 1501);
-static_assert((1 * km + 1.5 * m).numerical_value_ref_in(m) == 1001.5);
-static_assert((2 * m - 1.5 * m).numerical_value_ref_in(m) == 0.5);
-static_assert((1 * km - 1.5 * m).numerical_value_ref_in(m) == 998.5);
-static_assert((2 * m * 2.5L).numerical_value_ref_in(m) == 5);
-static_assert((2 * m * (2.5L * one)).numerical_value_ref_in(m) == 5);
-static_assert((2 * m * (2.5L * percent)).numerical_value_ref_in(m * percent) == 5);
-static_assert((2 * 2.5 * m).numerical_value_ref_in(m) == 5);
-static_assert((2 * one * (2.5 * m)).numerical_value_ref_in(m) == 5);
-static_assert((2 * percent * (2.5 * m)).numerical_value_ref_in(m * percent) == 5);
-static_assert((5 * m / 2.5L).numerical_value_ref_in(m) == 2);
-static_assert((5 * m / (2.5L * one)).numerical_value_ref_in(m) == 2);
-static_assert((5 * m / (2.5L * percent)).numerical_value_ref_in(m / percent) == 2);
-static_assert((5 * km / (2.5 * m)).numerical_value_ref_in(km / m) == 2);
-static_assert((5000 * m / (2.5 * m)).numerical_value_ref_in(one) == 2000);
+static_assert((1 * m + 1.5 * m).numerical_value_ == 2.5);
+static_assert((1 * m + 1.5 * km).numerical_value_ == 1501);
+static_assert((1 * km + 1.5 * m).numerical_value_ == 1001.5);
+static_assert((2 * m - 1.5 * m).numerical_value_ == 0.5);
+static_assert((1 * km - 1.5 * m).numerical_value_ == 998.5);
+static_assert((2 * m * 2.5L).numerical_value_ == 5);
+static_assert((2 * m * (2.5L * one)).numerical_value_ == 5);
+static_assert((2 * m * (2.5L * percent)).numerical_value_ == 5);
+static_assert((2 * 2.5 * m).numerical_value_ == 5);
+static_assert((2 * one * (2.5 * m)).numerical_value_ == 5);
+static_assert((2 * percent * (2.5 * m)).numerical_value_ == 5);
+static_assert((5 * m / 2.5L).numerical_value_ == 2);
+static_assert((5 * m / (2.5L * one)).numerical_value_ == 2);
+static_assert((5 * m / (2.5L * percent)).numerical_value_ == 2);
+static_assert((5 * km / (2.5 * m)).numerical_value_ == 2);
+static_assert((5000 * m / (2.5 * m)).numerical_value_ == 2000);
 
-static_assert((7 * m % (2 * m)).numerical_value_ref_in(m) == 1);
-static_assert((7 * km % (2000 * m)).numerical_value_ref_in(m) == 1000);
-static_assert((1300 * m % (1 * km)).numerical_value_ref_in(m) == 300);
-static_assert((7 * one % (2 * one)).numerical_value_ref_in(one) == 1);
+static_assert((7 * m % (2 * m)).numerical_value_ == 1);
+static_assert((7 * km % (2000 * m)).numerical_value_ == 1000);
+static_assert((1300 * m % (1 * km)).numerical_value_ == 300);
+static_assert((7 * one % (2 * one)).numerical_value_ == 1);
 
 static_assert((10 * m2 * (10 * m2)) / (50 * m2) == 2 * m2);
 
-static_assert((10 * km / (5 * m)).numerical_value_ref_in(km / m) == 2);
+static_assert((10 * km / (5 * m)).numerical_value_ == 2);
 static_assert((10 * km / (5 * m)).numerical_value_in(one) == 2000);
-static_assert((10 * s * (2 * kHz)).numerical_value_ref_in(s * kHz) == 20);
+static_assert((10 * s * (2 * kHz)).numerical_value_ == 20);
 
 // commutativity and associativity
 static_assert(10 * isq::length[si::metre] / (2 * isq::time[s]) + 5 * isq::speed[m / s] == 10 * isq::speed[m / s]);
@@ -743,16 +742,13 @@ static_assert(is_same_v<decltype(0.0 * one - 0 * one), decltype(0.0 * one)>);
 static_assert(1 * one - 30 * percent == (100 - 30) * percent);
 static_assert(1 * one + 30 * percent == (100 + 30) * percent);
 
-static_assert(is_same_v<decltype((std::uint8_t(0) * one + std::uint8_t(0) * one).numerical_value_ref_in(one)), int&&>);
-static_assert(is_same_v<decltype((std::uint8_t(0) * one - std::uint8_t(0) * one).numerical_value_ref_in(one)), int&&>);
-static_assert((std::uint8_t(128) * one + std::uint8_t(128) * one).numerical_value_ref_in(one) ==
-
+static_assert(is_same_v<decltype(std::uint8_t(0) * one + std::uint8_t(0) * one)::rep, int>);
+static_assert(is_same_v<decltype(std::uint8_t(0) * one - std::uint8_t(0) * one)::rep, int>);
+static_assert((std::uint8_t(128) * one + std::uint8_t(128) * one).numerical_value_ ==
               std::uint8_t(128) + std::uint8_t(128));
-static_assert((std::uint8_t(0) * one - std::uint8_t(1) * one).numerical_value_ref_in(one) ==
-              std::uint8_t(0) - std::uint8_t(1));
-
-static_assert(is_same_v<decltype((std::uint8_t(0) * one % (std::uint8_t(0) * one)).numerical_value_ref_in(one)),
-                        decltype(std::uint8_t(0) % std::uint8_t(0))&&>);
+static_assert((std::uint8_t(0) * one - std::uint8_t(1) * one).numerical_value_ == std::uint8_t(0) - std::uint8_t(1));
+static_assert(is_same_v<decltype(std::uint8_t(0) * one % (std::uint8_t(0) * one))::rep,
+                        decltype(std::uint8_t(0) % std::uint8_t(0))>);
 
 static_assert(2 * one * (1 * m) == 2 * m);
 static_assert(2 * one / (1 * m) == 2 / (1 * m));
@@ -895,14 +891,14 @@ static_assert((50. * percent).numerical_value_in(one) == 0.5);
 // value_cast
 //////////////////
 
-static_assert(value_cast<m>(2 * km).numerical_value_ref_in(m) == 2000);
-static_assert(value_cast<km>(2000 * m).numerical_value_ref_in(km) == 2);
-static_assert(value_cast<int>(1.23 * m).numerical_value_ref_in(m) == 1);
-static_assert(value_cast<km / h>(2000.0 * m / (3600.0 * s)).numerical_value_ref_in(km / h) == 2);
+static_assert(value_cast<m>(2 * km).numerical_value_ == 2000);
+static_assert(value_cast<km>(2000 * m).numerical_value_ == 2);
+static_assert(value_cast<int>(1.23 * m).numerical_value_ == 1);
+static_assert(value_cast<km / h>(2000.0 * m / (3600.0 * s)).numerical_value_ == 2);
 
-static_assert((2 * km).force_in(m).numerical_value_ref_in(m) == 2000);
-static_assert((2000 * m).force_in(km).numerical_value_ref_in(km) == 2);
-static_assert((2000.0 * m / (3600.0 * s)).force_in(km / h).numerical_value_ref_in(km / h) == 2);
+static_assert((2 * km).force_in(m).numerical_value_ == 2000);
+static_assert((2000 * m).force_in(km).numerical_value_ == 2);
+static_assert((2000.0 * m / (3600.0 * s)).force_in(km / h).numerical_value_ == 2);
 
 //////////////////
 // quantity_cast

--- a/test/unit_test/static/quantity_test.cpp
+++ b/test/unit_test/static/quantity_test.cpp
@@ -900,6 +900,10 @@ static_assert(value_cast<km>(2000 * m).numerical_value_ref_in(km) == 2);
 static_assert(value_cast<int>(1.23 * m).numerical_value_ref_in(m) == 1);
 static_assert(value_cast<km / h>(2000.0 * m / (3600.0 * s)).numerical_value_ref_in(km / h) == 2);
 
+static_assert((2 * km).force_in(m).numerical_value_ref_in(m) == 2000);
+static_assert((2000 * m).force_in(km).numerical_value_ref_in(km) == 2);
+static_assert((2000.0 * m / (3600.0 * s)).force_in(km / h).numerical_value_ref_in(km / h) == 2);
+
 //////////////////
 // quantity_cast
 //////////////////

--- a/test/unit_test/static/quantity_test.cpp
+++ b/test/unit_test/static/quantity_test.cpp
@@ -112,14 +112,15 @@ static_assert(is_same_v<quantity<isq::length[m], int>::rep, int>);
 // static member functions
 ////////////////////////////
 
-static_assert(quantity<isq::length[m], int>::zero().numerical_value() == 0);
-static_assert(quantity<isq::length[m], int>::one().numerical_value() == 1);
-static_assert(quantity<isq::length[m], int>::min().numerical_value() == std::numeric_limits<int>::lowest());
-static_assert(quantity<isq::length[m], int>::max().numerical_value() == std::numeric_limits<int>::max());
-static_assert(quantity<isq::length[m], double>::zero().numerical_value() == 0.0);
-static_assert(quantity<isq::length[m], double>::one().numerical_value() == 1.0);
-static_assert(quantity<isq::length[m], double>::min().numerical_value() == std::numeric_limits<double>::lowest());
-static_assert(quantity<isq::length[m], double>::max().numerical_value() == std::numeric_limits<double>::max());
+static_assert(quantity<isq::length[m], int>::zero().numerical_value_ref_in(m) == 0);
+static_assert(quantity<isq::length[m], int>::one().numerical_value_ref_in(m) == 1);
+static_assert(quantity<isq::length[m], int>::min().numerical_value_ref_in(m) == std::numeric_limits<int>::lowest());
+static_assert(quantity<isq::length[m], int>::max().numerical_value_ref_in(m) == std::numeric_limits<int>::max());
+static_assert(quantity<isq::length[m], double>::zero().numerical_value_ref_in(m) == 0.0);
+static_assert(quantity<isq::length[m], double>::one().numerical_value_ref_in(m) == 1.0);
+static_assert(quantity<isq::length[m], double>::min().numerical_value_ref_in(m) ==
+              std::numeric_limits<double>::lowest());
+static_assert(quantity<isq::length[m], double>::max().numerical_value_ref_in(m) == std::numeric_limits<double>::max());
 
 
 //////////////////////////////
@@ -190,10 +191,10 @@ static_assert(std::convertible_to<quantity<isq::length[m], int>, quantity<isq::l
 // obtaining a number
 ///////////////////////
 
-static_assert(quantity<isq::length[m], int>(123 * m).numerical_value() == 123);
-static_assert(quantity<isq::length[m], int>(2 * km).numerical_value() == 2000);
-static_assert(quantity<isq::length[km], int>(2 * km).numerical_value() == 2);
-static_assert(quantity<isq::length[km]>(1500 * m).numerical_value() == 1.5);
+static_assert(quantity<isq::length[m], int>(123 * m).numerical_value_ref_in(m) == 123);
+static_assert(quantity<isq::length[m], int>(2 * km).numerical_value_ref_in(m) == 2000);
+static_assert(quantity<isq::length[km], int>(2 * km).numerical_value_ref_in(km) == 2);
+static_assert(quantity<isq::length[km]>(1500 * m).numerical_value_ref_in(km) == 1.5);
 
 
 ///////////////////////////////////
@@ -204,11 +205,11 @@ static_assert(is_of_type<(2. * km).in(m), quantity<si::metre>>);
 static_assert(is_of_type<isq::length(2. * km).in(m), quantity<isq::length[m]>>);
 static_assert(is_of_type<isq::height(2. * km).in(m), quantity<isq::height[m]>>);
 
-static_assert(quantity<isq::length[km]>(2. * km).in(km).numerical_value() == 2.);
-static_assert(quantity<isq::length[km]>(2. * km).in(m).numerical_value() == 2000.);
-static_assert(quantity<isq::length[m]>(2000. * m).in(km).numerical_value() == 2.);
-static_assert(quantity<isq::length[km], int>(2 * km).in(km).numerical_value() == 2);
-static_assert(quantity<isq::length[km], int>(2 * km).in(m).numerical_value() == 2000);
+static_assert(quantity<isq::length[km]>(2. * km).in(km).numerical_value_ref_in(km) == 2.);
+static_assert(quantity<isq::length[km]>(2. * km).in(m).numerical_value_ref_in(m) == 2000.);
+static_assert(quantity<isq::length[m]>(2000. * m).in(km).numerical_value_ref_in(km) == 2.);
+static_assert(quantity<isq::length[km], int>(2 * km).in(km).numerical_value_ref_in(km) == 2);
+static_assert(quantity<isq::length[km], int>(2 * km).in(m).numerical_value_ref_in(m) == 2000);
 
 #if MP_UNITS_COMP_GCC != 10 || MP_UNITS_COMP_GCC_MINOR > 2
 template<template<auto, typename> typename Q>
@@ -308,28 +309,28 @@ static_assert([] {
   auto l1(1 * m), l2(2 * m);
   return l2 = l1;
 }()
-                .numerical_value() == 1);
+                .numerical_value_ref_in(m) == 1);
 static_assert([] {
   const auto l1(1 * m);
   auto l2(2 * m);
   return l2 = l1;
 }()
-                .numerical_value() == 1);
+                .numerical_value_ref_in(m) == 1);
 static_assert([]() {
   auto l1(1 * m), l2(2 * m);
   return l2 = std::move(l1);
 }()
-                .numerical_value() == 1);
+                .numerical_value_ref_in(m) == 1);
 
 
 ////////////////////
 // unary operators
 ////////////////////
 
-static_assert((+123 * m).numerical_value() == 123);
-static_assert((-123 * m).numerical_value() == -123);
-static_assert((+(-123 * m)).numerical_value() == -123);
-static_assert((-(-123 * m)).numerical_value() == 123);
+static_assert((+123 * m).numerical_value_ref_in(m) == 123);
+static_assert((-123 * m).numerical_value_ref_in(m) == -123);
+static_assert((+(-123 * m)).numerical_value_ref_in(m) == -123);
+static_assert((-(-123 * m)).numerical_value_ref_in(m) == 123);
 
 static_assert([](auto v) {
   auto vv = v++;
@@ -348,7 +349,7 @@ static_assert([](auto v) {
   return std::pair(v, vv);
 }(123 * m) == std::pair(122 * m, 122 * m));
 
-static_assert(is_same_v<decltype((+(short{0} * m)).numerical_value()), int&&>);
+static_assert(is_same_v<decltype((+(short{0} * m)).numerical_value_ref_in(m)), int&&>);
 
 
 ////////////////////////
@@ -356,29 +357,30 @@ static_assert(is_same_v<decltype((+(short{0} * m)).numerical_value()), int&&>);
 ////////////////////////
 
 // same type
-static_assert((1 * m += 1 * m).numerical_value() == 2);
-static_assert((2 * m -= 1 * m).numerical_value() == 1);
-static_assert((1 * m *= 2).numerical_value() == 2);
-static_assert((2 * m /= 2).numerical_value() == 1);
-static_assert((1 * m *= 2 * one).numerical_value() == 2);
-static_assert((2 * m /= 2 * one).numerical_value() == 1);
-static_assert((7 * m %= 2 * m).numerical_value() == 1);
+static_assert((1 * m += 1 * m).numerical_value_ref_in(m) == 2);
+static_assert((2 * m -= 1 * m).numerical_value_ref_in(m) == 1);
+static_assert((1 * m *= 2).numerical_value_ref_in(m) == 2);
+static_assert((2 * m /= 2).numerical_value_ref_in(m) == 1);
+static_assert((1 * m *= 2 * one).numerical_value_ref_in(m) == 2);
+static_assert((2 * m /= 2 * one).numerical_value_ref_in(m) == 1);
+static_assert((7 * m %= 2 * m).numerical_value_ref_in(m) == 1);
 
 // different types
-static_assert((2.5 * m += 3 * m).numerical_value() == 5.5);
-static_assert((123 * m += 1 * km).numerical_value() == 1123);
-static_assert((5.5 * m -= 3 * m).numerical_value() == 2.5);
-static_assert((1123 * m -= 1 * km).numerical_value() == 123);
-static_assert((2.5 * m *= 3).numerical_value() == 7.5);
-static_assert((7.5 * m /= 3).numerical_value() == 2.5);
-static_assert((2.5 * m *= 3 * one).numerical_value() == 7.5);
-static_assert((7.5 * m /= 3 * one).numerical_value() == 2.5);
-static_assert((3500 * m %= 1 * km).numerical_value() == 500);
+static_assert((2.5 * m += 3 * m).numerical_value_ref_in(m) == 5.5);
+static_assert((123 * m += 1 * km).numerical_value_ref_in(m) == 1123);
+static_assert((5.5 * m -= 3 * m).numerical_value_ref_in(m) == 2.5);
+static_assert((1123 * m -= 1 * km).numerical_value_ref_in(m) == 123);
+static_assert((2.5 * m *= 3).numerical_value_ref_in(m) == 7.5);
+static_assert((7.5 * m /= 3).numerical_value_ref_in(m) == 2.5);
+static_assert((2.5 * m *= 3 * one).numerical_value_ref_in(m) == 7.5);
+static_assert((7.5 * m /= 3 * one).numerical_value_ref_in(m) == 2.5);
+static_assert((3500 * m %= 1 * km).numerical_value_ref_in(m) == 500);
 
-// static_assert((std::uint8_t(255) * m %= 256 * m).numerical_value() != [] { std::uint8_t ui(255); return ui %= 256;
+// static_assert((std::uint8_t(255) * m %= 256 * m).numerical_value_ref_in(m) != [] { std::uint8_t ui(255); return ui %=
+// 256;
 // }());  // UB
 // TODO: Fix
-static_assert((std::uint8_t(255) * m %= 257 * m).numerical_value() != [] {
+static_assert((std::uint8_t(255) * m %= 257 * m).numerical_value_ref_in(m) != [] {
   std::uint8_t ui(255);
   return ui %= 257;
 }());
@@ -388,10 +390,10 @@ static_assert((std::uint8_t(255) * m %= 257 * m).numerical_value() != [] {
 #ifndef MP_UNITS_COMP_MSVC
 // next two lines trigger conversions warnings
 // (warning disabled in CMake for this file)
-static_assert((22 * m *= 33.33).numerical_value() == 733);
-static_assert((22 * m /= 3.33).numerical_value() == 6);
-static_assert((22 * m *= 33.33 * one).numerical_value() == 733);
-static_assert((22 * m /= 3.33 * one).numerical_value() == 6);
+static_assert((22 * m *= 33.33).numerical_value_ref_in(m) == 733);
+static_assert((22 * m /= 3.33).numerical_value_ref_in(m) == 6);
+static_assert((22 * m *= 33.33 * one).numerical_value_ref_in(m) == 733);
+static_assert((22 * m /= 3.33 * one).numerical_value_ref_in(m) == 6);
 #endif
 
 template<template<auto, typename> typename Q>
@@ -516,13 +518,14 @@ static_assert(is_of_type<1 * km % (300 * m), quantity<si::metre, int>>);
 static_assert(is_of_type<4 * one % (2 * one), quantity<one, int>>);
 
 // check for integral types promotion
-static_assert(is_same_v<decltype((std::uint8_t(0) * m + std::uint8_t(0) * m).numerical_value()), int&&>);
-static_assert(is_same_v<decltype((std::uint8_t(0) * m - std::uint8_t(0) * m).numerical_value()), int&&>);
-static_assert((std::uint8_t(128) * m + std::uint8_t(128) * m).numerical_value() ==
+static_assert(is_same_v<decltype((std::uint8_t(0) * m + std::uint8_t(0) * m).numerical_value_ref_in(m)), int&&>);
+static_assert(is_same_v<decltype((std::uint8_t(0) * m - std::uint8_t(0) * m).numerical_value_ref_in(m)), int&&>);
+static_assert((std::uint8_t(128) * m + std::uint8_t(128) * m).numerical_value_ref_in(m) ==
               std::uint8_t(128) + std::uint8_t(128));
-static_assert((std::uint8_t(0) * m - std::uint8_t(1) * m).numerical_value() == std::uint8_t(0) - std::uint8_t(1));
+static_assert((std::uint8_t(0) * m - std::uint8_t(1) * m).numerical_value_ref_in(m) ==
+              std::uint8_t(0) - std::uint8_t(1));
 
-static_assert(is_same_v<decltype(((std::uint8_t(0) * m) % (std::uint8_t(0) * m)).numerical_value()),
+static_assert(is_same_v<decltype(((std::uint8_t(0) * m) % (std::uint8_t(0) * m)).numerical_value_ref_in(m)),
                         decltype(std::uint8_t(0) % std::uint8_t(0))&&>);
 
 // different representation types
@@ -596,67 +599,67 @@ static_assert(is_of_type<1 * m / (1 * s), quantity<derived_unit<struct si::metre
 static_assert(is_of_type<1 * m / (1 * min), quantity<derived_unit<struct si::metre, per<struct si::minute>>{}, int>>);
 static_assert(is_of_type<1 * min / (1 * m), quantity<derived_unit<struct si::minute, per<struct si::metre>>{}, int>>);
 
-static_assert((1 * m + 1 * m).numerical_value() == 2);
-static_assert((1 * m + 1 * km).numerical_value() == 1001);
-static_assert((1 * km + 1 * m).numerical_value() == 1001);
-static_assert((2 * m - 1 * m).numerical_value() == 1);
-static_assert((1 * km - 1 * m).numerical_value() == 999);
-static_assert((2 * m * 2).numerical_value() == 4);
-static_assert((2 * m * (2 * one)).numerical_value() == 4);
-static_assert((2 * m * (2 * percent)).numerical_value() == 4);
-static_assert((3 * 3 * m).numerical_value() == 9);
-static_assert(((3 * one) * (3 * m)).numerical_value() == 9);
-static_assert(((3 * percent) * (3 * m)).numerical_value() == 9);
-static_assert((4 * m / 2).numerical_value() == 2);
-static_assert((4 * m / (2 * one)).numerical_value() == 2);
-static_assert((4 * m / (2 * percent)).numerical_value() == 2);
-static_assert((4 * km / (2 * m)).numerical_value() == 2);
-static_assert((4000 * m / (2 * m)).numerical_value() == 2000);
+static_assert((1 * m + 1 * m).numerical_value_ref_in(m) == 2);
+static_assert((1 * m + 1 * km).numerical_value_ref_in(m) == 1001);
+static_assert((1 * km + 1 * m).numerical_value_ref_in(m) == 1001);
+static_assert((2 * m - 1 * m).numerical_value_ref_in(m) == 1);
+static_assert((1 * km - 1 * m).numerical_value_ref_in(m) == 999);
+static_assert((2 * m * 2).numerical_value_ref_in(m) == 4);
+static_assert((2 * m * (2 * one)).numerical_value_ref_in(m) == 4);
+static_assert((2 * m * (2 * percent)).numerical_value_ref_in(m * percent) == 4);
+static_assert((3 * 3 * m).numerical_value_ref_in(m) == 9);
+static_assert(((3 * one) * (3 * m)).numerical_value_ref_in(m) == 9);
+static_assert(((3 * percent) * (3 * m)).numerical_value_ref_in(m * percent) == 9);
+static_assert((4 * m / 2).numerical_value_ref_in(m) == 2);
+static_assert((4 * m / (2 * one)).numerical_value_ref_in(m) == 2);
+static_assert((4 * m / (2 * percent)).numerical_value_ref_in(m / percent) == 2);
+static_assert((4 * km / (2 * m)).numerical_value_ref_in(km / m) == 2);
+static_assert((4000 * m / (2 * m)).numerical_value_ref_in(one) == 2000);
 
-static_assert((1.5 * m + 1 * m).numerical_value() == 2.5);
-static_assert((1.5 * m + 1 * km).numerical_value() == 1001.5);
-static_assert((1.5 * km + 1 * m).numerical_value() == 1501);
-static_assert((2.5 * m - 1 * m).numerical_value() == 1.5);
-static_assert((1.5 * km - 1 * m).numerical_value() == 1499);
-static_assert((2.5 * m * 2).numerical_value() == 5);
-static_assert((2.5 * m * (2 * one)).numerical_value() == 5);
-static_assert((2.5 * m * (2 * percent)).numerical_value() == 5);
-static_assert((2.5L * (2 * m)).numerical_value() == 5);
-static_assert((2.5L * one * (2 * m)).numerical_value() == 5);
-static_assert((2.5L * percent * (2 * m)).numerical_value() == 5);
-static_assert((5. * m / 2).numerical_value() == 2.5);
-static_assert((5. * m / (2 * one)).numerical_value() == 2.5);
-static_assert((5. * m / (2 * percent)).numerical_value() == 2.5);
-static_assert((5. * km / (2 * m)).numerical_value() == 2.5);
-static_assert((5000. * m / (2 * m)).numerical_value() == 2500);
+static_assert((1.5 * m + 1 * m).numerical_value_ref_in(m) == 2.5);
+static_assert((1.5 * m + 1 * km).numerical_value_ref_in(m) == 1001.5);
+static_assert((1.5 * km + 1 * m).numerical_value_ref_in(m) == 1501);
+static_assert((2.5 * m - 1 * m).numerical_value_ref_in(m) == 1.5);
+static_assert((1.5 * km - 1 * m).numerical_value_ref_in(m) == 1499);
+static_assert((2.5 * m * 2).numerical_value_ref_in(m) == 5);
+static_assert((2.5 * m * (2 * one)).numerical_value_ref_in(m) == 5);
+static_assert((2.5 * m * (2 * percent)).numerical_value_ref_in(m * percent) == 5);
+static_assert((2.5L * (2 * m)).numerical_value_ref_in(m) == 5);
+static_assert((2.5L * one * (2 * m)).numerical_value_ref_in(m) == 5);
+static_assert((2.5L * percent * (2 * m)).numerical_value_ref_in(m * percent) == 5);
+static_assert((5. * m / 2).numerical_value_ref_in(m) == 2.5);
+static_assert((5. * m / (2 * one)).numerical_value_ref_in(m) == 2.5);
+static_assert((5. * m / (2 * percent)).numerical_value_ref_in(m / percent) == 2.5);
+static_assert((5. * km / (2 * m)).numerical_value_ref_in(km / m) == 2.5);
+static_assert((5000. * m / (2 * m)).numerical_value_ref_in(one) == 2500);
 
-static_assert((1 * m + 1.5 * m).numerical_value() == 2.5);
-static_assert((1 * m + 1.5 * km).numerical_value() == 1501);
-static_assert((1 * km + 1.5 * m).numerical_value() == 1001.5);
-static_assert((2 * m - 1.5 * m).numerical_value() == 0.5);
-static_assert((1 * km - 1.5 * m).numerical_value() == 998.5);
-static_assert((2 * m * 2.5L).numerical_value() == 5);
-static_assert((2 * m * (2.5L * one)).numerical_value() == 5);
-static_assert((2 * m * (2.5L * percent)).numerical_value() == 5);
-static_assert((2 * 2.5 * m).numerical_value() == 5);
-static_assert((2 * one * (2.5 * m)).numerical_value() == 5);
-static_assert((2 * percent * (2.5 * m)).numerical_value() == 5);
-static_assert((5 * m / 2.5L).numerical_value() == 2);
-static_assert((5 * m / (2.5L * one)).numerical_value() == 2);
-static_assert((5 * m / (2.5L * percent)).numerical_value() == 2);
-static_assert((5 * km / (2.5 * m)).numerical_value() == 2);
-static_assert((5000 * m / (2.5 * m)).numerical_value() == 2000);
+static_assert((1 * m + 1.5 * m).numerical_value_ref_in(m) == 2.5);
+static_assert((1 * m + 1.5 * km).numerical_value_ref_in(m) == 1501);
+static_assert((1 * km + 1.5 * m).numerical_value_ref_in(m) == 1001.5);
+static_assert((2 * m - 1.5 * m).numerical_value_ref_in(m) == 0.5);
+static_assert((1 * km - 1.5 * m).numerical_value_ref_in(m) == 998.5);
+static_assert((2 * m * 2.5L).numerical_value_ref_in(m) == 5);
+static_assert((2 * m * (2.5L * one)).numerical_value_ref_in(m) == 5);
+static_assert((2 * m * (2.5L * percent)).numerical_value_ref_in(m * percent) == 5);
+static_assert((2 * 2.5 * m).numerical_value_ref_in(m) == 5);
+static_assert((2 * one * (2.5 * m)).numerical_value_ref_in(m) == 5);
+static_assert((2 * percent * (2.5 * m)).numerical_value_ref_in(m * percent) == 5);
+static_assert((5 * m / 2.5L).numerical_value_ref_in(m) == 2);
+static_assert((5 * m / (2.5L * one)).numerical_value_ref_in(m) == 2);
+static_assert((5 * m / (2.5L * percent)).numerical_value_ref_in(m / percent) == 2);
+static_assert((5 * km / (2.5 * m)).numerical_value_ref_in(km / m) == 2);
+static_assert((5000 * m / (2.5 * m)).numerical_value_ref_in(one) == 2000);
 
-static_assert((7 * m % (2 * m)).numerical_value() == 1);
-static_assert((7 * km % (2000 * m)).numerical_value() == 1000);
-static_assert((1300 * m % (1 * km)).numerical_value() == 300);
-static_assert((7 * one % (2 * one)).numerical_value() == 1);
+static_assert((7 * m % (2 * m)).numerical_value_ref_in(m) == 1);
+static_assert((7 * km % (2000 * m)).numerical_value_ref_in(m) == 1000);
+static_assert((1300 * m % (1 * km)).numerical_value_ref_in(m) == 300);
+static_assert((7 * one % (2 * one)).numerical_value_ref_in(one) == 1);
 
 static_assert((10 * m2 * (10 * m2)) / (50 * m2) == 2 * m2);
 
-static_assert((10 * km / (5 * m)).numerical_value() == 2);
-static_assert((10 * km / (5 * m)).in(one).numerical_value() == 2000);
-static_assert((10 * s * (2 * kHz)).numerical_value() == 20);
+static_assert((10 * km / (5 * m)).numerical_value_ref_in(km / m) == 2);
+static_assert((10 * km / (5 * m)).numerical_value_in(one) == 2000);
+static_assert((10 * s * (2 * kHz)).numerical_value_ref_in(s * kHz) == 20);
 
 // commutativity and associativity
 static_assert(10 * isq::length[si::metre] / (2 * isq::time[s]) + 5 * isq::speed[m / s] == 10 * isq::speed[m / s]);
@@ -740,13 +743,15 @@ static_assert(is_same_v<decltype(0.0 * one - 0 * one), decltype(0.0 * one)>);
 static_assert(1 * one - 30 * percent == (100 - 30) * percent);
 static_assert(1 * one + 30 * percent == (100 + 30) * percent);
 
-static_assert(is_same_v<decltype((std::uint8_t(0) * one + std::uint8_t(0) * one).numerical_value()), int&&>);
-static_assert(is_same_v<decltype((std::uint8_t(0) * one - std::uint8_t(0) * one).numerical_value()), int&&>);
-static_assert((std::uint8_t(128) * one + std::uint8_t(128) * one).numerical_value() ==
-              std::uint8_t(128) + std::uint8_t(128));
-static_assert((std::uint8_t(0) * one - std::uint8_t(1) * one).numerical_value() == std::uint8_t(0) - std::uint8_t(1));
+static_assert(is_same_v<decltype((std::uint8_t(0) * one + std::uint8_t(0) * one).numerical_value_ref_in(one)), int&&>);
+static_assert(is_same_v<decltype((std::uint8_t(0) * one - std::uint8_t(0) * one).numerical_value_ref_in(one)), int&&>);
+static_assert((std::uint8_t(128) * one + std::uint8_t(128) * one).numerical_value_ref_in(one) ==
 
-static_assert(is_same_v<decltype((std::uint8_t(0) * one % (std::uint8_t(0) * one)).numerical_value()),
+              std::uint8_t(128) + std::uint8_t(128));
+static_assert((std::uint8_t(0) * one - std::uint8_t(1) * one).numerical_value_ref_in(one) ==
+              std::uint8_t(0) - std::uint8_t(1));
+
+static_assert(is_same_v<decltype((std::uint8_t(0) * one % (std::uint8_t(0) * one)).numerical_value_ref_in(one)),
                         decltype(std::uint8_t(0) % std::uint8_t(0))&&>);
 
 static_assert(2 * one * (1 * m) == 2 * m);
@@ -880,20 +885,20 @@ static_assert(!(123 * km >= 321'000 * m));
 
 static_assert(is_of_type<10 * km / (5 * km), quantity<one, int>>);
 
-static_assert((50. * m / (100. * m)).in(percent).numerical_value() == 50);
+static_assert((50. * m / (100. * m)).numerical_value_in(percent) == 50);
 static_assert(50. * m / (100. * m) == 50 * percent);
 
-static_assert((50. * percent).in(one).numerical_value() == 0.5);
+static_assert((50. * percent).numerical_value_in(one) == 0.5);
 
 
 //////////////////
 // value_cast
 //////////////////
 
-static_assert(value_cast<m>(2 * km).numerical_value() == 2000);
-static_assert(value_cast<km>(2000 * m).numerical_value() == 2);
-static_assert(value_cast<int>(1.23 * m).numerical_value() == 1);
-static_assert(value_cast<km / h>(2000.0 * m / (3600.0 * s)).numerical_value() == 2);
+static_assert(value_cast<m>(2 * km).numerical_value_ref_in(m) == 2000);
+static_assert(value_cast<km>(2000 * m).numerical_value_ref_in(km) == 2);
+static_assert(value_cast<int>(1.23 * m).numerical_value_ref_in(m) == 1);
+static_assert(value_cast<km / h>(2000.0 * m / (3600.0 * s)).numerical_value_ref_in(km / h) == 2);
 
 //////////////////
 // quantity_cast


### PR DESCRIPTION
Changes introduced by this PR:
- `quantity::numerical_value()` refactored to `quantity::numerical_value_ref_in(Unit)`
- `quantity_point::quantity_from_origin` refactored to `quantity_point::quantity_ref_from(PointOrigin)`
- `quantity` and `quantity_point` compound assignment, pre-increment, and pre-decrement operators now preserve value category
- `quantity::numerical_value_ref_in(Unit)` allowed only for lvalues
- `quantity_point::quantity_ref_from(PointOrigin)` allows only for lvalues
- `quantity_point::quantity_from(PointOrigin)` added
- `quantity::force_numerical_value_in(Unit)` added
- `quantity::force_in(Unit)` and `quantity_point::force_in(Unit)` added
- usage of the above features in framework, examples, and unit tests

Resolves #477 and relates to #479