### PR TITLE
feat!: add number concepts

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,3 +1,4 @@
+include: ["cmake/.cmake-format-additional_commands-jegp.cmake_modules.yaml"]
 parse:
   additional_commands:
     add_documentation:

--- a/cmake/.cmake-format-additional_commands-jegp.cmake_modules.yaml
+++ b/cmake/.cmake-format-additional_commands-jegp.cmake_modules.yaml
@@ -1,0 +1,61 @@
+parse:
+  additional_commands:
+    _jegp_common_yaml_anchors:
+      kwargs:
+        PUBLIC_INTERFACE_PRIVATE: &public_interface_private
+          kwargs:
+            PUBLIC: +
+            INTERFACE: +
+            PRIVATE: +
+    jegp_add_standardese_sources:
+      pargs:
+        nargs: 1
+        flags:
+        - EXCLUDE_PDF_FROM_MAIN
+        - EXCLUDE_HTML_FROM_MAIN
+        - EXCLUDE_FROM_ALL
+      kwargs:
+        LIBRARIES: +
+        APPENDICES: +
+        EXTENSIONS: +
+        CHECKED: 1
+        PDF_PATH: 1
+        HTML_PATH: 1
+    jegp_add_module:
+      pargs: &jegp_add_module_pargs
+        nargs: 1
+        flags:
+        - IMPORTABLE_HEADER
+      kwargs:
+        SOURCES: +
+        COMPILE_OPTIONS: *public_interface_private
+        LINK_LIBRARIES: *public_interface_private
+    jegp_cpp_module:
+      pargs: *jegp_add_module_pargs
+    jegp_target_link_header_units:
+      pargs:
+        nargs: 1+
+    jegp_add_headers_test:
+      pargs:
+        nargs: 1+
+      kwargs:
+        PRIVATE_REGEXES: +
+    jegp_add_test:
+      pargs:
+        nargs: 1+
+        flags:
+        - COMPILE_ONLY
+      kwargs:
+        TYPE: 1
+        SOURCES: +
+        COMPILE_OPTIONS: +
+        LINK_LIBRARIES: +
+    jegp_add_build_error:
+      pargs:
+        nargs: 1+
+      kwargs:
+        AS: 1
+        TYPE: 1
+        SOURCE: 1
+        COMPILE_OPTIONS: +
+        LINK_LIBRARIES: +

--- a/docs/reference/CMakeLists.txt
+++ b/docs/reference/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.25.0)
+project(mp_units_reference_documentations LANGUAGES NONE)
+
+include(JEGPAddStandardeseSources)
+
+set(pdf_title "Mp-units Library")
+set(page_license "MIT License")
+set(first_library_chapter "nums")
+set(last_library_chapter "qties")
+# set(pdf_creator "Johel Ernesto Guerrero Pe\\~{n}a")
+# set(document_number [[\unspec]])
+# set(previous_document_number [[\unspec]])
+set(cover_title "Mp-units Library Reference Documentations")
+set(reply_to "\\href{${PROJECT_HOMEPAGE_URL}/discussions}{Discussions}, \\href{${PROJECT_HOMEPAGE_URL}/issues}{issues}")
+jegp_add_standardese_sources(
+    mp_units_reference_documentations
+    LIBRARIES intro numbers;quantities
+    EXTENSIONS macros_extensions
+    # CHECKED TRUE
+    PDF_PATH "mp_units.pdf"
+)

--- a/docs/reference/CMakeLists.txt
+++ b/docs/reference/CMakeLists.txt
@@ -1,19 +1,41 @@
-cmake_minimum_required(VERSION 3.25.0)
-project(mp_units_reference_documentations LANGUAGES NONE)
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Mateusz Pusz
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.19.0)
+project(mp-units-reference-documentations LANGUAGES NONE)
 
 include(JEGPAddStandardeseSources)
 
-set(pdf_title "Mp-units Library")
+set(pdf_title "mp-units - A Physical Quantities and Units library for C++")
 set(page_license "MIT License")
 set(first_library_chapter "nums")
 set(last_library_chapter "qties")
-# set(pdf_creator "Johel Ernesto Guerrero Pe\\~{n}a")
+# set(pdf_creator "") # Defaults to "the `user.name` of Git's configuration".
 # set(document_number [[\unspec]])
 # set(previous_document_number [[\unspec]])
-set(cover_title "Mp-units Library Reference Documentations")
+set(cover_title "mp-units Library Reference Documentations")
 set(reply_to "\\href{${PROJECT_HOMEPAGE_URL}/discussions}{Discussions}, \\href{${PROJECT_HOMEPAGE_URL}/issues}{issues}")
 jegp_add_standardese_sources(
-    mp_units_reference_documentations
+    mp-units-reference-documentations
     LIBRARIES intro numbers;quantities
     EXTENSIONS macros_extensions
     # CHECKED TRUE

--- a/docs/reference/codeblock/.clang-format
+++ b/docs/reference/codeblock/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: InheritParentConfig
+ColumnLimit: 97

--- a/docs/reference/codeblock/.clang-format
+++ b/docs/reference/codeblock/.clang-format
@@ -1,2 +1,0 @@
-BasedOnStyle: InheritParentConfig
-ColumnLimit: 97

--- a/docs/reference/intro.tex
+++ b/docs/reference/intro.tex
@@ -1,0 +1,160 @@
+%!TEX root = std.tex
+
+
+\rSec0[scope]{Scope}
+
+\pnum
+\indextext{scope|(}%
+This document describes the contents of the \defn{mp-units library}.
+\indextext{scope|)}
+
+
+\rSec0[refs]{References}
+
+\pnum
+\indextext{references|(}%
+The following documents are referred to in the text
+in such a way that some or all of their content
+constitutes requirements of this document.
+For dated references, only the edition cited applies.
+For undated references,
+the latest edition of the referenced document
+(including any amendments) applies.
+\begin{itemize}
+\item
+The \Cpp{} Standards Committee.
+N4892: \doccite{Working Draft, Standard for Programming Language \Cpp{}}.
+Edited by Thomas K\"{o}ppe.
+Available from: \url{https://wg21.link/N4892}
+\item
+The \Cpp{} Standards Committee.
+P1841R1: \doccite{Wording for Individually Specializable Numeric Traits}.
+Edited by Walter E. Brown.
+Available from: \url{https://wg21.link/P1841R1}
+\item
+The \Cpp{} Standards Committee.
+SD-8: \doccite{Standard Library Compatibility}.
+Edited by Bryce Lelbach.
+Available from: \url{https://wg21.link/SD8}
+\item
+ISO 80000-2:2019, \doccite{Quantities and units --- Part 2: Mathematics}
+\item
+IEC 60050 (all parts),
+\doccite{International Electrotechnical Vocabulary (IEV)}
+\item
+IEC 60050-102:2007/AMD3:2021,
+\doccite{Amendment 3 --- International Electrotechnical Vocabulary (IEV) ---
+Part 102: Mathematics --- General concepts and linear algebra}
+\item
+IEC 60050-112:2010/AMD2:2020,
+\doccite{Amendment 2 --- International Electrotechnical Vocabulary (IEV) ---
+Part 112: Quantities and units}
+\end{itemize}
+
+\pnum
+N4892 is hereinafter called \defn{\Cpp{}}.
+
+\pnum
+IEC 60050 is hereinafter called \defn{IEV}.
+\indextext{references|)}
+
+
+\rSec0[defs]{Terms and definitions}
+
+\pnum
+\indextext{definitions|(}%
+For the purposes of this document,
+the terms and definitions given in
+\Cpp{},
+IEC 60050-102:2007/AMD3:2021,
+IEC 60050-112:2010/AMD2:2020,
+the terms, definitions, and symbols given in
+ISO 80000-2:2019,
+and the following apply.
+
+\pnum
+ISO and IEC maintain terminology databases
+for use in standardization
+at the following addresses:
+\begin{itemize}
+\item ISO Online browsing platform: available at \url{https://www.iso.org/obp}
+\item IEC Electropedia: available at \url{http://www.electropedia.org}
+\end{itemize}
+
+\pnum
+Terms that are used only in a small portion of this document
+are defined where they are used and italicized where they are defined.
+
+\indexdefn{modulo}%
+\definition{modulo}{def.mod}
+operation performed on a set for which a division\irefiev{102-01-21} and an addition are defined,
+the result of which, for elements $a$ and $b$ of the set,
+is the unique element $r$, if it exists in the set,
+such that $a = \lfloor a/b \rfloor b + r$
+
+
+\rSec0[spec]{Specification}
+
+\rSec1[spec.ext]{External}
+
+\pnum
+The specification of the mp-units library subsumes
+\refcpp{description}, \refcpp{requirements}, \refcpp{concepts.equality}, and SD-8,
+all assumingly amended for the context of this library.
+\begin{note}
+This means that, non exhaustively,
+\begin{itemize}
+\item \tcode{::mp_units2} is a reserved namespace, and
+\item
+\tcode{std::vector<mp_units::\placeholdernc{type}>}
+is a program-defined specialization and a library-defined specialization
+from the point of view of \Cpp{} and this library, respectively.
+\end{itemize}
+\end{note}
+
+\pnum
+The mp-units library is not part of the \Cpp{} implementation.
+
+\rSec1[spec.cats]{Categories}
+
+\pnum
+Detailed specifications for each of the components in the library are in
+\ref{\firstlibchapter}--\ref{\lastlibchapter},
+as shown in \tref{lib.cats}.
+
+\begin{floattable}{Library categories}{lib.cats}
+{ll}
+\topline
+\hdstyle{Clause}        & \hdstyle{Category}                              \\ \capsep
+\ref{nums}              & Numbers library                                 \\
+\ref{qties}             & Quantities library                              \\
+\end{floattable}
+
+\pnum
+The numbers library\iref{nums}
+describes components for dealing with numbers.
+
+\pnum
+The quantities library\iref{qties}
+describes components for dealing with quantities.
+
+\rSec1[headers]{Headers}
+
+\pnum
+The mp-units library provides the
+\defnx{mp-units library headers}{header!mp-units library},
+shown in \tref{headers.mp.units}.
+
+\begin{multicolfloattable}{mp-units library headers}{headers.mp.units}
+{l}
+\tcode{<mp_units/numbers.h>} \\
+\tcode{<mp_units/quantity.h>} \\
+\end{multicolfloattable}
+
+\rSec1[spec.reqs]{Library-wide requirements}
+
+\rSec2[spec.res.names]{Reserved names}
+
+\pnum
+The mp-units library reserves macro names that start with
+\tcode{MP_UNITS\opt{\gterm{digit-sequence}}_}.

--- a/docs/reference/intro.tex
+++ b/docs/reference/intro.tex
@@ -87,7 +87,7 @@ are defined where they are used and italicized where they are defined.
 
 \indexdefn{modulo}%
 \definition{modulo}{def.mod}
-operation performed on a set for which a division\irefiev{102-01-21} and an addition are defined,
+operation performed on a set for which a division\irefiev{102-01-21} and an addition\irefiev{102-01-11} are defined,
 the result of which, for elements $a$ and $b$ of the set,
 is the unique element $r$, if it exists in the set,
 such that $a = \lfloor a/b \rfloor b + r$
@@ -147,8 +147,8 @@ shown in \tref{headers.mp.units}.
 
 \begin{multicolfloattable}{mp-units library headers}{headers.mp.units}
 {l}
-\tcode{<mp_units/numbers.h>} \\
-\tcode{<mp_units/quantity.h>} \\
+\tcode{<mp-units/numbers.h>} \\
+\tcode{<mp-units/quantity.h>} \\
 \end{multicolfloattable}
 
 \rSec1[spec.reqs]{Library-wide requirements}

--- a/docs/reference/itemdecl/.clang-format
+++ b/docs/reference/itemdecl/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: InheritParentConfig
+ColumnLimit: 99

--- a/docs/reference/itemdecl/.clang-format
+++ b/docs/reference/itemdecl/.clang-format
@@ -1,2 +1,0 @@
-BasedOnStyle: InheritParentConfig
-ColumnLimit: 99

--- a/docs/reference/macros_extensions.tex
+++ b/docs/reference/macros_extensions.tex
@@ -1,0 +1,20 @@
+% \newcommand{\idxmdl}[1]{#1@\CodeStylex{#1}}
+\newcommand{\idxexposid}[1]{#1@\ExposStylex{#1}}
+
+\newcommand{\indexlibraryspec}[2]{\indexlibrarymisc{#1}{\idxcode{#2}}}
+
+\newcommand{\ExposStylex}[1]{\CodeStylex{\textit{#1}}}
+
+\newnoteenvironment{source}{Source}{end source}
+
+\newcommand{\dvalue}{\Fundesc{Default value}}
+
+%% Inline non-parenthesized C++ reference
+\newcommand{\refcpp}[1]{\href{https://wg21.link/#1}{\Cpp{} [#1]}}
+\newcommand{\irefcpp}[1]{\nolinebreak[3] (\refcpp{#1})}
+\newcommand{\refcppx}[2]{\href{https://wg21.link/#1\##2}{\Cpp{} [#1]}}
+\newcommand{\irefcppx}[2]{\nolinebreak[3] (\refcppx{#1}{#2})}
+
+%% Inline IEV reference
+\newcommand{\refiev}[1]{\href{https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=#1}{IEV #1}}
+\newcommand{\irefiev}[1]{\nolinebreak[3] (\refiev{#1})}

--- a/docs/reference/numbers.tex
+++ b/docs/reference/numbers.tex
@@ -289,6 +289,10 @@ Each row of \tref{num.scalar} denotes a specialization.
 template<typename T>
 concept @\deflibconcept{number}@ = is_number_v<T> && std::regular<T>;
 
+template<typename T, typename U>
+concept @\deflibconcept{common_number_with}@ =
+  @\libconcept{number}@<T> && @\libconcept{number}@<U> && std::common_with<T, U> && @\libconcept{number}@<std::common_type_t<T, U>>;
+
 template<typename T>
 concept @\deflibconcept{ordered_number}@ = @\libconcept{number}@<T> && std::totally_ordered<T>;
 \end{itemdecl}

--- a/docs/reference/numbers.tex
+++ b/docs/reference/numbers.tex
@@ -1,0 +1,601 @@
+%!TEX root = std.tex
+\Sec0[nums]{Numbers library}
+
+\Sec1[nums.summary]{Summary}
+
+\pnum
+This Clause describes components for dealing with numbers,
+as summarized in \tref{nums.summary}.
+
+\begin{libsumtab}{Numbers library summary}{nums.summary}
+\ref{num.traits}        & Traits                                 & \tcode{<mp_units/numbers.h>} \\
+\ref{num.concepts}      & Concepts                               & \\
+\end{libsumtab}
+
+\Sec1[nums.syn]{Header \tcode{<mp_units/numbers.h>} synopsis}
+
+\indexheader{mp_units/numbers.h}%
+\begin{codeblock}
+namespace mp_units {
+
+// \ref{num.traits}, traits
+
+// \ref{num.opt.ins}, \cname{number} opt-ins
+template<typename T>
+struct is_number;
+template<typename T>
+struct is_complex_number;
+
+template<typename T>
+constexpr bool @\libglobal{is_number_v}@ = is_number<T>::value;
+template<typename T>
+constexpr bool @\libglobal{is_complex_number_v}@ = is_complex_number<T>::value;
+
+// \ref{num.ids}, identities
+template<typename T>
+struct number_zero;
+template<typename T>
+struct number_one;
+
+template<typename T>
+constexpr T @\libglobal{number_zero_v}@ = number_zero<T>::value;
+template<typename T>
+constexpr T @\libglobal{number_one_v}@ = number_one<T>::value;
+
+// \ref{num.assoc.types}, associated types
+template<typename T>
+struct number_scalar;
+
+template<typename T>
+using number_difference_t = decltype(std::declval<const T>() - std::declval<const T>());
+template<typename T>
+using @\libglobal{number_scalar_t}@ = number_scalar<T>::type;
+
+// \ref{num.concepts}, concepts
+template<typename T>
+concept number = @\seebelow@;
+template<typename T>
+concept ordered_number = @\seebelow@;
+template<typename T>
+concept number_line = @\seebelow@;
+template<typename T, typename U>
+concept modulo_with = @\seebelow@;
+template<typename T, typename U>
+concept compound_modulo_with = @\seebelow@;
+template<typename T, typename U>
+concept modulus_for = @\seebelow@;
+template<typename T, typename U>
+concept compound_modulus_for = @\seebelow@;
+template<typename T>
+concept negative = @\seebelow@;
+template<typename T>
+concept set_with_inverse = @\seebelow@;
+template<typename T, typename U>
+concept point_space_for = @\seebelow@;
+template<typename T, typename U>
+concept compound_point_space_for = @\seebelow@;
+template<typename T>
+concept point_space = @\seebelow@;
+template<typename T, typename U>
+concept vector_space_for = @\seebelow@;
+template<typename T, typename U>
+concept compound_vector_space_for = @\seebelow@;
+template<typename T, typename U>
+concept scalar_for = @\seebelow@;
+template<typename T, typename U>
+concept field_for = @\seebelow@;
+template<typename T, typename U>
+concept compound_scalar_for = @\seebelow@;
+template<typename T, typename U>
+concept compound_field_for = @\seebelow@;
+template<typename T>
+concept vector_space = @\seebelow@;
+template<typename T>
+concept f_vector_space = @\seebelow@;
+template<typename T>
+concept field_number = @\seebelow@;
+template<typename T>
+concept field_number_line = @\seebelow@;
+template<typename T>
+concept scalar_number = @\seebelow@;
+
+}  // namespace mp_units
+\end{codeblock}
+
+\Sec1[num.traits]{Traits}
+
+\Sec2[num.traits.reqs]{Requirements}
+
+\pnum
+Subclause \ref{num.traits} subsumes \refcpp{meta.rqmts},
+assumingly amended for its context.
+Pursuant to the subsumed \refcpp{namespace.std}\iref{spec.ext},
+each class template specified in \ref{num.traits}
+may be specialized for any numeric type\irefcppx{numeric.requirements}{def:type,numeric}.
+
+\pnum
+\indexlibrary{\idxexposid{number-trait}!{\tcode{const T}}}%
+Each template \tcode{\placeholder{number-trait}} specified in \ref{num.traits}
+has a partial specialization of the form
+\begin{codeblock}
+template<class T>
+struct @\placeholder{number-trait}@<const T> : @\placeholder{number-trait}@<T> { };
+\end{codeblock}
+
+\pnum
+Each template \tcode{\placeholder{number-trait}} specified in \ref{num.opt.ins}
+is a \oldconcept{UnaryTypeTrait}
+with a base characteristic of \tcode{std::bool_constant<\placeholder{B}>}.
+\tcode{\placeholder{B}} is a value consistent with \placeholdernc{\tcode{number-trait}}'s specification.
+
+\pnum
+Each template specified in \ref{num.ids}
+is a numeric distinguished value trait
+(\href{https://wg21.link/P1841R3}{P1841R3} [num.traits.val]),
+except that there are no declared specializations for arithmetic or volatile-qualified types.
+
+\pnum
+A specialization of any template \tcode{\placeholder{number-trait}} specified in \ref{num.assoc.types}
+has no members other than a \tcode{type} member
+that names a type consistent with \placeholdernc{\tcode{number-trait}}'s specification.
+
+\Sec2[num.opt.ins]{\cname{number} opt-ins}
+
+\begin{itemdecl}
+template<typename T>
+struct @\libglobal{is_number}@ : @\seebelow@ {};
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\cvalue
+\tcode{true} if \tcode{T} represents a number, and
+\tcode{false} otherwise.
+
+\pnum
+\dvalue
+\tcode{true} if \tcode{number_scalar_t<T>} is valid, and
+\tcode{false} otherwise.
+\end{itemdescr}
+
+\indexlibraryspec{is_number}{std::chrono::time_point}%
+\indexlibraryspec{is_number}{std::chrono::day}%
+\indexlibraryspec{is_number}{std::chrono::month}%
+\indexlibraryspec{is_number}{std::chrono::year}%
+\indexlibraryspec{is_number}{std::chrono::weekday}%
+\indexlibraryspec{is_number}{std::chrono::year_month}%
+\begin{itemdecl}
+template<class... T>
+struct is_number<std::chrono::time_point<T...>> : std::true_type {};
+template<>
+struct is_number<std::chrono::day> : std::true_type {};
+template<>
+struct is_number<std::chrono::month> : std::true_type {};
+template<>
+struct is_number<std::chrono::year> : std::true_type {};
+template<>
+struct is_number<std::chrono::weekday> : std::true_type {};
+template<>
+struct is_number<std::chrono::year_month> : std::true_type {};
+\end{itemdecl}
+
+\begin{itemdecl}
+template<typename T>
+struct @\libglobal{is_complex_number}@ : std::false_type {};
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\cvalue
+\tcode{true} if \tcode{T} represents a complex number\irefiev{102-02-09}, and
+\tcode{false} otherwise.
+\end{itemdescr}
+
+\indexlibraryspec{is_complex_number}{std::complex}%
+\begin{itemdecl}
+template<class T>
+struct is_complex_number<std::complex<T>> : std::true_type {};
+\end{itemdecl}
+
+\Sec2[num.ids]{Identities}
+
+\begin{codeblock}
+template<typename T>
+concept @\defexposconcept{inferable-identities}@ =
+  std::common_with<T, number_difference_t<T>> && std::constructible_from<T, int>;
+\end{codeblock}
+
+\indexlibrary{\idxcode{number_zero}!\idxexposconcept{inferable-identities}}%
+\begin{itemdecl}
+template<typename T>
+struct @\libglobal{number_zero}@ { @\seebelow@ };
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\cvalue
+\tcode{T}'s neutral element for addition\irefiev{102-01-12}, if any.
+
+\pnum
+\dvalue
+If \tcode{T} models \exposconcept{inferable-identities}, \tcode{T(0)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{number_one}!\idxexposconcept{inferable-identities}}%
+\begin{itemdecl}
+template<typename T>
+struct @\libglobal{number_one}@ { @\seebelow@ };
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\cvalue
+\tcode{T}'s neutral element for multiplication\irefiev{102-01-19}, if any.
+
+\pnum
+\dvalue
+If \tcode{T} models \exposconcept{inferable-identities}, \tcode{T(1)}.
+\end{itemdescr}
+
+\Sec2[num.assoc.types]{Associated types}
+
+\begin{itemdecl}
+template<typename T>
+using @\libglobal{number_difference_t}@ = decltype(std::declval<const T>() - std::declval<const T>());
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\tcode{number_difference_t<T>} represents \tcode{T}'s difference's\irefiev{102-01-17} type, if any.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{number_scalar}!arithmetic type}%
+\indexlibraryspec{number_scalar}{std::complex}%
+\indexlibraryspec{number_scalar}{std::chrono::duration}%
+\begin{itemdecl}
+template<typename T>
+struct @\libglobal{number_scalar}@ {};
+template<@\seebelow@>
+struct number_scalar<@\seebelow@> {
+  using type = @\seebelow@;
+};
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\ctype
+\tcode{T}'s scalar\irefiev{102-02-18}, if any.
+
+\pnum
+Each row of \tref{num.scalar} denotes a specialization.
+
+\begin{floattable}{Specializations of \tcode{number_scalar}}{num.scalar}{lll}
+\topline
+\lhdr{\fakegrammarterm{template-parameter-list}}
+                              & \chdr{\fakegrammarterm{template-argument-list}}
+                                                              & \rhdr{\Fundescx{Type}} \\ \rowsep
+\tcode{std::integral T}       & \tcode{T}                     & \tcode{T} \\ \rowsep
+\tcode{std::floating_point T} & \tcode{T}                     & \tcode{T} \\ \rowsep
+\tcode{class T}               & \tcode{std::complex<T>}       & \tcode{T} \\ \rowsep
+\tcode{class T, class U}      & \tcode{std::duration<T, U>}   & \tcode{T} \\
+\end{floattable}
+\end{itemdescr}
+
+\Sec1[num.concepts]{Concepts}
+
+\begin{itemdecl}
+template<typename T>
+concept @\deflibconcept{number}@ = is_number_v<T> && std::regular<T>;
+
+template<typename T>
+concept @\deflibconcept{ordered_number}@ = @\libconcept{number}@<T> && std::totally_ordered<T>;
+\end{itemdecl}
+
+\begin{itemdecl}
+template<class T>
+concept @\deflibconcept{number_line}@ =
+  @\libconcept{ordered_number}@<T> &&
+  requires(T& v) {
+    number_one_v<number_difference_t<T>>;
+    { ++v } -> std::same_as<T&>;
+    { --v } -> std::same_as<T&>;
+    { v++ } -> std::same_as<T>;
+    { v-- } -> std::same_as<T>;
+  };
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{v} and \tcode{u} be equal objects of type \tcode{T},
+and \tcode{one} be the value \tcode{number_one_v<number_difference_t<T>>}.
+\tcode{T} models \libconcept{number_line} only if
+\begin{itemize}
+\item
+The expressions \tcode{++v} and \tcode{v++} have the same domain\irefcppx{concepts.equality}{def:expression,domain}.
+\item
+The expressions \tcode{--v} and \tcode{v--} have the same domain.
+\item
+If \tcode{v} is incrementable\irefcppx{iterator.concept.winc}{\#def:incrementable},
+then both \tcode{++v} and \tcode{v++} add \tcode{one} to \tcode{v},
+and the following expressions all equal \tcode{true}:
+\begin{itemize}
+\item \tcode{v++ == u},
+\item \tcode{((void)v++, v) == ++u}, and
+\item \tcode{std::addressof(++v) == std::addressof(v)}.
+\end{itemize}
+\item
+If \tcode{v} is decrementable\irefcppx{range.iota.view}{\#def:decrementable},
+then both \tcode{--v} and \tcode{v--} subtract \tcode{one} from \tcode{v},
+and the following expressions all equal \tcode{true}:
+\begin{itemize}
+\item \tcode{v-- == u},
+\item \tcode{((void)v--, v) == --u}, and
+\item \tcode{std::addressof(--v) == std::addressof(v)}.
+\end{itemize}
+\end{itemize}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<class T, class U> concept @\defexposconceptnc{addition-with}@ =
+  @\libconcept{number}@<T> &&
+  @\libconcept{number}@<U> &&
+  requires(const T& c, const U& d) {
+    { c + d } -> std::common_with<T>;
+    { d + c } -> std::common_with<T>;
+  };
+
+template<class T, class U> concept @\defexposconceptnc{compound-addition-with}@ =
+  @\exposconcept{addition-with}@<T, U> &&
+  requires(T& l, const U& d) {
+    { l += d } -> std::same_as<T&>;
+  };
+
+template<class T, class U> concept @\defexposconceptnc{subtraction-with}@ =
+  @\exposconcept{addition-with}@<T, U> &&
+  requires(const T& c, const U& d) {
+    { c - d } -> std::common_with<T>;
+  };
+
+template<class T, class U> concept @\defexposconceptnc{compound-subtraction-with}@ =
+  @\exposconcept{subtraction-with}@<T, U> &&
+  @\exposconcept{compound-addition-with}@<T, U> &&
+  requires(T& l, const U& d) {
+    { l -= d } -> std::same_as<T&>;
+  };
+
+template<class T, class U, class V> concept @\defexposconceptnc{multiplication-with}@ =
+  @\libconcept{number}@<T> &&
+  @\libconcept{number}@<U> &&
+  @\libconcept{number}@<V> &&
+  requires(const T& c, const U& u) {
+    { c * u } -> std::common_with<V>;
+  };
+
+template<class T, class U> concept @\defexposconceptnc{compound-multiplication-with}@ =
+  @\exposconcept{multiplication-with}@<T, U, T> &&
+  requires(T& l, const U& u) {
+    { l *= u } -> std::same_as<T&>;
+  };
+
+template<class T, class U> concept @\defexposconceptnc{division-with}@ =
+  @\exposconcept{multiplication-with}@<T, U, T> &&
+  @\exposconcept{multiplication-with}@<U, T, T> &&
+  requires(const T& c, const U& u) {
+    { c / u } -> std::common_with<T>;
+  };
+
+template<class T, class U> concept @\defexposconceptnc{compound-division-with}@ =
+  @\exposconcept{division-with}@<T, U> &&
+  @\exposconcept{compound-multiplication-with}@<T, U> &&
+  requires(T& l, const U& u) {
+    { l /= u } -> std::same_as<T&>;
+  };
+
+export template<class T, class U> concept @\deflibconcept{modulo_with}@ =
+  @\libconcept{number}@<T> &&
+  @\libconcept{number}@<U> &&
+  requires(const T& c, const U& u) {
+    { c % u } -> std::common_with<T>;
+  };
+
+export template<class T, class U> concept @\deflibconcept{compound_modulo_with}@ =
+  @\libconcept{modulo_with}@<T, U> &&
+  requires(T& l, const U& u) {
+    { l %= u } -> std::same_as<T&>;
+  };
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{q} be an object of type \tcode{T},
+and \tcode{r} be an object of type \tcode{U}.
+
+\pnum
+For \exposconcept{addition-with} and \exposconcept{compound-addition-with},
+let $E$ be the expression \tcode{q + r} or \tcode{r + q}, and \tcode{q += r}, respectively, and
+let $F$ be the addition\irefiev{102-01-11} of the inputs to $E$.
+
+\pnum
+For \exposconcept{subtraction-with} and \exposconcept{compound-subtraction-with},
+let $E$ be the expression \tcode{q - r} and \tcode{q -= r}, respectively, and
+let $F$ be the subtraction\irefiev{102-01-13} of the inputs to $E$.
+
+\pnum
+For \exposconcept{multiplication-with} and \exposconcept{compound-multiplication-with},
+let $E$ be the expression \tcode{q * r} and \tcode{q *= r}, respectively, and
+let $F$ be the multiplication\irefiev{102-01-18} of the inputs to $E$.
+
+\pnum
+For \exposconcept{division-with} and \exposconcept{compound-division-with},
+let $E$ be the expression \tcode{q / r} and \tcode{q /= r}, respectively, and
+let $F$ be the division\irefiev{102-01-21} of the inputs to $E$.
+
+\pnum
+For \libconcept{modulo_with} and \libconcept{compound_modulo_with},
+let $E$ be the expression \tcode{q \% r} and \tcode{q \%= r}, respectively, and
+let $F$ be the modulo\iref{def.mod} of the inputs to $E$.
+
+\pnum
+\tcode{T} respectively models
+\tcode{\exposconcept{addition-with}<U>},
+\tcode{\exposconcept{compound-addition-with}<U>},
+\tcode{\exposconcept{subtraction-with}<U>},
+\tcode{\exposconcept{compound-subtraction-with}<U>},
+\tcode{\exposconcept{multiplication-with}<U, V>},
+\tcode{\exposconcept{compound-multiplication-with}<U>},
+\tcode{\exposconcept{division-with}<U>},
+\tcode{\exposconcept{compound-division-with}<U>},
+\tcode{\libconcept{modulo_with}<U>}, and
+\tcode{\libconcept{compound_modulo_with}<U>}
+only if, for each respective $E$, when the inputs to $E$ are in the domain of $E$
+\begin{itemize}
+\item
+$E$ performs $F$ in an unspecified set.
+\item
+If the operator of $E$ is an \fakegrammarterm{assignment-operator},
+\begin{itemize}
+\item
+$E$ maps the value of $F$ to \tcode{q}, and
+the result of $E$ is a reference to \tcode{q}, and
+\item
+the result of $E$ is the value of $F$ mapped to the type of $E$ otherwise.
+\end{itemize}
+\end{itemize}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<typename T, typename U>
+concept @\deflibconcept{modulus_for}@ = @\libconcept{modulo_with}@<U, T>;
+template<typename T, typename U>
+concept @\deflibconcept{compound_modulus_for}@ = @\libconcept{compound_modulo_with}@<U, T>;
+\end{itemdecl}
+
+\begin{itemdecl}
+export template<class T> concept @\deflibconcept{negative}@ =
+  @\exposconcept{compound-addition-with}@<T, T> &&
+  requires(const T& c) {
+    number_zero_v<T>;
+    { -c } -> std::common_with<T>;
+  };
+
+template<class T> concept @\deflibconcept{set_with_inverse}@ =
+  @\exposconcept{compound-multiplication-with}@<T, T> &&
+  requires(const T& c) {
+    { number_one_v<T> / c } -> std::common_with<T>;
+  };
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+Let \tcode{v} be an object of type \tcode{T}.
+
+\pnum
+For \libconcept{negative},
+let $E$ be the expression \tcode{-v}, and
+let $F$ be the negative\irefiev{102-01-14} of \tcode{v}.
+
+\pnum
+For \libconcept{set_with_inverse},
+let $E$ be the expression \tcode{number_one_v<T> / v}, and
+let $F$ be the inverse\irefiev{102-01-24} of \tcode{v}.
+
+\pnum
+\tcode{T} respectively models
+\tcode{\libconcept{negative}<U>} and
+\tcode{\libconcept{set_with_inverse}<U>}
+only if, for the respective $E$, when \tcode{v} is in the domain of $E$
+\begin{itemize}
+\item
+$E$ performs $F$ in an unspecified set.
+\item
+The result of $E$ is the value of $F$ mapped to the type of $E$.
+\end{itemize}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<typename T, typename U>
+concept @\deflibconcept{point_space_for}@ =
+  @\exposconcept{subtraction-with}@<T, U> && @\libconcept{negative}@<U> && std::common_with<number_difference_t<T>, U>;
+template<typename T, typename U>
+concept @\deflibconcept{compound_point_space_for}@ = @\libconcept{point_space_for}@<T, U> && @\exposconcept{compound-subtraction-with}@<T, U>;
+template<typename T>
+concept @\deflibconcept{point_space}@ = @\libconcept{compound_point_space_for}@<T, number_difference_t<T>>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\begin{note}
+The \libconcept{point_space} concept is modeled by types
+that behave similarly to \tcode{std::chrono::sys_seconds}.
+\end{note}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<typename T, typename U>
+concept @\deflibconcept{vector_space_for}@ = @\libconcept{point_space_for}@<U, T>;
+template<typename T, typename U>
+concept @\deflibconcept{compound_vector_space_for}@ = @\libconcept{compound_point_space_for}@<U, T>;
+
+template<typename T>
+concept @\defexposconceptnc{weak-scalar}@ =
+  std::common_with<T, number_difference_t<T>> && @\libconcept{point_space}@<T> && @\libconcept{negative}@<T>;
+
+template<typename T, typename U>
+concept @\defexposconceptnc{scales-with}@ = std::common_with<U, number_scalar_t<T>> && @\exposconcept{weak-scalar}@<U> &&
+                      @\exposconcept{multiplication-with}@<T, U, T> && @\libconcept{set_with_inverse}@<U>;
+template<typename T, typename U>
+concept @\defexposconceptnc{compound-scales-with}@ = @\exposconcept{scales-with}@<T, U> && @\exposconcept{compound-multiplication-with}@<T, U>;
+
+template<typename T, typename U>
+concept @\deflibconcept{scalar_for}@ = @\exposconcept{scales-with}@<U, T>;
+template<typename T, typename U>
+concept @\deflibconcept{field_for}@ = @\libconcept{scalar_for}@<T, U> && @\exposconcept{division-with}@<U, T>;
+template<typename T, typename U>
+concept @\deflibconcept{compound_scalar_for}@ = @\exposconcept{compound-scales-with}@<U, T>;
+template<typename T, typename U>
+concept @\deflibconcept{compound_field_for}@ = @\libconcept{compound_scalar_for}@<T, U> && @\exposconcept{compound-division-with}@<U, T>;
+
+template<typename T>
+concept @\deflibconcept{vector_space}@ = @\libconcept{point_space}@<T> && @\exposconcept{compound-scales-with}@<T, number_scalar_t<T>>;
+template<typename T>
+concept @\deflibconcept{f_vector_space}@ = @\libconcept{vector_space}@<T> && @\exposconcept{compound-division-with}@<T, number_scalar_t<T>>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\begin{note}
+The \libconcept{f_vector_space} concept is modeled by types
+that behave similarly to \tcode{std::chrono::seconds}.
+\end{note}
+\end{itemdescr}
+
+\begin{itemdecl}
+template<typename T>
+concept @\deflibconcept{field_number}@ = @\libconcept{f_vector_space}@<T> && @\exposconcept{compound-scales-with}@<T, T>;
+
+template<typename T>
+concept @\deflibconcept{field_number_line}@ = @\libconcept{field_number}@<T> && @\libconcept{number_line}@<T>;
+
+template<typename T>
+concept @\deflibconcept{scalar_number}@ = @\libconcept{field_number}@<T> && (@\libconcept{field_number_line}@<T> || is_complex_number_v<T>);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\begin{note}
+The \libconcept{field_number} concept is modeled by types
+that behave similarly to \tcode{std::complex<double>}.
+It represents an approximation of a field, see \refiev{102-02-18}, Note 2 to entry.
+\end{note}
+
+\pnum
+\begin{note}
+The \libconcept{field_number_line} concept is modeled by types
+that behave similarly to \tcode{double}.
+\end{note}
+
+\pnum
+\begin{note}
+\libconcept{scalar_number} represents an approximation of a scalar number\irefiev{102-02-18}.
+\end{note}
+\end{itemdescr}

--- a/docs/reference/numbers.tex
+++ b/docs/reference/numbers.tex
@@ -54,6 +54,8 @@ using @\libglobal{number_scalar_t}@ = number_scalar<T>::type;
 // \ref{num.concepts}, concepts
 template<typename T>
 concept number = @\seebelow@;
+template<typename T, typename U>
+concept common_number_with = @\seebelow@;
 template<typename T>
 concept ordered_number = @\seebelow@;
 template<typename T>
@@ -202,7 +204,7 @@ struct is_complex_number<std::complex<T>> : std::true_type {};
 \begin{codeblock}
 template<typename T>
 concept @\defexposconcept{inferable-identities}@ =
-  std::common_with<T, number_difference_t<T>> && std::constructible_from<T, int>;
+  common_number_with<T, number_difference_t<T>> && std::constructible_from<T, int>;
 \end{codeblock}
 
 \indexlibrary{\idxcode{number_zero}!\idxexposconcept{inferable-identities}}%
@@ -340,8 +342,8 @@ template<class T, class U> concept @\defexposconceptnc{addition-with}@ =
   @\libconcept{number}@<T> &&
   @\libconcept{number}@<U> &&
   requires(const T& c, const U& d) {
-    { c + d } -> std::common_with<T>;
-    { d + c } -> std::common_with<T>;
+    { c + d } -> common_number_with<T>;
+    { d + c } -> common_number_with<T>;
   };
 
 template<class T, class U> concept @\defexposconceptnc{compound-addition-with}@ =
@@ -353,7 +355,7 @@ template<class T, class U> concept @\defexposconceptnc{compound-addition-with}@ 
 template<class T, class U> concept @\defexposconceptnc{subtraction-with}@ =
   @\exposconcept{addition-with}@<T, U> &&
   requires(const T& c, const U& d) {
-    { c - d } -> std::common_with<T>;
+    { c - d } -> common_number_with<T>;
   };
 
 template<class T, class U> concept @\defexposconceptnc{compound-subtraction-with}@ =
@@ -368,7 +370,7 @@ template<class T, class U, class V> concept @\defexposconceptnc{multiplication-w
   @\libconcept{number}@<U> &&
   @\libconcept{number}@<V> &&
   requires(const T& c, const U& u) {
-    { c * u } -> std::common_with<V>;
+    { c * u } -> common_number_with<V>;
   };
 
 template<class T, class U> concept @\defexposconceptnc{compound-multiplication-with}@ =
@@ -381,7 +383,7 @@ template<class T, class U> concept @\defexposconceptnc{division-with}@ =
   @\exposconcept{multiplication-with}@<T, U, T> &&
   @\exposconcept{multiplication-with}@<U, T, T> &&
   requires(const T& c, const U& u) {
-    { c / u } -> std::common_with<T>;
+    { c / u } -> common_number_with<T>;
   };
 
 template<class T, class U> concept @\defexposconceptnc{compound-division-with}@ =
@@ -395,7 +397,7 @@ template<class T, class U> concept @\deflibconcept{modulo_with}@ =
   @\libconcept{number}@<T> &&
   @\libconcept{number}@<U> &&
   requires(const T& c, const U& u) {
-    { c % u } -> std::common_with<T>;
+    { c % u } -> common_number_with<T>;
   };
 
 template<class T, class U> concept @\deflibconcept{compound_modulo_with}@ =
@@ -475,7 +477,7 @@ template<class T> concept @\deflibconcept{negative}@ =
   @\exposconcept{compound-addition-with}@<T, T> &&
   requires(const T& c) {
     number_zero_v<T>;
-    { -c } -> std::common_with<T>;
+    { -c } -> common_number_with<T>;
   };
 
 template<class T> concept @\deflibconcept{set_with_inverse}@ =
@@ -515,7 +517,7 @@ The result of $E$ is the value of $F$ mapped to the type of $E$.
 \begin{itemdecl}
 template<typename T, typename U>
 concept @\deflibconcept{point_space_for}@ =
-  @\exposconcept{subtraction-with}@<T, U> && @\libconcept{negative}@<U> && std::common_with<number_difference_t<T>, U>;
+  @\exposconcept{subtraction-with}@<T, U> && @\libconcept{negative}@<U> && common_number_with<number_difference_t<T>, U>;
 template<typename T, typename U>
 concept @\deflibconcept{compound_point_space_for}@ = @\libconcept{point_space_for}@<T, U> && @\exposconcept{compound-subtraction-with}@<T, U>;
 template<typename T>
@@ -538,10 +540,10 @@ concept @\deflibconcept{compound_vector_space_for}@ = @\libconcept{compound_poin
 
 template<typename T>
 concept @\defexposconceptnc{weak-scalar}@ =
-  std::common_with<T, number_difference_t<T>> && @\libconcept{point_space}@<T> && @\libconcept{negative}@<T>;
+  common_number_with<T, number_difference_t<T>> && @\libconcept{point_space}@<T> && @\libconcept{negative}@<T>;
 
 template<typename T, typename U>
-concept @\defexposconceptnc{scales-with}@ = std::common_with<U, number_scalar_t<T>> && @\exposconcept{weak-scalar}@<U> &&
+concept @\defexposconceptnc{scales-with}@ = common_number_with<U, number_scalar_t<T>> && @\exposconcept{weak-scalar}@<U> &&
                       @\exposconcept{multiplication-with}@<T, U, T> && @\libconcept{set_with_inverse}@<U>;
 template<typename T, typename U>
 concept @\defexposconceptnc{compound-scales-with}@ = @\exposconcept{scales-with}@<T, U> && @\exposconcept{compound-multiplication-with}@<T, U>;

--- a/docs/reference/numbers.tex
+++ b/docs/reference/numbers.tex
@@ -22,14 +22,14 @@ namespace mp_units {
 
 // \ref{num.opt.ins}, \cname{number} opt-ins
 template<typename T>
-struct is_number;
+struct enable_number;
 template<typename T>
-struct is_complex_number;
+struct enable_complex_number;
 
 template<typename T>
-constexpr bool @\libglobal{is_number_v}@ = is_number<T>::value;
+constexpr bool @\libglobal{enable_number_v}@ = enable_number<T>::value;
 template<typename T>
-constexpr bool @\libglobal{is_complex_number_v}@ = is_complex_number<T>::value;
+constexpr bool @\libglobal{enable_complex_number_v}@ = enable_complex_number<T>::value;
 
 // \ref{num.ids}, identities
 template<typename T>
@@ -145,7 +145,7 @@ that names a type consistent with \placeholdernc{\tcode{number-trait}}'s specifi
 
 \begin{itemdecl}
 template<typename T>
-struct @\libglobal{is_number}@ : @\seebelow@ {};
+struct @\libglobal{enable_number}@ : @\seebelow@ {};
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -160,30 +160,30 @@ struct @\libglobal{is_number}@ : @\seebelow@ {};
 \tcode{false} otherwise.
 \end{itemdescr}
 
-\indexlibraryspec{is_number}{std::chrono::time_point}%
-\indexlibraryspec{is_number}{std::chrono::day}%
-\indexlibraryspec{is_number}{std::chrono::month}%
-\indexlibraryspec{is_number}{std::chrono::year}%
-\indexlibraryspec{is_number}{std::chrono::weekday}%
-\indexlibraryspec{is_number}{std::chrono::year_month}%
+\indexlibraryspec{enable_number}{std::chrono::time_point}%
+\indexlibraryspec{enable_number}{std::chrono::day}%
+\indexlibraryspec{enable_number}{std::chrono::month}%
+\indexlibraryspec{enable_number}{std::chrono::year}%
+\indexlibraryspec{enable_number}{std::chrono::weekday}%
+\indexlibraryspec{enable_number}{std::chrono::year_month}%
 \begin{itemdecl}
 template<class... T>
-struct is_number<std::chrono::time_point<T...>> : std::true_type {};
+struct enable_number<std::chrono::time_point<T...>> : std::true_type {};
 template<>
-struct is_number<std::chrono::day> : std::true_type {};
+struct enable_number<std::chrono::day> : std::true_type {};
 template<>
-struct is_number<std::chrono::month> : std::true_type {};
+struct enable_number<std::chrono::month> : std::true_type {};
 template<>
-struct is_number<std::chrono::year> : std::true_type {};
+struct enable_number<std::chrono::year> : std::true_type {};
 template<>
-struct is_number<std::chrono::weekday> : std::true_type {};
+struct enable_number<std::chrono::weekday> : std::true_type {};
 template<>
-struct is_number<std::chrono::year_month> : std::true_type {};
+struct enable_number<std::chrono::year_month> : std::true_type {};
 \end{itemdecl}
 
 \begin{itemdecl}
 template<typename T>
-struct @\libglobal{is_complex_number}@ : std::false_type {};
+struct @\libglobal{enable_complex_number}@ : std::false_type {};
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -193,10 +193,10 @@ struct @\libglobal{is_complex_number}@ : std::false_type {};
 \tcode{false} otherwise.
 \end{itemdescr}
 
-\indexlibraryspec{is_complex_number}{std::complex}%
+\indexlibraryspec{enable_complex_number}{std::complex}%
 \begin{itemdecl}
 template<class T>
-struct is_complex_number<std::complex<T>> : std::true_type {};
+struct enable_complex_number<std::complex<T>> : std::true_type {};
 \end{itemdecl}
 
 \Sec2[num.ids]{Identities}
@@ -287,7 +287,7 @@ Each row of \tref{num.scalar} denotes a specialization.
 
 \begin{itemdecl}
 template<typename T>
-concept @\deflibconcept{number}@ = is_number_v<T> && std::regular<T>;
+concept @\deflibconcept{number}@ = enable_number_v<T> && std::regular<T>;
 
 template<typename T, typename U>
 concept @\deflibconcept{common_number_with}@ =
@@ -583,7 +583,7 @@ template<typename T>
 concept @\deflibconcept{field_number_line}@ = @\libconcept{field_number}@<T> && @\libconcept{number_line}@<T>;
 
 template<typename T>
-concept @\deflibconcept{scalar_number}@ = @\libconcept{field_number}@<T> && (@\libconcept{field_number_line}@<T> || is_complex_number_v<T>);
+concept @\deflibconcept{scalar_number}@ = @\libconcept{field_number}@<T> && (@\libconcept{field_number_line}@<T> || enable_complex_number_v<T>);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/docs/reference/numbers.tex
+++ b/docs/reference/numbers.tex
@@ -44,12 +44,12 @@ constexpr T @\libglobal{number_one_v}@ = number_one<T>::value;
 
 // \ref{num.assoc.types}, associated types
 template<typename T>
-struct number_scalar;
+struct vector_scalar;
 
 template<typename T>
 using number_difference_t = decltype(std::declval<const T>() - std::declval<const T>());
 template<typename T>
-using @\libglobal{number_scalar_t}@ = number_scalar<T>::type;
+using @\libglobal{vector_scalar_t}@ = vector_scalar<T>::type;
 
 // \ref{num.concepts}, concepts
 template<typename T>
@@ -156,7 +156,7 @@ struct @\libglobal{is_number}@ : @\seebelow@ {};
 
 \pnum
 \dvalue
-\tcode{true} if \tcode{number_scalar_t<T>} is valid, and
+\tcode{true} if \tcode{vector_scalar_t<T>} is valid, and
 \tcode{false} otherwise.
 \end{itemdescr}
 
@@ -251,14 +251,14 @@ using @\libglobal{number_difference_t}@ = decltype(std::declval<const T>() - std
 \tcode{number_difference_t<T>} represents \tcode{T}'s difference's\irefiev{102-01-17} type, if any.
 \end{itemdescr}
 
-\indexlibrary{\idxcode{number_scalar}!arithmetic type}%
-\indexlibraryspec{number_scalar}{std::complex}%
-\indexlibraryspec{number_scalar}{std::chrono::duration}%
+\indexlibrary{\idxcode{vector_scalar}!arithmetic type}%
+\indexlibraryspec{vector_scalar}{std::complex}%
+\indexlibraryspec{vector_scalar}{std::chrono::duration}%
 \begin{itemdecl}
 template<typename T>
-struct @\libglobal{number_scalar}@ {};
+struct @\libglobal{vector_scalar}@ {};
 template<@\seebelow@>
-struct number_scalar<@\seebelow@> {
+struct vector_scalar<@\seebelow@> {
   using type = @\seebelow@;
 };
 \end{itemdecl}
@@ -266,12 +266,12 @@ struct number_scalar<@\seebelow@> {
 \begin{itemdescr}
 \pnum
 \ctype
-\tcode{T}'s scalar\irefiev{102-02-18}, if any.
+Scalar\irefiev{102-02-18} for the vector space\irefiev{102-03-01} \tcode{T}.
 
 \pnum
 Each row of \tref{num.scalar} denotes a specialization.
 
-\begin{floattable}{Specializations of \tcode{number_scalar}}{num.scalar}{lll}
+\begin{floattable}{Specializations of \tcode{vector_scalar}}{num.scalar}{lll}
 \topline
 \lhdr{\fakegrammarterm{template-parameter-list}}
                               & \chdr{\fakegrammarterm{template-argument-list}}
@@ -543,7 +543,7 @@ concept @\defexposconceptnc{weak-scalar}@ =
   common_number_with<T, number_difference_t<T>> && @\libconcept{point_space}@<T> && @\libconcept{negative}@<T>;
 
 template<typename T, typename U>
-concept @\defexposconceptnc{scales-with}@ = common_number_with<U, number_scalar_t<T>> && @\exposconcept{weak-scalar}@<U> &&
+concept @\defexposconceptnc{scales-with}@ = common_number_with<U, vector_scalar_t<T>> && @\exposconcept{weak-scalar}@<U> &&
                       @\exposconcept{multiplication-with}@<T, U, T> && @\libconcept{set_with_inverse}@<U>;
 template<typename T, typename U>
 concept @\defexposconceptnc{compound-scales-with}@ = @\exposconcept{scales-with}@<T, U> && @\exposconcept{compound-multiplication-with}@<T, U>;
@@ -558,9 +558,9 @@ template<typename T, typename U>
 concept @\deflibconcept{compound_field_for}@ = @\libconcept{compound_scalar_for}@<T, U> && @\exposconcept{compound-division-with}@<U, T>;
 
 template<typename T>
-concept @\deflibconcept{vector_space}@ = @\libconcept{point_space}@<T> && @\exposconcept{compound-scales-with}@<T, number_scalar_t<T>>;
+concept @\deflibconcept{vector_space}@ = @\libconcept{point_space}@<T> && @\exposconcept{compound-scales-with}@<T, vector_scalar_t<T>>;
 template<typename T>
-concept @\deflibconcept{f_vector_space}@ = @\libconcept{vector_space}@<T> && @\exposconcept{compound-division-with}@<T, number_scalar_t<T>>;
+concept @\deflibconcept{f_vector_space}@ = @\libconcept{vector_space}@<T> && @\exposconcept{compound-division-with}@<T, vector_scalar_t<T>>;
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/docs/reference/numbers.tex
+++ b/docs/reference/numbers.tex
@@ -8,13 +8,13 @@ This Clause describes components for dealing with numbers,
 as summarized in \tref{nums.summary}.
 
 \begin{libsumtab}{Numbers library summary}{nums.summary}
-\ref{num.traits}        & Traits                                 & \tcode{<mp_units/numbers.h>} \\
+\ref{num.traits}        & Traits                                 & \tcode{<mp-units/numbers.h>} \\
 \ref{num.concepts}      & Concepts                               & \\
 \end{libsumtab}
 
-\Sec1[nums.syn]{Header \tcode{<mp_units/numbers.h>} synopsis}
+\Sec1[nums.syn]{Header \tcode{<mp-units/numbers.h>} synopsis}
 
-\indexheader{mp_units/numbers.h}%
+\indexheader{mp-units/numbers.h}%
 \begin{codeblock}
 namespace mp_units {
 
@@ -273,11 +273,11 @@ Each row of \tref{num.scalar} denotes a specialization.
 \topline
 \lhdr{\fakegrammarterm{template-parameter-list}}
                               & \chdr{\fakegrammarterm{template-argument-list}}
-                                                              & \rhdr{\Fundescx{Type}} \\ \rowsep
-\tcode{std::integral T}       & \tcode{T}                     & \tcode{T} \\ \rowsep
-\tcode{std::floating_point T} & \tcode{T}                     & \tcode{T} \\ \rowsep
-\tcode{class T}               & \tcode{std::complex<T>}       & \tcode{T} \\ \rowsep
-\tcode{class T, class U}      & \tcode{std::duration<T, U>}   & \tcode{T} \\
+                                                                    & \rhdr{\Fundescx{Type}} \\ \rowsep
+\tcode{std::integral T}       & \tcode{T}                           & \tcode{T} \\ \rowsep
+\tcode{std::floating_point T} & \tcode{T}                           & \tcode{T} \\ \rowsep
+\tcode{class T}               & \tcode{std::complex<T>}             & \tcode{T} \\ \rowsep
+\tcode{class T, class U}      & \tcode{std::chrono::duration<T, U>} & \tcode{T} \\
 \end{floattable}
 \end{itemdescr}
 
@@ -391,14 +391,14 @@ template<class T, class U> concept @\defexposconceptnc{compound-division-with}@ 
     { l /= u } -> std::same_as<T&>;
   };
 
-export template<class T, class U> concept @\deflibconcept{modulo_with}@ =
+template<class T, class U> concept @\deflibconcept{modulo_with}@ =
   @\libconcept{number}@<T> &&
   @\libconcept{number}@<U> &&
   requires(const T& c, const U& u) {
     { c % u } -> std::common_with<T>;
   };
 
-export template<class T, class U> concept @\deflibconcept{compound_modulo_with}@ =
+template<class T, class U> concept @\deflibconcept{compound_modulo_with}@ =
   @\libconcept{modulo_with}@<T, U> &&
   requires(T& l, const U& u) {
     { l %= u } -> std::same_as<T&>;
@@ -437,14 +437,14 @@ let $F$ be the modulo\iref{def.mod} of the inputs to $E$.
 
 \pnum
 \tcode{T} respectively models
-\tcode{\exposconcept{addition-with}<U>},
-\tcode{\exposconcept{compound-addition-with}<U>},
-\tcode{\exposconcept{subtraction-with}<U>},
-\tcode{\exposconcept{compound-subtraction-with}<U>},
-\tcode{\exposconcept{multiplication-with}<U, V>},
-\tcode{\exposconcept{compound-multiplication-with}<U>},
-\tcode{\exposconcept{division-with}<U>},
-\tcode{\exposconcept{compound-division-with}<U>},
+\tcode{\exposconceptnc{addition-with}<U>},
+\tcode{\exposconceptnc{compound-addition-with}<U>},
+\tcode{\exposconceptnc{subtraction-with}<U>},
+\tcode{\exposconceptx{com\-pound-subtraction-with}{compound-subtraction-with}<U>},
+\tcode{\exposconceptnc{multiplication-with}<U, V>},
+\tcode{\exposconceptnc{compound-multiplication-with}<U>},
+\tcode{\exposconceptnc{division-with}<U>},
+\tcode{\exposconceptnc{compound-division-with}<U>},
 \tcode{\libconcept{modulo_with}<U>}, and
 \tcode{\libconcept{compound_modulo_with}<U>}
 only if, for each respective $E$, when the inputs to $E$ are in the domain of $E$
@@ -471,7 +471,7 @@ concept @\deflibconcept{compound_modulus_for}@ = @\libconcept{compound_modulo_wi
 \end{itemdecl}
 
 \begin{itemdecl}
-export template<class T> concept @\deflibconcept{negative}@ =
+template<class T> concept @\deflibconcept{negative}@ =
   @\exposconcept{compound-addition-with}@<T, T> &&
   requires(const T& c) {
     number_zero_v<T>;

--- a/docs/reference/quantities.tex
+++ b/docs/reference/quantities.tex
@@ -8,15 +8,15 @@ This Clause describes components for dealing with quantities,
 as summarized in \tref{qties.summary}.
 
 \begin{modularlibsumtab}{Quantities library summary}{qties.summary}
-\ref{qty.concepts}      & Concepts                               & \tcode{<mp_units/quantity.h>} \\
+\ref{qty.concepts}      & Concepts                               & \tcode{<mp-units/quantity.h>} \\
 \end{modularlibsumtab}
 
-\Sec1[qty.syn]{Header \tcode{<mp_units/quantity.h>} synopsis}
+\Sec1[qty.syn]{Header \tcode{<mp-units/quantity.h>} synopsis}
 
-\indexheader{mp_units/quantity.h}%
+\indexheader{mp-units/quantity.h}%
 \indexlibraryspec{number_scalar}{quantity}%
 \begin{codeblock}
-#include <mp_units/numbers.h>  // see \ref{nums.syn}
+#include <mp-units/numbers.h>  // see \ref{nums.syn}
 
 namespace mp_units {
 

--- a/docs/reference/quantities.tex
+++ b/docs/reference/quantities.tex
@@ -1,0 +1,46 @@
+%!TEX root = std.tex
+\Sec0[qties]{Quantities library}
+
+\Sec1[qties.summary]{Summary}
+
+\pnum
+This Clause describes components for dealing with quantities,
+as summarized in \tref{qties.summary}.
+
+\begin{modularlibsumtab}{Quantities library summary}{qties.summary}
+\ref{qty.concepts}      & Concepts                               & \tcode{<mp_units/quantity.h>} \\
+\end{modularlibsumtab}
+
+\Sec1[qty.syn]{Header \tcode{<mp_units/quantity.h>} synopsis}
+
+\indexheader{mp_units/quantity.h}%
+\indexlibraryspec{number_scalar}{quantity}%
+\begin{codeblock}
+#include <mp_units/numbers.h>  // see \ref{nums.syn}
+
+namespace mp_units {
+
+// \ref{qty.concepts}, concepts
+template<class>
+concept scalar_quantity = @\seebelow@;
+
+template<Quantity Q>
+struct number_scalar<Q> : number_scalar<typename Q::rep> {};
+
+}  // namespace mp_units
+\end{codeblock}
+
+\Sec1[qty.concepts]{Concepts}
+
+\begin{itemdecl}
+template<class T>
+concept @\deflibconcept{scalar_quantity}@ = Quantity<T> && @\libconcept{scalar_number}@<typename T::rep>;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\begin{note}
+The \libconcept{scalar_quantity} concept
+represents an approximation of a scalar quantity\irefiev{102-02-19}.
+\end{note}
+\end{itemdescr}

--- a/example/include/ranged_representation.h
+++ b/example/include/ranged_representation.h
@@ -45,35 +45,19 @@ public:
   using validated_type<T, is_in_range_t<T, Min, Max>>::validated_type;
   constexpr ranged_representation() : validated_type<T, is_in_range_t<T, Min, Max>>(T{}) {}
 
-  [[nodiscard]] constexpr ranged_representation operator-() const
-    requires requires(T t) { -t; }
-  {
-    return ranged_representation(-this->value());
-  }
+  [[nodiscard]] constexpr ranged_representation operator-() const { return ranged_representation(-this->value()); }
 
-  [[nodiscard]] friend constexpr ranged_representation operator-(const ranged_representation& lhs,
-                                                                 const ranged_representation& rhs)
+  constexpr ranged_representation& operator+=(const T& that)
   {
-    return ranged_representation(lhs.value() - rhs.value());
+    return *this = ranged_representation(this->value() + that);
   }
-
-  constexpr ranged_representation& operator+=(const ranged_representation& that)
+  constexpr ranged_representation& operator-=(const T& that)
   {
-    this->value() += that.value();
-    gsl_Expects(validate(this->value()));
-    return *this;
-  }
-  constexpr ranged_representation& operator-=(const ranged_representation& that)
-  {
-    this->value() -= that.value();
-    gsl_Expects(validate(this->value()));
-    return *this;
+    return *this = ranged_representation(this->value() - that);
   }
   constexpr ranged_representation& operator*=(const T& rhs)
   {
-    this->value() *= rhs;
-    gsl_Expects(validate(this->value()));
-    return *this;
+    return *this = ranged_representation(this->value() * rhs);
   }
 };
 

--- a/example/include/ranged_representation.h
+++ b/example/include/ranged_representation.h
@@ -38,7 +38,7 @@ template<std::movable T, MP_UNITS_CONSTRAINED_NTTP_WORKAROUND(std::convertible_t
          MP_UNITS_CONSTRAINED_NTTP_WORKAROUND(std::convertible_to<T>) auto Max>
 using is_in_range_t = decltype(is_in_range<T, Min, Max>);
 
-template<std::movable T, MP_UNITS_CONSTRAINED_NTTP_WORKAROUND(std::convertible_to<T>) auto Min,
+template<mp_units::vector_space T, MP_UNITS_CONSTRAINED_NTTP_WORKAROUND(std::convertible_to<T>) auto Min,
          MP_UNITS_CONSTRAINED_NTTP_WORKAROUND(std::convertible_to<T>) auto Max>
 class ranged_representation : public validated_type<T, is_in_range_t<T, Min, Max>> {
 public:
@@ -50,14 +50,43 @@ public:
   {
     return ranged_representation(-this->value());
   }
+
+  friend constexpr ranged_representation operator-(const ranged_representation& lhs, const ranged_representation& rhs)
+  {
+    return ranged_representation(lhs.value() - rhs.value());
+  }
+
+  constexpr ranged_representation& operator+=(ranged_representation that)
+  {
+    this->value() += that.value();
+    gsl_Expects(validate(this->value()));
+    return *this;
+  }
+  constexpr ranged_representation& operator-=(ranged_representation that)
+  {
+    this->value() -= that.value();
+    gsl_Expects(validate(this->value()));
+    return *this;
+  }
+  constexpr ranged_representation& operator*=(T rhs)
+  {
+    this->value() *= rhs;
+    gsl_Expects(validate(this->value()));
+    return *this;
+  }
 };
 
 template<typename T, auto Min, auto Max>
 inline constexpr bool mp_units::is_scalar<ranged_representation<T, Min, Max>> = mp_units::is_scalar<T>;
 
 template<typename T, auto Min, auto Max>
+struct mp_units::number_scalar<ranged_representation<T, Min, Max>> : std::type_identity<T> {};
+
+template<typename T, auto Min, auto Max>
 inline constexpr bool mp_units::treat_as_floating_point<ranged_representation<T, Min, Max>> =
   mp_units::treat_as_floating_point<T>;
+
+static_assert(mp_units::vector_space<ranged_representation<int, 17, 29>>);
 
 template<typename T, auto Min, auto Max>
 struct MP_UNITS_STD_FMT::formatter<ranged_representation<T, Min, Max>> : formatter<T> {

--- a/example/include/ranged_representation.h
+++ b/example/include/ranged_representation.h
@@ -81,7 +81,7 @@ template<typename T, auto Min, auto Max>
 inline constexpr bool mp_units::is_scalar<ranged_representation<T, Min, Max>> = mp_units::is_scalar<T>;
 
 template<typename T, auto Min, auto Max>
-struct mp_units::number_scalar<ranged_representation<T, Min, Max>> : std::type_identity<T> {};
+struct mp_units::vector_scalar<ranged_representation<T, Min, Max>> : std::type_identity<T> {};
 
 template<typename T, auto Min, auto Max>
 inline constexpr bool mp_units::treat_as_floating_point<ranged_representation<T, Min, Max>> =

--- a/example/include/ranged_representation.h
+++ b/example/include/ranged_representation.h
@@ -51,24 +51,25 @@ public:
     return ranged_representation(-this->value());
   }
 
-  friend constexpr ranged_representation operator-(const ranged_representation& lhs, const ranged_representation& rhs)
+  [[nodiscard]] friend constexpr ranged_representation operator-(const ranged_representation& lhs,
+                                                                 const ranged_representation& rhs)
   {
     return ranged_representation(lhs.value() - rhs.value());
   }
 
-  constexpr ranged_representation& operator+=(ranged_representation that)
+  constexpr ranged_representation& operator+=(const ranged_representation& that)
   {
     this->value() += that.value();
     gsl_Expects(validate(this->value()));
     return *this;
   }
-  constexpr ranged_representation& operator-=(ranged_representation that)
+  constexpr ranged_representation& operator-=(const ranged_representation& that)
   {
     this->value() -= that.value();
     gsl_Expects(validate(this->value()));
     return *this;
   }
-  constexpr ranged_representation& operator*=(T rhs)
+  constexpr ranged_representation& operator*=(const T& rhs)
   {
     this->value() *= rhs;
     gsl_Expects(validate(this->value()));

--- a/example/measurement.cpp
+++ b/example/measurement.cpp
@@ -65,13 +65,13 @@ public:
     return measurement(lhs.value() - rhs.value(), hypot(lhs.uncertainty(), rhs.uncertainty()));
   }
 
-  constexpr measurement& operator+=(measurement that)
+  constexpr measurement& operator+=(const measurement& that)
   {
     value_ = *this + that;
     return *this;
   }
 
-  constexpr measurement& operator-=(measurement that)
+  constexpr measurement& operator-=(const measurement& that)
   {
     value_ = *this - that;
     return *this;

--- a/example/measurement.cpp
+++ b/example/measurement.cpp
@@ -144,7 +144,7 @@ template<class T>
 inline constexpr bool mp_units::is_vector<measurement<T>> = true;
 
 template<typename T>
-struct mp_units::number_scalar<measurement<T>> : std::type_identity<T> {};
+struct mp_units::vector_scalar<measurement<T>> : std::type_identity<T> {};
 
 static_assert(mp_units::RepresentationOf<measurement<double>, mp_units::quantity_character::scalar>);
 static_assert(mp_units::vector_space<measurement<double>>);

--- a/example/measurement.cpp
+++ b/example/measurement.cpp
@@ -30,7 +30,7 @@
 
 namespace {
 
-template<typename T>
+template<mp_units::vector_space T>
 class measurement {
 public:
   using value_type = T;
@@ -65,6 +65,18 @@ public:
     return measurement(lhs.value() - rhs.value(), hypot(lhs.uncertainty(), rhs.uncertainty()));
   }
 
+  constexpr measurement& operator+=(measurement that)
+  {
+    value_ = *this + that;
+    return *this;
+  }
+
+  constexpr measurement& operator-=(measurement that)
+  {
+    value_ = *this - that;
+    return *this;
+  }
+
   [[nodiscard]] friend constexpr measurement operator*(const measurement& lhs, const measurement& rhs)
   {
     const auto val = lhs.value() * rhs.value();
@@ -76,6 +88,12 @@ public:
   {
     const auto val = lhs.value() * value;
     return measurement(val, val * lhs.relative_uncertainty());
+  }
+
+  constexpr measurement& operator*=(const value_type& value)
+  {
+    value_ = *this * value;
+    return *this;
   }
 
   [[nodiscard]] friend constexpr measurement operator*(const value_type& value, const measurement& rhs)
@@ -125,7 +143,11 @@ inline constexpr bool mp_units::is_scalar<measurement<T>> = true;
 template<class T>
 inline constexpr bool mp_units::is_vector<measurement<T>> = true;
 
+template<typename T>
+struct mp_units::number_scalar<measurement<T>> : std::type_identity<T> {};
+
 static_assert(mp_units::RepresentationOf<measurement<double>, mp_units::quantity_character::scalar>);
+static_assert(mp_units::vector_space<measurement<double>>);
 
 namespace {
 

--- a/src/core/include/mp-units/bits/external/type_list.h
+++ b/src/core/include/mp-units/bits/external/type_list.h
@@ -24,6 +24,7 @@
 
 #include <mp-units/bits/external/hacks.h>  // IWYU pragma: keep
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 
 MP_UNITS_DIAGNOSTIC_PUSH

--- a/src/core/include/mp-units/bits/fwd.h
+++ b/src/core/include/mp-units/bits/fwd.h
@@ -1,0 +1,34 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <mp-units/bits/reference_concepts.h>
+#include <mp-units/bits/representation_concepts.h>
+
+namespace mp_units {
+
+template<Reference auto R, RepresentationOf<get_quantity_spec(R).character> Rep>
+  requires vector_space<Rep>
+class quantity;
+
+}  // namespace mp_units

--- a/src/core/include/mp-units/bits/quantity_concepts.h
+++ b/src/core/include/mp-units/bits/quantity_concepts.h
@@ -22,15 +22,13 @@
 
 #pragma once
 
+#include <mp-units/bits/fwd.h>
 #include <mp-units/bits/quantity_spec_concepts.h>
 #include <mp-units/bits/reference_concepts.h>
 #include <mp-units/bits/representation_concepts.h>
 #include <mp-units/customization_points.h>
 
 namespace mp_units {
-
-template<Reference auto R, RepresentationOf<get_quantity_spec(R).character> Rep>
-class quantity;
 
 #if defined MP_UNITS_COMP_CLANG && MP_UNITS_COMP_CLANG < 17
 template<auto R, typename Rep>

--- a/src/core/include/mp-units/bits/quantity_point_concepts.h
+++ b/src/core/include/mp-units/bits/quantity_point_concepts.h
@@ -107,6 +107,7 @@ concept PointOriginFor = PointOrigin<T> && QuantitySpecOf<std::remove_const_t<de
 
 template<Reference auto R, PointOriginFor<get_quantity_spec(R)> auto PO,
          RepresentationOf<get_quantity_spec(R).character> Rep>
+  requires vector_space<Rep>
 class quantity_point;
 
 #if defined MP_UNITS_COMP_CLANG && MP_UNITS_COMP_CLANG < 17

--- a/src/core/include/mp-units/customization_points.h
+++ b/src/core/include/mp-units/customization_points.h
@@ -24,6 +24,7 @@
 
 #include <mp-units/bits/external/hacks.h>
 #include <mp-units/bits/external/type_traits.h>
+#include <mp-units/numbers.h>
 #include <limits>
 #include <type_traits>
 

--- a/src/core/include/mp-units/numbers.h
+++ b/src/core/include/mp-units/numbers.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <complex>
 #include <concepts>
 #include <type_traits>

--- a/src/core/include/mp-units/numbers.h
+++ b/src/core/include/mp-units/numbers.h
@@ -1,0 +1,294 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <complex>
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+namespace mp_units {
+
+template<typename T>
+struct number_scalar;
+
+namespace detail {
+
+template<typename T>
+struct inferred_number_zero {};
+template<typename T>
+struct inferred_number_one {};
+
+}  // namespace detail
+
+template<typename T>
+using number_difference_t = decltype(std::declval<const T>() - std::declval<const T>());
+template<typename T>
+using number_scalar_t = number_scalar<T>::type;
+
+template<typename T>
+concept is_inferred_number = std::regular<number_scalar_t<T>>;
+
+template<typename T>
+struct is_number : std::bool_constant<is_inferred_number<T>> {};
+template<typename T>
+struct is_complex_number : std::false_type {};
+template<typename T>
+struct number_zero : detail::inferred_number_zero<T> {};
+template<typename T>
+struct number_one : detail::inferred_number_one<T> {};
+template<typename T>
+struct number_scalar {};
+
+template<typename T>
+constexpr bool is_number_v = is_number<T>::value;
+template<typename T>
+constexpr bool is_complex_number_v = is_complex_number<T>::value;
+
+template<typename T>
+constexpr T number_zero_v = number_zero<T>::value;
+template<typename T>
+constexpr T number_one_v = number_one<T>::value;
+
+template<typename T>
+concept number = is_number_v<T> && std::regular<T>;
+
+template<typename T>
+concept ordered_number = number<T> && std::totally_ordered<T>;
+
+template<typename T>
+concept number_line =  // clang-format off
+  ordered_number<T> &&
+  requires(T& v) {
+    number_one_v<number_difference_t<T>>;
+    { ++v } -> std::same_as<T&>;
+    { --v } -> std::same_as<T&>;
+    { v-- } -> std::same_as<T>;
+    { v-- } -> std::same_as<T>;
+  };  // clang-format on
+
+namespace detail {
+
+template<typename T, typename U>
+concept addition_with =  // clang-format off
+  number<T> &&
+  number<U> &&
+  requires( const T & c,  const U & d) {
+    { c + d } -> std::common_with<T>;
+    { d + c } -> std::common_with<T>;
+  };  // clang-format on
+
+template<typename T, typename U>
+concept compound_addition_with =  // clang-format off
+  addition_with<T,U> &&
+  requires(T& l,  const U & d) {
+    { l += d } -> std::same_as<T&>;
+  };  // clang-format on
+
+template<typename T, typename U>
+concept subtraction_with =  // clang-format off
+  addition_with<T,U> &&
+  requires( const T & c,  const U & d) {
+    { c - d } -> std::common_with<T>;
+  };  // clang-format on
+
+template<typename T, typename U>
+concept compound_subtraction_with =  // clang-format off
+  subtraction_with<T,U> &&
+  compound_addition_with<T,U> &&
+  requires(T& l,  const U & d) {
+    { l -= d } -> std::same_as<T&>;
+  };  // clang-format on
+
+template<typename T, typename U, typename V>
+concept multiplication_with =  // clang-format off
+  number<T> &&
+  number<U> &&
+  number<V> &&
+  requires( const T & c,  const U & u) {
+    { (c * u) } -> std::common_with<V>;
+  };  // clang-format on
+
+template<typename T, typename U>
+concept compound_multiplication_with =  // clang-format off
+  multiplication_with<T,U,T> &&
+  requires(T& l,  const U & u) {
+    { l *= u } -> std::same_as<T&>;
+  };  // clang-format on
+
+template<typename T, typename U>
+concept division_with =  // clang-format off
+  multiplication_with<T,U,T> &&
+  multiplication_with<U,T,T> &&
+  requires( const T & c,  const U & u) {
+    { c / u } -> std::common_with<T>;
+  };  // clang-format on
+
+template<typename T, typename U>
+concept compound_division_with =  // clang-format off
+  division_with<T,U> &&
+  compound_multiplication_with<T,U> &&
+  requires(T& l,  const U & u) {
+    { l /= u } -> std::same_as<T&>;
+  };  // clang-format on
+
+}  // namespace detail
+
+template<typename T, typename U>
+concept modulo_with =  // clang-format off
+  number<T> &&
+  number<U> &&
+  requires( const T & c,  const U & u) {
+    { (c % u) } -> std::common_with<T>;
+  };  // clang-format on
+
+template<typename T, typename U>
+concept compound_modulo_with =  // clang-format off
+  modulo_with<T,U> &&
+  requires(T& l,  const U & u) {
+    { l %= u } -> std::same_as<T&>;
+  };  // clang-format on
+
+template<typename T, typename U>
+concept modulus_for = modulo_with<U, T>;
+template<typename T, typename U>
+concept compound_modulus_for = compound_modulo_with<U, T>;
+
+template<typename T>
+concept negative =  // clang-format off
+  detail::compound_addition_with<T,T> &&
+  requires( const T & c) {
+    number_zero_v<T>;
+    { -c } -> std::common_with<T>;
+  };  // clang-format on
+
+template<typename T>
+concept set_with_inverse =  // clang-format off
+  detail::compound_multiplication_with<T,T> &&
+  requires( const T & c) {
+    { number_one_v<T> / c } -> std::common_with<T>;
+  };  // clang-format on
+
+template<typename T, typename U>
+concept point_space_for = detail::subtraction_with<T, U> && negative<U> && std::common_with<number_difference_t<T>, U>;
+template<typename T, typename U>
+concept compound_point_space_for = point_space_for<T, U> && detail::compound_subtraction_with<T, U>;
+template<typename T>
+concept point_space = compound_point_space_for<T, number_difference_t<T>>;
+
+template<typename T, typename U>
+concept vector_space_for = point_space_for<U, T>;
+template<typename T, typename U>
+concept compound_vector_space_for = compound_point_space_for<U, T>;
+
+namespace detail {
+
+template<typename T>
+concept weak_scalar = std::common_with<T, number_difference_t<T>> && point_space<T> && negative<T>;
+
+template<typename T, typename U>
+concept scales_with =
+  std::common_with<U, number_scalar_t<T>> && weak_scalar<U> && multiplication_with<T, U, T> && set_with_inverse<U>;
+template<typename T, typename U>
+concept compound_scales_with = scales_with<T, U> && detail::compound_multiplication_with<T, U>;
+
+}  // namespace detail
+
+template<typename T, typename U>
+concept scalar_for = detail::scales_with<U, T>;
+template<typename T, typename U>
+concept field_for = scalar_for<T, U> && detail::division_with<U, T>;
+template<typename T, typename U>
+concept compound_scalar_for = detail::compound_scales_with<U, T>;
+template<typename T, typename U>
+concept compound_field_for = compound_scalar_for<T, U> && detail::compound_division_with<U, T>;
+
+template<typename T>
+concept vector_space = point_space<T> && detail::compound_scales_with<T, number_scalar_t<T>>;
+template<typename T>
+concept f_vector_space = vector_space<T> && detail::compound_division_with<T, number_scalar_t<T>>;
+
+template<typename T>
+concept field_number = f_vector_space<T> && detail::compound_scales_with<T, T>;
+
+template<typename T>
+concept field_number_line = field_number<T> && number_line<T>;
+
+template<typename T>
+concept scalar_number = field_number<T> && (field_number_line<T> || is_complex_number_v<T>);
+
+template<typename T>
+struct is_number<const T> : is_number<T> {};
+template<typename T, typename U>
+struct is_number<std::chrono::time_point<T, U>> : std::true_type {};
+#if __cpp_lib_chrono >= 201803
+template<>
+struct is_number<std::chrono::day> : std::true_type {};
+template<>
+struct is_number<std::chrono::month> : std::true_type {};
+template<>
+struct is_number<std::chrono::year> : std::true_type {};
+template<>
+struct is_number<std::chrono::weekday> : std::true_type {};
+template<>
+struct is_number<std::chrono::year_month> : std::true_type {};
+#endif
+
+template<typename T>
+struct is_complex_number<const T> : is_complex_number<T> {};
+template<typename T>
+struct is_complex_number<std::complex<T>> : std::true_type {};
+
+namespace detail {
+
+template<typename T>
+concept inferable_identities = std::common_with<T, number_difference_t<T>> && std::constructible_from<T, int>;
+
+template<detail::inferable_identities T>
+struct inferred_number_zero<T> {
+  auto static constexpr value = T(0);
+};
+template<detail::inferable_identities T>
+struct inferred_number_one<T> {
+  auto static constexpr value = T(1);
+};
+
+}  // namespace detail
+
+template<typename T>
+struct number_zero<const T> : number_zero<T> {};
+template<typename T>
+struct number_one<const T> : number_one<T> {};
+
+template<typename T>
+struct number_scalar<const T> : number_scalar<T> {};
+template<std::integral T>
+struct number_scalar<T> : std::type_identity<T> {};
+template<std::floating_point T>
+struct number_scalar<T> : std::type_identity<T> {};
+template<typename T>
+struct number_scalar<std::complex<T>> : std::type_identity<T> {};
+template<typename T, typename U>
+struct number_scalar<std::chrono::duration<T, U>> : std::type_identity<T> {};
+
+}  // namespace mp_units

--- a/src/core/include/mp-units/numbers.h
+++ b/src/core/include/mp-units/numbers.h
@@ -31,12 +31,12 @@
 namespace mp_units {
 
 template<typename T>
-struct number_scalar;
+struct vector_scalar;
 
 template<typename T>
 using number_difference_t = decltype(std::declval<const T>() - std::declval<const T>());
 template<typename T>
-using number_scalar_t = number_scalar<T>::type;
+using vector_scalar_t = vector_scalar<T>::type;
 
 namespace detail {
 
@@ -46,7 +46,7 @@ template<typename T>
 struct inferred_number_one {};
 
 template<typename T>
-concept is_inferred_number = std::regular<number_scalar_t<T>>;
+concept is_inferred_number = std::regular<vector_scalar_t<T>>;
 
 }  // namespace detail
 
@@ -59,7 +59,7 @@ struct number_zero : detail::inferred_number_zero<T> {};
 template<typename T>
 struct number_one : detail::inferred_number_one<T> {};
 template<typename T>
-struct number_scalar {};
+struct vector_scalar {};
 
 template<typename T>
 constexpr bool is_number_v = is_number<T>::value;
@@ -213,7 +213,7 @@ concept weak_scalar = common_number_with<T, number_difference_t<T>> && point_spa
 
 template<typename T, typename U>
 concept scales_with =
-  common_number_with<U, number_scalar_t<T>> && weak_scalar<U> && multiplication_with<T, U, T> && set_with_inverse<U>;
+  common_number_with<U, vector_scalar_t<T>> && weak_scalar<U> && multiplication_with<T, U, T> && set_with_inverse<U>;
 template<typename T, typename U>
 concept compound_scales_with = scales_with<T, U> && detail::compound_multiplication_with<T, U>;
 
@@ -229,9 +229,9 @@ template<typename T, typename U>
 concept compound_field_for = compound_scalar_for<T, U> && detail::compound_division_with<U, T>;
 
 template<typename T>
-concept vector_space = point_space<T> && detail::compound_scales_with<T, number_scalar_t<T>>;
+concept vector_space = point_space<T> && detail::compound_scales_with<T, vector_scalar_t<T>>;
 template<typename T>
-concept f_vector_space = vector_space<T> && detail::compound_division_with<T, number_scalar_t<T>>;
+concept f_vector_space = vector_space<T> && detail::compound_division_with<T, vector_scalar_t<T>>;
 
 template<typename T>
 concept field_number = f_vector_space<T> && detail::compound_scales_with<T, T>;
@@ -286,14 +286,14 @@ template<typename T>
 struct number_one<const T> : number_one<T> {};
 
 template<typename T>
-struct number_scalar<const T> : number_scalar<T> {};
+struct vector_scalar<const T> : vector_scalar<T> {};
 template<std::integral T>
-struct number_scalar<T> : std::type_identity<T> {};
+struct vector_scalar<T> : std::type_identity<T> {};
 template<std::floating_point T>
-struct number_scalar<T> : std::type_identity<T> {};
+struct vector_scalar<T> : std::type_identity<T> {};
 template<typename T>
-struct number_scalar<std::complex<T>> : std::type_identity<T> {};
+struct vector_scalar<std::complex<T>> : std::type_identity<T> {};
 template<typename T, typename U>
-struct number_scalar<std::chrono::duration<T, U>> : std::type_identity<T> {};
+struct vector_scalar<std::chrono::duration<T, U>> : std::type_identity<T> {};
 
 }  // namespace mp_units

--- a/src/core/include/mp-units/numbers.h
+++ b/src/core/include/mp-units/numbers.h
@@ -75,7 +75,7 @@ template<typename T>
 concept number = is_number_v<T> && std::regular<T>;
 
 template<typename T, typename U>
-concept common_number_with = number<T> && number<U> && std::common_with<T, U>;
+concept common_number_with = number<T> && number<U> && std::common_with<T, U> && number<std::common_type_t<T, U>>;
 
 template<typename T>
 concept ordered_number = number<T> && std::totally_ordered<T>;

--- a/src/core/include/mp-units/numbers.h
+++ b/src/core/include/mp-units/numbers.h
@@ -51,9 +51,9 @@ concept is_inferred_number = std::regular<vector_scalar_t<T>>;
 }  // namespace detail
 
 template<typename T>
-struct is_number : std::bool_constant<detail::is_inferred_number<T>> {};
+struct enable_number : std::bool_constant<detail::is_inferred_number<T>> {};
 template<typename T>
-struct is_complex_number : std::false_type {};
+struct enable_complex_number : std::false_type {};
 template<typename T>
 struct number_zero : detail::inferred_number_zero<T> {};
 template<typename T>
@@ -62,9 +62,9 @@ template<typename T>
 struct vector_scalar {};
 
 template<typename T>
-constexpr bool is_number_v = is_number<T>::value;
+constexpr bool enable_number_v = enable_number<T>::value;
 template<typename T>
-constexpr bool is_complex_number_v = is_complex_number<T>::value;
+constexpr bool enable_complex_number_v = enable_complex_number<T>::value;
 
 template<typename T>
 constexpr T number_zero_v = number_zero<T>::value;
@@ -72,7 +72,7 @@ template<typename T>
 constexpr T number_one_v = number_one<T>::value;
 
 template<typename T>
-concept number = is_number_v<T> && std::regular<T>;
+concept number = enable_number_v<T> && std::regular<T>;
 
 template<typename T, typename U>
 concept common_number_with = number<T> && number<U> && std::common_with<T, U> && number<std::common_type_t<T, U>>;
@@ -240,29 +240,29 @@ template<typename T>
 concept field_number_line = field_number<T> && number_line<T>;
 
 template<typename T>
-concept scalar_number = field_number<T> && (field_number_line<T> || is_complex_number_v<T>);
+concept scalar_number = field_number<T> && (field_number_line<T> || enable_complex_number_v<T>);
 
 template<typename T>
-struct is_number<const T> : is_number<T> {};
+struct enable_number<const T> : enable_number<T> {};
 template<typename T, typename U>
-struct is_number<std::chrono::time_point<T, U>> : std::true_type {};
+struct enable_number<std::chrono::time_point<T, U>> : std::true_type {};
 // #if __cpp_lib_chrono >= 201803
 template<>
-struct is_number<std::chrono::day> : std::true_type {};
+struct enable_number<std::chrono::day> : std::true_type {};
 template<>
-struct is_number<std::chrono::month> : std::true_type {};
+struct enable_number<std::chrono::month> : std::true_type {};
 template<>
-struct is_number<std::chrono::year> : std::true_type {};
+struct enable_number<std::chrono::year> : std::true_type {};
 template<>
-struct is_number<std::chrono::weekday> : std::true_type {};
+struct enable_number<std::chrono::weekday> : std::true_type {};
 template<>
-struct is_number<std::chrono::year_month> : std::true_type {};
+struct enable_number<std::chrono::year_month> : std::true_type {};
 // #endif
 
 template<typename T>
-struct is_complex_number<const T> : is_complex_number<T> {};
+struct enable_complex_number<const T> : enable_complex_number<T> {};
 template<typename T>
-struct is_complex_number<std::complex<T>> : std::true_type {};
+struct enable_complex_number<std::complex<T>> : std::true_type {};
 
 namespace detail {
 

--- a/src/core/include/mp-units/numbers.h
+++ b/src/core/include/mp-units/numbers.h
@@ -32,6 +32,11 @@ namespace mp_units {
 template<typename T>
 struct number_scalar;
 
+template<typename T>
+using number_difference_t = decltype(std::declval<const T>() - std::declval<const T>());
+template<typename T>
+using number_scalar_t = number_scalar<T>::type;
+
 namespace detail {
 
 template<typename T>
@@ -39,18 +44,13 @@ struct inferred_number_zero {};
 template<typename T>
 struct inferred_number_one {};
 
-}  // namespace detail
-
-template<typename T>
-using number_difference_t = decltype(std::declval<const T>() - std::declval<const T>());
-template<typename T>
-using number_scalar_t = number_scalar<T>::type;
-
 template<typename T>
 concept is_inferred_number = std::regular<number_scalar_t<T>>;
 
+}  // namespace detail
+
 template<typename T>
-struct is_number : std::bool_constant<is_inferred_number<T>> {};
+struct is_number : std::bool_constant<detail::is_inferred_number<T>> {};
 template<typename T>
 struct is_complex_number : std::false_type {};
 template<typename T>
@@ -266,11 +266,11 @@ concept inferable_identities = std::common_with<T, number_difference_t<T>> && st
 
 template<detail::inferable_identities T>
 struct inferred_number_zero<T> {
-  auto static constexpr value = T(0);
+  static constexpr auto value = T(0);
 };
 template<detail::inferable_identities T>
 struct inferred_number_one<T> {
-  auto static constexpr value = T(1);
+  static constexpr auto value = T(1);
 };
 
 }  // namespace detail

--- a/src/core/include/mp-units/numbers.h
+++ b/src/core/include/mp-units/numbers.h
@@ -246,7 +246,7 @@ template<typename T>
 struct is_number<const T> : is_number<T> {};
 template<typename T, typename U>
 struct is_number<std::chrono::time_point<T, U>> : std::true_type {};
-#if __cpp_lib_chrono >= 201803
+// #if __cpp_lib_chrono >= 201803
 template<>
 struct is_number<std::chrono::day> : std::true_type {};
 template<>
@@ -257,7 +257,7 @@ template<>
 struct is_number<std::chrono::weekday> : std::true_type {};
 template<>
 struct is_number<std::chrono::year_month> : std::true_type {};
-#endif
+// #endif
 
 template<typename T>
 struct is_complex_number<const T> : is_complex_number<T> {};

--- a/src/core/include/mp-units/numbers.h
+++ b/src/core/include/mp-units/numbers.h
@@ -74,6 +74,9 @@ constexpr T number_one_v = number_one<T>::value;
 template<typename T>
 concept number = is_number_v<T> && std::regular<T>;
 
+template<typename T, typename U>
+concept common_number_with = number<T> && number<U> && std::common_with<T, U>;
+
 template<typename T>
 concept ordered_number = number<T> && std::totally_ordered<T>;
 
@@ -95,8 +98,8 @@ concept addition_with =  // clang-format off
   number<T> &&
   number<U> &&
   requires( const T & c,  const U & d) {
-    { c + d } -> std::common_with<T>;
-    { d + c } -> std::common_with<T>;
+    { c + d } -> common_number_with<T>;
+    { d + c } -> common_number_with<T>;
   };  // clang-format on
 
 template<typename T, typename U>
@@ -110,7 +113,7 @@ template<typename T, typename U>
 concept subtraction_with =  // clang-format off
   addition_with<T,U> &&
   requires( const T & c,  const U & d) {
-    { c - d } -> std::common_with<T>;
+    { c - d } -> common_number_with<T>;
   };  // clang-format on
 
 template<typename T, typename U>
@@ -127,7 +130,7 @@ concept multiplication_with =  // clang-format off
   number<U> &&
   number<V> &&
   requires( const T & c,  const U & u) {
-    { (c * u) } -> std::common_with<V>;
+    { (c * u) } -> common_number_with<V>;
   };  // clang-format on
 
 template<typename T, typename U>
@@ -142,7 +145,7 @@ concept division_with =  // clang-format off
   multiplication_with<T,U,T> &&
   multiplication_with<U,T,T> &&
   requires( const T & c,  const U & u) {
-    { c / u } -> std::common_with<T>;
+    { c / u } -> common_number_with<T>;
   };  // clang-format on
 
 template<typename T, typename U>
@@ -160,7 +163,7 @@ concept modulo_with =  // clang-format off
   number<T> &&
   number<U> &&
   requires( const T & c,  const U & u) {
-    { (c % u) } -> std::common_with<T>;
+    { (c % u) } -> common_number_with<T>;
   };  // clang-format on
 
 template<typename T, typename U>
@@ -180,7 +183,7 @@ concept negative =  // clang-format off
   detail::compound_addition_with<T,T> &&
   requires( const T & c) {
     number_zero_v<T>;
-    { -c } -> std::common_with<T>;
+    { -c } -> common_number_with<T>;
   };  // clang-format on
 
 template<typename T>
@@ -191,7 +194,8 @@ concept set_with_inverse =  // clang-format off
   };  // clang-format on
 
 template<typename T, typename U>
-concept point_space_for = detail::subtraction_with<T, U> && negative<U> && std::common_with<number_difference_t<T>, U>;
+concept point_space_for =
+  detail::subtraction_with<T, U> && negative<U> && common_number_with<number_difference_t<T>, U>;
 template<typename T, typename U>
 concept compound_point_space_for = point_space_for<T, U> && detail::compound_subtraction_with<T, U>;
 template<typename T>
@@ -205,11 +209,11 @@ concept compound_vector_space_for = compound_point_space_for<U, T>;
 namespace detail {
 
 template<typename T>
-concept weak_scalar = std::common_with<T, number_difference_t<T>> && point_space<T> && negative<T>;
+concept weak_scalar = common_number_with<T, number_difference_t<T>> && point_space<T> && negative<T>;
 
 template<typename T, typename U>
 concept scales_with =
-  std::common_with<U, number_scalar_t<T>> && weak_scalar<U> && multiplication_with<T, U, T> && set_with_inverse<U>;
+  common_number_with<U, number_scalar_t<T>> && weak_scalar<U> && multiplication_with<T, U, T> && set_with_inverse<U>;
 template<typename T, typename U>
 concept compound_scales_with = scales_with<T, U> && detail::compound_multiplication_with<T, U>;
 
@@ -263,7 +267,7 @@ struct is_complex_number<std::complex<T>> : std::true_type {};
 namespace detail {
 
 template<typename T>
-concept inferable_identities = std::common_with<T, number_difference_t<T>> && std::constructible_from<T, int>;
+concept inferable_identities = common_number_with<T, number_difference_t<T>> && std::constructible_from<T, int>;
 
 template<detail::inferable_identities T>
 struct inferred_number_zero<T> {

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -424,7 +424,7 @@ template<Reference auto R, typename Rep>
 }
 
 template<Quantity Q>
-struct number_scalar<Q> : number_scalar<typename Q::rep> {};
+struct vector_scalar<Q> : vector_scalar<typename Q::rep> {};
 
 }  // namespace mp_units
 

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -394,6 +394,6 @@ template<PointOrigin auto PO, Quantity Q>
 }
 
 template<QuantityPoint QP>
-struct is_number<QP> : std::true_type {};
+struct enable_number<QP> : std::true_type {};
 
 }  // namespace mp_units

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -70,6 +70,7 @@ namespace detail {
  */
 template<Reference auto R, PointOriginFor<get_quantity_spec(R)> auto PO,
          RepresentationOf<get_quantity_spec(R).character> Rep = double>
+  requires vector_space<Rep>
 class quantity_point {
 public:
   // member types and values
@@ -184,47 +185,45 @@ public:
 
   // member unary operators
   template<typename QP>
-  friend constexpr decltype(auto) operator++(QP&& qp)
-    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> && requires { ++qp.quantity_from_origin_; }
+  friend constexpr decltype(auto) operator++(QP && qp)
+    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> && number_line<rep>
   {
     ++qp.quantity_from_origin_;
     return std::forward<QP>(qp);
   }
 
   [[nodiscard]] constexpr quantity_point operator++(int)
-    requires requires { quantity_from_origin_++; }
+    requires number_line<rep>
   {
     return quantity_point(quantity_from_origin_++);
   }
 
   template<typename QP>
-  friend constexpr decltype(auto) operator--(QP&& qp)
-    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> && requires { --qp.quantity_from_origin_; }
+  friend constexpr decltype(auto) operator--(QP && qp)
+    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> && number_line<rep>
   {
     --qp.quantity_from_origin_;
     return std::forward<QP>(qp);
   }
 
   [[nodiscard]] constexpr quantity_point operator--(int)
-    requires requires { quantity_from_origin_--; }
+    requires number_line<rep>
   {
     return quantity_point(quantity_from_origin_--);
   }
 
   // compound assignment operators
   template<typename QP>
-    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> &&
-             requires(quantity_type q) { quantity_from_origin_ += q; }
-  friend constexpr decltype(auto) operator+=(QP&& qp, const quantity_type& q)
+    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point>
+  friend constexpr decltype(auto) operator+=(QP && qp, const quantity_type & q)
   {
     qp.quantity_from_origin_ += q;
     return std::forward<QP>(qp);
   }
 
   template<typename QP>
-    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point> &&
-             requires(quantity_type q) { quantity_from_origin_ -= q; }
-  friend constexpr decltype(auto) operator-=(QP&& qp, const quantity_type& q)
+    requires std::derived_from<std::remove_cvref_t<QP>, quantity_point>
+  friend constexpr decltype(auto) operator-=(QP && qp, const quantity_type & q)
   {
     qp.quantity_from_origin_ -= q;
     return std::forward<QP>(qp);
@@ -253,22 +252,20 @@ explicit quantity_point(QP)
   -> quantity_point<quantity_point_like_traits<QP>::reference, quantity_point_like_traits<QP>::point_origin,
                     typename quantity_point_like_traits<QP>::rep>;
 
-template<auto R1, auto PO1, typename Rep1, auto R2, typename Rep2>
+template<auto R1, auto PO1, typename Rep1, auto R2, vector_space_for<Rep1> Rep2>
 // TODO simplify when gcc catches up
   requires ReferenceOf<std::remove_const_t<decltype(R2)>, PO1.quantity_spec>
 [[nodiscard]] constexpr QuantityPoint auto operator+(const quantity_point<R1, PO1, Rep1>& qp,
                                                      const quantity<R2, Rep2>& q)
-  requires requires { qp.quantity_ref_from(PO1) + q; }
 {
   return make_quantity_point<PO1>(qp.quantity_ref_from(PO1) + q);
 }
 
-template<auto R1, typename Rep1, auto R2, auto PO2, typename Rep2>
+template<auto R1, typename Rep2, auto R2, auto PO2, vector_space_for<Rep2> Rep1>
 // TODO simplify when gcc catches up
   requires ReferenceOf<std::remove_const_t<decltype(R1)>, PO2.quantity_spec>
 [[nodiscard]] constexpr QuantityPoint auto operator+(const quantity<R1, Rep1>& q,
                                                      const quantity_point<R2, PO2, Rep2>& qp)
-  requires requires { q + qp.quantity_ref_from(PO2); }
 {
   return qp + q;
 }
@@ -287,12 +284,11 @@ template<Quantity Q, PointOrigin PO>
   return po + std::forward<Q>(q);
 }
 
-template<auto R1, auto PO1, typename Rep1, auto R2, typename Rep2>
+template<auto R1, auto PO1, typename Rep1, auto R2, vector_space_for<Rep1> Rep2>
 // TODO simplify when gcc catches up
   requires ReferenceOf<std::remove_const_t<decltype(R2)>, PO1.quantity_spec>
 [[nodiscard]] constexpr QuantityPoint auto operator-(const quantity_point<R1, PO1, Rep1>& qp,
                                                      const quantity<R2, Rep2>& q)
-  requires requires { qp.quantity_ref_from(PO1) - q; }
 {
   return make_quantity_point<PO1>(qp.quantity_ref_from(PO1) - q);
 }
@@ -300,15 +296,14 @@ template<auto R1, auto PO1, typename Rep1, auto R2, typename Rep2>
 template<PointOrigin PO, Quantity Q>
   requires ReferenceOf<std::remove_const_t<decltype(Q::reference)>, PO::quantity_spec>
 [[nodiscard]] constexpr QuantityPoint auto operator-(PO po, const Q& q)
-  requires requires { -q; }
 {
   return po + (-q);
 }
 
 template<QuantityPoint QP1, QuantityPointOf<QP1::absolute_point_origin> QP2>
+// TODO consider constraining it for both branches
+  requires vector_space_for<typename QP1::quantity_type, typename QP2::quantity_type>
 [[nodiscard]] constexpr Quantity auto operator-(const QP1& lhs, const QP2& rhs)
-  // TODO consider constraining it for both branches
-  requires requires { lhs.quantity_ref_from(QP1::point_origin) - rhs.quantity_ref_from(QP2::point_origin); }
 {
   if constexpr (is_same_v<std::remove_const_t<decltype(QP1::point_origin)>,
                           std::remove_const_t<decltype(QP2::point_origin)>>)
@@ -397,5 +392,8 @@ template<PointOrigin auto PO, Quantity Q>
 {
   return quantity_point<Q::reference, PO, typename Q::rep>(std::forward<Q>(q));
 }
+
+template<QuantityPoint QP>
+struct is_number<QP> : std::true_type {};
 
 }  // namespace mp_units

--- a/src/core/include/mp-units/reference.h
+++ b/src/core/include/mp-units/reference.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <mp-units/bits/fwd.h>
 #include <mp-units/bits/get_associated_quantity.h>
 #include <mp-units/bits/quantity_concepts.h>
 #include <mp-units/bits/reference_concepts.h>
@@ -154,9 +155,6 @@ struct reference {
     return implicitly_convertible(get_quantity_spec(u1), Q) && convertible(u1, U);
   }
 };
-
-template<Reference auto R, RepresentationOf<get_quantity_spec(R).character> Rep>
-class quantity;
 
 template<typename Rep, Reference R>
 [[nodiscard]] constexpr quantity<R{}, std::remove_cvref_t<Rep>> operator*(Rep&& lhs, R)

--- a/src/utility/include/mp-units/math.h
+++ b/src/utility/include/mp-units/math.h
@@ -274,7 +274,7 @@ template<Unit auto To, auto R, typename Rep>
 /**
  * @brief Computes the inverse of a quantity in a provided unit
  */
-template<Unit auto To, auto R, typename Rep>
+template<Unit auto To, auto R, set_with_inverse Rep>
 [[nodiscard]] constexpr QuantityOf<dimensionless / get_quantity_spec(R)> auto inverse(const quantity<R, Rep>& q)
   requires requires {
     quantity_values<Rep>::one();

--- a/test/unit_test/runtime/CMakeLists.txt
+++ b/test/unit_test/runtime/CMakeLists.txt
@@ -27,11 +27,11 @@ find_package(Catch2 3 CONFIG REQUIRED)
 add_executable(unit_tests_runtime distribution_test.cpp fmt_test.cpp math_test.cpp)
 target_link_libraries(unit_tests_runtime PRIVATE mp-units::mp-units Catch2::Catch2WithMain)
 
-if(${projectPrefix}BUILD_LA)
-    find_package(wg21_linear_algebra CONFIG REQUIRED)
-    target_sources(unit_tests_runtime PRIVATE linear_algebra_test.cpp)
-    target_link_libraries(unit_tests_runtime PRIVATE wg21_linear_algebra::wg21_linear_algebra)
-endif()
+# if(${projectPrefix}BUILD_LA)
+#     find_package(wg21_linear_algebra CONFIG REQUIRED)
+#     target_sources(unit_tests_runtime PRIVATE linear_algebra_test.cpp)
+#     target_link_libraries(unit_tests_runtime PRIVATE wg21_linear_algebra::wg21_linear_algebra)
+# endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(

--- a/test/unit_test/runtime/linear_algebra_test.cpp
+++ b/test/unit_test/runtime/linear_algebra_test.cpp
@@ -43,7 +43,7 @@ template<typename Rep>
 inline constexpr bool mp_units::is_vector<vector<Rep>> = true;
 
 template<typename Rep>
-constexpr bool mp_units::is_number_v<vector<Rep>> = mp_units::is_number_v<Rep>;
+struct mp_units::number_scalar<vector<Rep>> : std::type_identity<Rep> {};
 
 template<typename Rep>
 std::ostream& operator<<(std::ostream& os, const vector<Rep>& v)

--- a/test/unit_test/runtime/linear_algebra_test.cpp
+++ b/test/unit_test/runtime/linear_algebra_test.cpp
@@ -34,11 +34,16 @@
 template<typename Rep = double>
 using vector = STD_LA::fixed_size_column_vector<Rep, 3>;
 
+static_assert(mp_units::vector_space<decltype(vector<int>{3, 2, 1})>);
+
 template<class Rep>
 inline constexpr bool mp_units::treat_as_floating_point<vector<Rep>> = mp_units::treat_as_floating_point<Rep>;
 
 template<typename Rep>
 inline constexpr bool mp_units::is_vector<vector<Rep>> = true;
+
+template<typename Rep>
+constexpr bool mp_units::is_number_v<vector<Rep>> = mp_units::is_number_v<Rep>;
 
 template<typename Rep>
 std::ostream& operator<<(std::ostream& os, const vector<Rep>& v)

--- a/test/unit_test/runtime/linear_algebra_test.cpp
+++ b/test/unit_test/runtime/linear_algebra_test.cpp
@@ -43,7 +43,7 @@ template<typename Rep>
 inline constexpr bool mp_units::is_vector<vector<Rep>> = true;
 
 template<typename Rep>
-struct mp_units::number_scalar<vector<Rep>> : std::type_identity<Rep> {};
+struct mp_units::vector_scalar<vector<Rep>> : std::type_identity<Rep> {};
 
 template<typename Rep>
 std::ostream& operator<<(std::ostream& os, const vector<Rep>& v)

--- a/test/unit_test/static/custom_rep_test_min_impl.cpp
+++ b/test/unit_test/static/custom_rep_test_min_impl.cpp
@@ -32,7 +32,7 @@ namespace {
  *
  * @tparam T element type
  */
-template<typename T>
+template<mp_units::vector_space T>
 class min_impl {
   T value_;
 public:
@@ -45,12 +45,31 @@ public:
   {
   }
   constexpr explicit(false) operator T() const noexcept { return value_; }
+
+  constexpr min_impl& operator+=(min_impl that)
+  {
+    value_ += that.value_;
+    return *this;
+  }
+  constexpr min_impl& operator-=(min_impl that)
+  {
+    value_ -= that.value_;
+    return *this;
+  }
+  constexpr min_impl& operator*=(T rhs)
+  {
+    value_ *= rhs;
+    return *this;
+  }
 };
 
 }  // namespace
 
 template<typename T>
 inline constexpr bool mp_units::is_scalar<min_impl<T>> = true;
+
+template<typename Rep>
+struct mp_units::number_scalar<min_impl<Rep>> : std::type_identity<Rep> {};
 
 template<typename T, typename U>
 struct std::common_type<min_impl<T>, min_impl<U>> : std::type_identity<min_impl<std::common_type_t<T, U>>> {};
@@ -65,6 +84,8 @@ using namespace mp_units;
 
 static_assert(Representation<min_impl<int>>);
 static_assert(Representation<min_impl<double>>);
+static_assert(vector_space<min_impl<int>>);
+static_assert(vector_space<min_impl<double>>);
 
 // construction from a value is not allowed
 static_assert(!std::constructible_from<quantity<si::metre, min_impl<int>>, min_impl<int>>);

--- a/test/unit_test/static/custom_rep_test_min_impl.cpp
+++ b/test/unit_test/static/custom_rep_test_min_impl.cpp
@@ -69,7 +69,7 @@ template<typename T>
 inline constexpr bool mp_units::is_scalar<min_impl<T>> = true;
 
 template<typename Rep>
-struct mp_units::number_scalar<min_impl<Rep>> : std::type_identity<Rep> {};
+struct mp_units::vector_scalar<min_impl<Rep>> : std::type_identity<Rep> {};
 
 template<typename T, typename U>
 struct std::common_type<min_impl<T>, min_impl<U>> : std::type_identity<min_impl<std::common_type_t<T, U>>> {};

--- a/test/unit_test/static/quantity_point_test.cpp
+++ b/test/unit_test/static/quantity_point_test.cpp
@@ -130,6 +130,8 @@ static_assert(std::regular<quantity_point<si::metre, mean_sea_level>>);
 
 static_assert(std::three_way_comparable<quantity_point<si::metre, mean_sea_level>>);
 
+static_assert(point_space<quantity_point<si::metre, mean_sea_level>>);
+
 
 //////////////////
 // member values

--- a/test/unit_test/static/quantity_test.cpp
+++ b/test/unit_test/static/quantity_test.cpp
@@ -85,6 +85,10 @@ static_assert(std::regular<quantity<isq::length[m]>>);
 
 static_assert(std::three_way_comparable<quantity<isq::length[m]>>);
 
+static_assert(f_vector_space<quantity<isq::length[m]>>);
+static_assert(!scalar_number<quantity<dimensionless[one]>>,
+              "`std::common_with<quantity<dimensionless[one]>, double>` is `false`.");
+
 
 //////////////////
 // member values


### PR DESCRIPTION
Resolves #29.

---

The number concepts are meant to be at a lower level than the units' library.
This means that `quantity` can use it to constrain `rep`, and `quantity` itself can model `vector_space`.
So `number_one_v` would supersede `quantity_values::one()`, and same for `zero`.

---

<https://github.com/BobSteagall/wg21/> doesn't work because it doesn't provide compound assignments.
https://github.com/mpusz/mp-units/blob/a356db749ef8651d6b8c48cf732673286a0faa39/test/unit_test/runtime/linear_algebra_test.cpp#L97
`v + v` is valid and the same type as `v`.
But the equivalent for lvalues, `v += v`, isn't provided to mean the same thing.

---

There's still room for more integration.
That would involve breaking up `mp_units`'s specific concepts
that couple checks on the reference and the representation:
https://github.com/mpusz/mp-units/blob/a356db749ef8651d6b8c48cf732673286a0faa39/src/core/include/mp-units/quantity.h#L60-L67
Because `concept`s can't be generically composed (i.e., passed to a concept template parameter),
interfaces would have to check the reference and representation separately.