### PR TITLE
feat: interoperability with other libraries redesigned

### DIFF
--- a/src/core/include/mp-units/bits/quantity_concepts.h
+++ b/src/core/include/mp-units/bits/quantity_concepts.h
@@ -74,15 +74,19 @@ concept QuantityOf = Quantity<Q> && ReferenceOf<std::remove_const_t<decltype(Q::
  * all quantity-specific information.
  */
 template<typename T>
-concept QuantityLike = requires(T q) {
+concept QuantityLike = requires {
   quantity_like_traits<T>::reference;
   requires Reference<std::remove_const_t<decltype(quantity_like_traits<T>::reference)>>;
   typename quantity_like_traits<T>::rep;
   requires RepresentationOf<typename quantity_like_traits<T>::rep,
                             get_quantity_spec(quantity_like_traits<T>::reference).character>;
+} && requires(T q, typename quantity_like_traits<T>::rep v) {
   {
-    make_quantity<quantity_like_traits<T>::reference>(quantity_like_traits<T>::value(q))
-  } -> std::same_as<quantity<quantity_like_traits<T>::reference, typename quantity_like_traits<T>::rep>>;
+    quantity_like_traits<T>::to_numerical_value(q)
+  } -> detail::ConversionSpecOf<typename quantity_like_traits<T>::rep>;
+  {
+    quantity_like_traits<T>::from_numerical_value(v)
+  } -> detail::ConversionSpecOf<T>;
 };
 
 }  // namespace mp_units

--- a/src/core/include/mp-units/bits/quantity_point_concepts.h
+++ b/src/core/include/mp-units/bits/quantity_point_concepts.h
@@ -173,7 +173,7 @@ concept QuantityPointOf =
  * all quantity_point-specific information.
  */
 template<typename T>
-concept QuantityPointLike = requires(T qp) {
+concept QuantityPointLike = requires {
   quantity_point_like_traits<T>::reference;
   requires Reference<std::remove_const_t<decltype(quantity_point_like_traits<T>::reference)>>;
   quantity_point_like_traits<T>::point_origin;
@@ -181,13 +181,15 @@ concept QuantityPointLike = requires(T qp) {
   typename quantity_point_like_traits<T>::rep;
   requires RepresentationOf<typename quantity_point_like_traits<T>::rep,
                             get_quantity_spec(quantity_point_like_traits<T>::reference).character>;
-  requires Quantity<std::remove_cvref_t<decltype(quantity_point_like_traits<T>::quantity_from_origin(qp))>>;
+} && requires(T qp, quantity<quantity_point_like_traits<T>::reference, typename quantity_point_like_traits<T>::rep> q) {
   {
-    make_quantity_point<quantity_point_like_traits<T>::point_origin>(
-      quantity_point_like_traits<T>::quantity_from_origin(qp))
-  }
-  -> std::same_as<quantity_point<quantity_point_like_traits<T>::reference, quantity_point_like_traits<T>::point_origin,
-                                 typename quantity_point_like_traits<T>::rep>>;
+    quantity_point_like_traits<T>::to_quantity(qp)
+  } -> detail::ConversionSpecOf<
+    quantity<quantity_point_like_traits<T>::reference, typename quantity_point_like_traits<T>::rep>>;
+
+  {
+    quantity_point_like_traits<T>::from_quantity(q)
+  } -> detail::ConversionSpecOf<T>;
 };
 
 }  // namespace mp_units

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -143,7 +143,7 @@ public:
   quantity& operator=(const quantity&) = default;
   quantity& operator=(quantity&&) = default;
 
-  // conversions
+  // unit conversions
   template<UnitCompatibleWith<unit, quantity_spec> U>
     requires detail::QuantityConvertibleTo<quantity, quantity<detail::make_reference(quantity_spec, U{}), Rep>>
   [[nodiscard]] constexpr Quantity auto in(U) const
@@ -192,7 +192,8 @@ public:
   }
 
   // conversion operators
-  template<QuantityLike Q>
+  template<typename Q>
+    requires QuantityLike<std::remove_cvref_t<Q>>
   [[nodiscard]] explicit(is_specialization_of<decltype(quantity_like_traits<Q>::from_numerical_value(numerical_value_)),
                                               convert_explicitly>) constexpr
   operator Q() const& noexcept(noexcept(quantity_like_traits<Q>::from_numerical_value(numerical_value_)) &&
@@ -201,11 +202,12 @@ public:
     return quantity_like_traits<Q>::from_numerical_value(numerical_value_).value;
   }
 
-  template<QuantityLike Q>
+  template<typename Q>
+    requires QuantityLike<std::remove_cvref_t<Q>>
   [[nodiscard]] explicit(is_specialization_of<decltype(quantity_like_traits<Q>::from_numerical_value(numerical_value_)),
                                               convert_explicitly>) constexpr
   operator Q() && noexcept(noexcept(quantity_like_traits<Q>::from_numerical_value(numerical_value_)) &&
-                                std::is_nothrow_move_constructible_v<rep>)
+                           std::is_nothrow_move_constructible_v<rep>)
   {
     return quantity_like_traits<Q>::from_numerical_value(std::move(numerical_value_)).value;
   }

--- a/src/core/include/mp-units/quantity.h
+++ b/src/core/include/mp-units/quantity.h
@@ -204,8 +204,8 @@ public:
   template<QuantityLike Q>
   [[nodiscard]] explicit(is_specialization_of<decltype(quantity_like_traits<Q>::from_numerical_value(numerical_value_)),
                                               convert_explicitly>) constexpr
-  operator Q() const&& noexcept(noexcept(quantity_like_traits<Q>::from_numerical_value(numerical_value_)) &&
-                                std::is_nothrow_copy_constructible_v<rep>)
+  operator Q() && noexcept(noexcept(quantity_like_traits<Q>::from_numerical_value(numerical_value_)) &&
+                                std::is_nothrow_move_constructible_v<rep>)
   {
     return quantity_like_traits<Q>::from_numerical_value(std::move(numerical_value_)).value;
   }

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -170,6 +170,7 @@ public:
     return *this - PO2{};
   }
 
+  // unit conversions
   template<UnitCompatibleWith<unit, quantity_spec> U>
     requires detail::QuantityConvertibleTo<quantity_type, quantity<detail::make_reference(quantity_spec, U{}), Rep>>
   [[nodiscard]] constexpr QuantityPoint auto in(U) const
@@ -185,7 +186,8 @@ public:
   }
 
   // conversion operators
-  template<QuantityPointLike QP>
+  template<typename QP>
+    requires QuantityPointLike<std::remove_cvref_t<QP>>
   [[nodiscard]] explicit(
     is_specialization_of<decltype(quantity_point_like_traits<QP>::from_quantity(quantity_from_origin_)),
                          convert_explicitly>) constexpr
@@ -195,12 +197,13 @@ public:
     return quantity_point_like_traits<QP>::from_quantity(quantity_from_origin_).value;
   }
 
-  template<QuantityPointLike QP>
+  template<typename QP>
+    requires QuantityPointLike<std::remove_cvref_t<QP>>
   [[nodiscard]] explicit(
     is_specialization_of<decltype(quantity_point_like_traits<QP>::from_quantity(quantity_from_origin_)),
                          convert_explicitly>) constexpr
   operator QP() && noexcept(noexcept(quantity_point_like_traits<QP>::from_quantity(quantity_from_origin_)) &&
-                                 std::is_nothrow_move_constructible_v<rep>)
+                            std::is_nothrow_move_constructible_v<rep>)
   {
     return quantity_point_like_traits<QP>::from_quantity(std::move(quantity_from_origin_)).value;
   }

--- a/src/core/include/mp-units/quantity_point.h
+++ b/src/core/include/mp-units/quantity_point.h
@@ -199,8 +199,8 @@ public:
   [[nodiscard]] explicit(
     is_specialization_of<decltype(quantity_point_like_traits<QP>::from_quantity(quantity_from_origin_)),
                          convert_explicitly>) constexpr
-  operator QP() const&& noexcept(noexcept(quantity_point_like_traits<QP>::from_quantity(quantity_from_origin_)) &&
-                                 std::is_nothrow_copy_constructible_v<rep>)
+  operator QP() && noexcept(noexcept(quantity_point_like_traits<QP>::from_quantity(quantity_from_origin_)) &&
+                                 std::is_nothrow_move_constructible_v<rep>)
   {
     return quantity_point_like_traits<QP>::from_quantity(std::move(quantity_from_origin_)).value;
   }

--- a/test/unit_test/static/chrono_test.cpp
+++ b/test/unit_test/static/chrono_test.cpp
@@ -52,40 +52,40 @@ static_assert(!QuantityPoint<sys_seconds>);
 // construction - same rep type
 static_assert(
   std::constructible_from<quantity<isq::time[si::second], std::chrono::seconds::rep>, std::chrono::seconds>);
-static_assert(!std::convertible_to<std::chrono::seconds, quantity<isq::time[si::second], std::chrono::seconds::rep>>);
+static_assert(std::convertible_to<std::chrono::seconds, quantity<isq::time[si::second], std::chrono::seconds::rep>>);
 static_assert(std::constructible_from<quantity<isq::time[si::hour], std::chrono::hours::rep>, std::chrono::hours>);
-static_assert(!std::convertible_to<std::chrono::hours, quantity<isq::time[si::hour], std::chrono::hours::rep>>);
+static_assert(std::convertible_to<std::chrono::hours, quantity<isq::time[si::hour], std::chrono::hours::rep>>);
 static_assert(std::constructible_from<quantity<isq::time[si::second], std::chrono::hours::rep>, std::chrono::hours>);
-static_assert(!std::convertible_to<std::chrono::hours, quantity<isq::time[si::second], std::chrono::hours::rep>>);
+static_assert(std::convertible_to<std::chrono::hours, quantity<isq::time[si::second], std::chrono::hours::rep>>);
 static_assert(!std::constructible_from<quantity<isq::time[si::hour], std::chrono::seconds::rep>, std::chrono::seconds>);
 static_assert(!std::convertible_to<std::chrono::seconds, quantity<isq::time[si::hour], std::chrono::seconds::rep>>);
 static_assert(
   std::constructible_from<time_point<si::second, std::chrono::system_clock, sys_seconds::rep>, sys_seconds>);
 static_assert(
   !std::constructible_from<time_point<si::second, std::chrono::steady_clock, sys_seconds::rep>, sys_seconds>);
-static_assert(!std::convertible_to<sys_seconds, time_point<si::second, std::chrono::system_clock, sys_seconds::rep>>);
+static_assert(std::convertible_to<sys_seconds, time_point<si::second, std::chrono::system_clock, sys_seconds::rep>>);
 static_assert(std::constructible_from<time_point<si::day, std::chrono::system_clock, sys_days::rep>, sys_days>);
 static_assert(!std::constructible_from<time_point<si::day, std::chrono::steady_clock, sys_days::rep>, sys_days>);
-static_assert(!std::convertible_to<sys_days, time_point<si::day, std::chrono::system_clock, sys_days::rep>>);
+static_assert(std::convertible_to<sys_days, time_point<si::day, std::chrono::system_clock, sys_days::rep>>);
 static_assert(std::constructible_from<time_point<si::second, std::chrono::system_clock, sys_days::rep>, sys_days>);
 static_assert(!std::constructible_from<time_point<si::second, std::chrono::steady_clock, sys_days::rep>, sys_days>);
-static_assert(!std::convertible_to<sys_days, time_point<si::second, std::chrono::system_clock, sys_days::rep>>);
+static_assert(std::convertible_to<sys_days, time_point<si::second, std::chrono::system_clock, sys_days::rep>>);
 static_assert(!std::constructible_from<time_point<si::day, std::chrono::system_clock, sys_seconds::rep>, sys_seconds>);
 static_assert(!std::convertible_to<sys_seconds, time_point<si::day, std::chrono::system_clock, sys_seconds::rep>>);
 
 // construction - different rep type (integral to a floating-point)
 static_assert(std::constructible_from<quantity<isq::time[si::second]>, std::chrono::seconds>);
-static_assert(!std::convertible_to<std::chrono::seconds, quantity<isq::time[si::second]>>);
+static_assert(std::convertible_to<std::chrono::seconds, quantity<isq::time[si::second]>>);
 static_assert(std::constructible_from<quantity<isq::time[si::second]>, std::chrono::hours>);
-static_assert(!std::convertible_to<std::chrono::hours, quantity<isq::time[si::second]>>);
+static_assert(std::convertible_to<std::chrono::hours, quantity<isq::time[si::second]>>);
 static_assert(std::constructible_from<quantity<isq::time[si::hour]>, std::chrono::seconds>);
-static_assert(!std::convertible_to<std::chrono::seconds, quantity<isq::time[si::hour]>>);
+static_assert(std::convertible_to<std::chrono::seconds, quantity<isq::time[si::hour]>>);
 static_assert(std::constructible_from<time_point<si::second, std::chrono::system_clock>, sys_seconds>);
-static_assert(!std::convertible_to<sys_seconds, time_point<si::second, std::chrono::system_clock>>);
+static_assert(std::convertible_to<sys_seconds, time_point<si::second, std::chrono::system_clock>>);
 static_assert(std::constructible_from<time_point<si::second, std::chrono::system_clock>, sys_days>);
-static_assert(!std::convertible_to<sys_days, time_point<si::second, std::chrono::system_clock>>);
+static_assert(std::convertible_to<sys_days, time_point<si::second, std::chrono::system_clock>>);
 static_assert(std::constructible_from<time_point<si::day, std::chrono::system_clock>, sys_seconds>);
-static_assert(!std::convertible_to<sys_seconds, time_point<si::day, std::chrono::system_clock>>);
+static_assert(std::convertible_to<sys_seconds, time_point<si::day, std::chrono::system_clock>>);
 
 static_assert(quantity<si::second>{1s} == 1 * s);
 static_assert(quantity<isq::time[si::second]>{1s} == 1 * s);

--- a/test/unit_test/static/quantity_point_test.cpp
+++ b/test/unit_test/static/quantity_point_test.cpp
@@ -525,7 +525,7 @@ static_assert(!std::convertible_to<quantity_point<isq::height[m], ground_level>,
 static_assert(
   std::constructible_from<quantity_point<isq::time[s], chrono_point_origin<std::chrono::system_clock>>, sys_seconds>);
 static_assert(
-  !std::convertible_to<sys_seconds, quantity_point<isq::time[s], chrono_point_origin<std::chrono::system_clock>>>);
+  std::convertible_to<sys_seconds, quantity_point<isq::time[s], chrono_point_origin<std::chrono::system_clock>>>);
 
 // incompatible origin
 static_assert(


### PR DESCRIPTION
- existing customization points converting from an external type refactored
- control over explicit/implicit conversion added
- conversion to the external type added
- `std::chrono` types now implicitly convert in both directions