### PR TITLE
Constexpr unit symbol

### DIFF
--- a/src/core/include/mp-units/unit.h
+++ b/src/core/include/mp-units/unit.h
@@ -819,19 +819,17 @@ template<typename CharT = char, Unit U>
 
 template<typename CharT, Unit U, unit_symbol_formatting fmt>
 struct const_unit_symbol {
-  static constexpr std::size_t size{255};
+  static consteval auto unit_symbol_len() -> std::size_t { return unit_symbol(U{}, fmt).size(); }
   static constexpr auto impl() noexcept
   {
-    std::array<CharT, size> array{};
-    auto out_it{mp_units::unit_symbol_to(array.begin(), U{}, fmt)};
-    auto len = std::distance(array.begin(), out_it);
-    return std::make_pair(array, len);
+    std::array<CharT, unit_symbol_len() + 1> buffer{};
+    mp_units::unit_symbol_to(std::begin(buffer), U{}, fmt);
+    return buffer;
   }
   // Give the joined string static storage
   static constexpr auto arr = impl();
-  static_assert(arr.second < size);
   // View as a std::string_view
-  static constexpr std::basic_string_view<CharT> value{arr.first.data(), arr.second};
+  static constexpr std::basic_string_view<CharT> value{arr.data(), arr.size() - 1};
 };
 
 template<typename CharT = char, Unit U, unit_symbol_formatting fmt = unit_symbol_formatting{}>

--- a/src/core/include/mp-units/unit.h
+++ b/src/core/include/mp-units/unit.h
@@ -765,7 +765,7 @@ constexpr Out unit_symbol_impl(Out out, const type_list<Nums...>& nums, const ty
   } else {
     using enum unit_symbol_solidus;
     if constexpr (sizeof...(Nums) > 0) {
-      unit_symbol_impl<CharT>(out, nums, std::index_sequence_for<Nums...>(), fmt, false);
+      out = unit_symbol_impl<CharT>(out, nums, std::index_sequence_for<Nums...>(), fmt, false);
     }
 
     if (fmt.solidus == always || (fmt.solidus == one_denominator && sizeof...(Dens) == 1)) {

--- a/src/core/include/mp-units/unit.h
+++ b/src/core/include/mp-units/unit.h
@@ -817,4 +817,27 @@ template<typename CharT = char, Unit U>
   return buffer;
 }
 
+template<typename CharT, Unit U, unit_symbol_formatting fmt>
+struct const_unit_symbol {
+  static constexpr std::size_t size{255};
+  static constexpr auto impl() noexcept
+  {
+    std::array<CharT, size> array{};
+    auto out_it{mp_units::unit_symbol_to(array.begin(), U{}, fmt)};
+    auto len = std::distance(array.begin(), out_it);
+    return std::make_pair(array, len);
+  }
+  // Give the joined string static storage
+  static constexpr auto arr = impl();
+  static_assert(arr.second < size);
+  // View as a std::string_view
+  static constexpr std::basic_string_view<CharT> value{arr.first.data(), arr.second};
+};
+
+template<typename CharT = char, Unit U, unit_symbol_formatting fmt = unit_symbol_formatting{}>
+[[nodiscard]] constexpr std::basic_string_view<CharT> unit_symbol_view(U)
+{
+  return const_unit_symbol<CharT, U, fmt>::value;
+}
+
 }  // namespace mp_units

--- a/test/unit_test/static/unit_test.cpp
+++ b/test/unit_test/static/unit_test.cpp
@@ -540,4 +540,11 @@ static_assert(is_of_type<common_unit(kilometre, mile), scaled_unit<mag<ratio{8, 
 static_assert(is_of_type<common_unit(mile, kilometre), scaled_unit<mag<ratio{8, 125}>, metre_>>);
 static_assert(is_of_type<common_unit(speed_of_light_in_vacuum, metre / second), derived_unit<metre_, per<second_>>>);
 
+using ::std::string_view_literals::operator""sv;
+static_assert(unit_symbol_view(kilometre) == "km"sv);
+static_assert(unit_symbol_view(kilometre / hour) == "km/h"sv);
+static_assert(unit_symbol_view(kilometre / (hour * hour)) == "km/h²"sv);
+static_assert(unit_symbol_view(degree_Celsius) == "°C"sv);
+static_assert(unit_symbol_view(kelvin) == "K"sv);
+
 }  // namespace


### PR DESCRIPTION
Add `unit_symbol_view` to generate unit_symbol during compilation.

Update iterator when adding to the provided buffer.