### PR TITLE
Update minimum cmake version to 3.5

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 
 macro(_enable_ccache_failed)
     if(NOT _enable_ccache_QUIET)

--- a/cmake/modern_project_structure.cmake
+++ b/cmake/modern_project_structure.cmake
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 
 function(ensure_entry_point)
     if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 add_library(example_utils INTERFACE)
 target_include_directories(example_utils INTERFACE include)

--- a/example/glide_computer_lib/CMakeLists.txt
+++ b/example/glide_computer_lib/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 add_library(glide_computer_lib STATIC glide_computer_lib.cpp include/glide_computer_lib.h)
 target_link_libraries(glide_computer_lib PRIVATE mp-units::core-fmt PUBLIC mp-units::si mp-units::utility example_utils)

--- a/example/kalman_filter/CMakeLists.txt
+++ b/example/kalman_filter/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 #
 # add_example(target <depependencies>...)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 add_subdirectory(unit_test/runtime)
 add_subdirectory(unit_test/static)

--- a/test/unit_test/runtime/CMakeLists.txt
+++ b/test/unit_test/runtime/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 find_package(Catch2 3 CONFIG REQUIRED)
 

--- a/test/unit_test/static/CMakeLists.txt
+++ b/test/unit_test/static/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 add_library(unit_tests_static_truncating quantity_test.cpp)
 target_link_libraries(unit_tests_static_truncating PRIVATE mp-units::mp-units)


### PR DESCRIPTION
Currently, cmake is emitting the following warning:

```
CMake Deprecation Warning at cmake/ccache.cmake:23 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
```

Update the CMake min version to 3.5 to unclutter the build logs and ensure users don't get broken by the deprecation.