### PR TITLE
added support for quantity_point math

### DIFF
--- a/src/core/include/mp-units/math.h
+++ b/src/core/include/mp-units/math.h
@@ -151,11 +151,10 @@ template<auto R, typename Rep>
  * @return bool: Whether the quantity point is finite or not.
  */
 template<auto R, auto PO, typename Rep>
-  requires requires(Rep v) { isfinite(v); } || requires(Rep v) { std::isfinite(v); }
+  requires requires(quantity<R, Rep> q) { isfinite(q); }
 [[nodiscard]] constexpr bool isfinite(const quantity_point<R, PO, Rep>& a) noexcept
 {
-  using std::isfinite;
-  return isfinite(a.quantity_ref_from(a.point_origin).numerical_value_ref_in(a.unit));
+  return isfinite(a.quantity_ref_from(a.point_origin));
 }
 
 /**
@@ -179,11 +178,10 @@ template<auto R, typename Rep>
  * @return bool: Whether the quantity point is infinite or not.
  */
 template<auto R, auto PO, typename Rep>
-  requires requires(Rep v) { isinf(v); } || requires(Rep v) { std::isinf(v); }
+  requires requires(quantity<R, Rep> q) { isinf(q); }
 [[nodiscard]] constexpr bool isinf(const quantity_point<R, PO, Rep>& a) noexcept
 {
-  using std::isinf;
-  return isinf(a.quantity_ref_from(a.point_origin).numerical_value_ref_in(a.unit));
+  return isinf(a.quantity_ref_from(a.point_origin));
 }
 
 
@@ -209,11 +207,10 @@ template<auto R, typename Rep>
  * @return bool: Whether the quantity point is a NaN or not.
  */
 template<auto R, auto PO, typename Rep>
-  requires requires(Rep v) { isnan(v); } || requires(Rep v) { std::isnan(v); }
+  requires requires(quantity<R, Rep> q) { isnan(q); }
 [[nodiscard]] constexpr bool isnan(const quantity_point<R, PO, Rep>& a) noexcept
 {
-  using std::isnan;
-  return isnan(a.quantity_ref_from(a.point_origin).numerical_value_ref_in(a.unit));
+  return isnan(a.quantity_ref_from(a.point_origin));
 }
 
 /**

--- a/src/core/include/mp-units/math.h
+++ b/src/core/include/mp-units/math.h
@@ -25,6 +25,7 @@
 #include <mp-units/bits/module_macros.h>
 #include <mp-units/framework/customization_points.h>
 #include <mp-units/framework/quantity.h>
+#include <mp-units/framework/quantity_point.h>
 #include <mp-units/framework/unit.h>
 #include <mp-units/framework/value_cast.h>
 
@@ -130,10 +131,10 @@ template<auto R, typename Rep>
 }
 
 /**
- * @brief Determines if a number is finite.
+ * @brief Determines if a quantity is finite.
  *
- * @param a: Number to analyze.
- * @return bool: Whether the number is finite or not.
+ * @param a: Quantity to analyze.
+ * @return bool: Whether the quantity is finite or not.
  */
 template<auto R, typename Rep>
   requires requires(Rep v) { isfinite(v); } || requires(Rep v) { std::isfinite(v); }
@@ -144,10 +145,24 @@ template<auto R, typename Rep>
 }
 
 /**
- * @brief Determines if a number is infinite.
+ * @brief Determines if a quantity point is finite.
  *
- * @param a: Number to analyze.
- * @return bool: Whether the number is infinite or not.
+ * @param a: Quantity point to analyze.
+ * @return bool: Whether the quantity point is finite or not.
+ */
+template<auto R, auto PO, typename Rep>
+  requires requires(Rep v) { isfinite(v); } || requires(Rep v) { std::isfinite(v); }
+[[nodiscard]] constexpr bool isfinite(const quantity_point<R, PO, Rep>& a) noexcept
+{
+  using std::isfinite;
+  return isfinite(a.quantity_ref_from(a.point_origin).numerical_value_ref_in(a.unit));
+}
+
+/**
+ * @brief Determines if a quantity is infinite.
+ *
+ * @param a: Quantity to analyze.
+ * @return bool: Whether the quantity is infinite or not.
  */
 template<auto R, typename Rep>
   requires requires(Rep v) { isinf(v); } || requires(Rep v) { std::isinf(v); }
@@ -157,12 +172,26 @@ template<auto R, typename Rep>
   return isinf(a.numerical_value_ref_in(a.unit));
 }
 
+/**
+ * @brief Determines if a quantity point is infinite.
+ *
+ * @param a: Quantity point to analyze.
+ * @return bool: Whether the quantity point is infinite or not.
+ */
+template<auto R, auto PO, typename Rep>
+  requires requires(Rep v) { isinf(v); } || requires(Rep v) { std::isinf(v); }
+[[nodiscard]] constexpr bool isinf(const quantity_point<R, PO, Rep>& a) noexcept
+{
+  using std::isinf;
+  return isinf(a.quantity_ref_from(a.point_origin).numerical_value_ref_in(a.unit));
+}
+
 
 /**
- * @brief Determines if a number is a nan.
+ * @brief Determines if a quantity is a nan.
  *
- * @param a: Number to analyze.
- * @return bool: Whether the number is a NaN or not.
+ * @param a: Quantity to analyze.
+ * @return bool: Whether the quantity is a NaN or not.
  */
 template<auto R, typename Rep>
   requires requires(Rep v) { isnan(v); } || requires(Rep v) { std::isnan(v); }
@@ -170,6 +199,21 @@ template<auto R, typename Rep>
 {
   using std::isnan;
   return isnan(a.numerical_value_ref_in(a.unit));
+}
+
+
+/**
+ * @brief Determines if a quantity point is a nan.
+ *
+ * @param a: Quantity point to analyze.
+ * @return bool: Whether the quantity point is a NaN or not.
+ */
+template<auto R, auto PO, typename Rep>
+  requires requires(Rep v) { isnan(v); } || requires(Rep v) { std::isnan(v); }
+[[nodiscard]] constexpr bool isnan(const quantity_point<R, PO, Rep>& a) noexcept
+{
+  using std::isnan;
+  return isnan(a.quantity_ref_from(a.point_origin).numerical_value_ref_in(a.unit));
 }
 
 /**


### PR DESCRIPTION
A small number of `math.h` operations are even well-specified for points in the affine space; I identified `isfinite`, `isinf` and `isnan` so far. We should eventually also support [`midpoint`](https://en.cppreference.com/w/cpp/numeric/midpoint) and [`lerp`](https://en.cppreference.com/w/cpp/numeric/lerp) eventually - both of them are currently missing for bare quantities either. Work for another PR.