### PR TITLE
Bug: overflow in value_cast

### DIFF
--- a/test/runtime/almost_equals.h
+++ b/test/runtime/almost_equals.h
@@ -50,7 +50,7 @@ struct AlmostEqualsMatcher : Catch::Matchers::MatcherGenericBase {
       const auto maxXYOne = std::max({rep{1}, abs(x), abs(y)});
       return abs(x - y) <= std::numeric_limits<rep>::epsilon() * maxXYOne;
     } else {
-      if (x >= 0) {
+      if (x > 0) {
         return x - 1 <= y && y - 1 <= x;
       } else {
         return x <= y + 1 && y <= x + 1;


### PR DESCRIPTION
I was now able to find a test-cast highlighting that overflow I suspected in #579. I keep this as a separate issue/PR, so that #579 can be merged before we fix the issue highlighted here. After all, it appears it's still a fairly uncommon issue given that you need a value whose representation times the numerator of a rational conversion factor overflows `std::intmax_t`.