### PR TITLE
fix: Support fmtlib 11.0.0

### DIFF
--- a/src/core/include/mp-units/bits/fmt.h
+++ b/src/core/include/mp-units/bits/fmt.h
@@ -146,7 +146,11 @@ template<typename Int>
 template<class Handler, typename FormatArg>
 [[nodiscard]] constexpr int get_dynamic_spec(FormatArg arg)
 {
+#if defined MP_UNITS_USE_FMTLIB && FMT_VERSION >= 110000
+  const unsigned long long value = arg.visit(Handler{});
+#else
   const unsigned long long value = MP_UNITS_STD_FMT::visit_format_arg(Handler{}, arg);
+#endif
   if (value > ::mp_units::detail::to_unsigned(std::numeric_limits<int>::max())) {
     MP_UNITS_THROW(MP_UNITS_STD_FMT::format_error("number is too big"));
   }

--- a/src/core/include/mp-units/format.h
+++ b/src/core/include/mp-units/format.h
@@ -467,8 +467,8 @@ public:
     return parse_defaults_specs(it, end);
   }
 
-  template<typename OutIt>
-  OutIt format(const quantity_t& q, MP_UNITS_STD_FMT::basic_format_context<OutIt, Char>& ctx) const
+  template<typename FormatContext>
+  auto format(const quantity_t& q, FormatContext& ctx) const
   {
     auto specs = specs_;
     mp_units::detail::handle_dynamic_spec<mp_units::detail::width_checker>(specs.width, specs.width_ref, ctx);


### PR DESCRIPTION
fmtlib [v11.0.0](https://github.com/fmtlib/fmt/releases/tag/11.0.0) released today.