### PR TITLE
Compute values for rational magnitude powers

### DIFF
--- a/src/core/include/mp-units/framework/expression_template.h
+++ b/src/core/include/mp-units/framework/expression_template.h
@@ -334,7 +334,7 @@ struct expr_fractions : decltype(expr_fractions_impl<OneType, type_list<Ts...>>(
 
 // expr_make_spec
 template<typename NumList, typename DenList, typename OneType, template<typename...> typename To>
-[[nodiscard]] consteval auto expr_make_spec_impl()
+[[nodiscard]] MP_UNITS_CONSTEVAL auto expr_make_spec_impl()
 {
   constexpr std::size_t num = type_list_size<NumList>;
   constexpr std::size_t den = type_list_size<DenList>;
@@ -359,7 +359,7 @@ template<typename NumList, typename DenList, typename OneType, template<typename
  */
 template<typename NumList, typename DenList, typename OneType, template<typename, typename> typename Pred,
          template<typename...> typename To>
-[[nodiscard]] consteval auto get_optimized_expression()
+[[nodiscard]] MP_UNITS_CONSTEVAL auto get_optimized_expression()
 {
   using num_list = expr_consolidate<NumList>;
   using den_list = expr_consolidate<DenList>;
@@ -380,7 +380,7 @@ template<typename NumList, typename DenList, typename OneType, template<typename
  */
 template<template<typename...> typename To, typename OneType, template<typename, typename> typename Pred, typename Lhs,
          typename Rhs>
-[[nodiscard]] consteval auto expr_multiply(Lhs, Rhs)
+[[nodiscard]] MP_UNITS_CONSTEVAL auto expr_multiply(Lhs, Rhs)
 {
   if constexpr (is_same_v<Lhs, OneType>) {
     return Rhs{};

--- a/src/core/include/mp-units/framework/magnitude.h
+++ b/src/core/include/mp-units/framework/magnitude.h
@@ -307,118 +307,118 @@ template<typename T>
   return checked_square(int_power(base, exp / 2));
 }
 
-template <typename T>
-[[nodiscard]] consteval std::optional<T> checked_int_pow(T base, std::uintmax_t exp) {
-    T result = T{1};
-    while (exp > 0u) {
-        if (exp % 2u == 1u) {
-            if (base > std::numeric_limits<T>::max() / result) {
-                return std::nullopt;
-            }
-            result *= base;
-        }
-
-        exp /= 2u;
-
-        if (base > std::numeric_limits<T>::max() / base) {
-            return (exp == 0u)
-                       ? std::make_optional(result)
-                       : std::nullopt;
-        }
-        base *= base;
+template<typename T>
+[[nodiscard]] consteval std::optional<T> checked_int_pow(T base, std::uintmax_t exp)
+{
+  T result = T{1};
+  while (exp > 0u) {
+    if (exp % 2u == 1u) {
+      if (base > std::numeric_limits<T>::max() / result) {
+        return std::nullopt;
+      }
+      result *= base;
     }
-    return result;
+
+    exp /= 2u;
+
+    if (base > std::numeric_limits<T>::max() / base) {
+      return (exp == 0u) ? std::make_optional(result) : std::nullopt;
+    }
+    base *= base;
+  }
+  return result;
 }
 
-template <typename T>
-[[nodiscard]] consteval std::optional<T> root(T x, std::uintmax_t n) {
-    // The "zeroth root" would be mathematically undefined.
-    if (n == 0) {
+template<typename T>
+[[nodiscard]] consteval std::optional<T> root(T x, std::uintmax_t n)
+{
+  // The "zeroth root" would be mathematically undefined.
+  if (n == 0) {
+    return std::nullopt;
+  }
+
+  // The "first root" is trivial.
+  if (n == 1) {
+    return x;
+  }
+
+  // We only support nontrivial roots of floating point types.
+  if (!std::is_floating_point<T>::value) {
+    return std::nullopt;
+  }
+
+  // Handle negative numbers: only odd roots are allowed.
+  if (x < 0) {
+    if (n % 2 == 0) {
+      return std::nullopt;
+    } else {
+      const auto negative_result = root(-x, n);
+      if (!negative_result.has_value()) {
         return std::nullopt;
+      }
+      return static_cast<T>(-negative_result.value());
+    }
+  }
+
+  // Handle special cases of zero and one.
+  if (x == 0 || x == 1) {
+    return x;
+  }
+
+  // Handle numbers bewtween 0 and 1.
+  if (x < 1) {
+    const auto inverse_result = root(T{1} / x, n);
+    if (!inverse_result.has_value()) {
+      return std::nullopt;
+    }
+    return static_cast<T>(T{1} / inverse_result.value());
+  }
+
+  //
+  // At this point, error conditions are finished, and we can proceed with the "core" algorithm.
+  //
+
+  // Always use `long double` for intermediate computations.  We don't ever expect people to be
+  // calling this at runtime, so we want maximum accuracy.
+  long double lo = 1.0;
+  long double hi = static_cast<long double>(x);
+
+  // Do a binary search to find the closest value such that `checked_int_pow` recovers the input.
+  //
+  // Because we know `n > 1`, and `x > 1`, and x^n is monotonically increasing, we know that
+  // `checked_int_pow(lo, n) < x < checked_int_pow(hi, n)`.  We will preserve this as an
+  // invariant.
+  while (lo < hi) {
+    long double mid = lo + (hi - lo) / 2;
+
+    auto result = checked_int_pow(mid, n);
+
+    if (!result.has_value()) {
+      return std::nullopt;
     }
 
-    // The "first root" is trivial.
-    if (n == 1) {
-        return x;
+    // Early return if we get lucky with an exact answer.
+    if (result.value() == x) {
+      return static_cast<T>(mid);
     }
 
-    // We only support nontrivial roots of floating point types.
-    if (!std::is_floating_point<T>::value) {
-        return std::nullopt;
+    // Check for stagnation.
+    if (mid == lo || mid == hi) {
+      break;
     }
 
-    // Handle negative numbers: only odd roots are allowed.
-    if (x < 0) {
-        if (n % 2 == 0) {
-            return std::nullopt;
-        } else {
-            const auto negative_result = root(-x, n);
-            if (!negative_result.has_value()) {
-                return std::nullopt;
-            }
-            return static_cast<T>(-negative_result.value());
-        }
+    // Preserve the invariant that `checked_int_pow(lo, n) < x < checked_int_pow(hi, n)`.
+    if (result.value() < x) {
+      lo = mid;
+    } else {
+      hi = mid;
     }
+  }
 
-    // Handle special cases of zero and one.
-    if (x == 0 || x == 1) {
-        return x;
-    }
-
-    // Handle numbers bewtween 0 and 1.
-    if (x < 1) {
-        const auto inverse_result = root(T{1} / x, n);
-        if (!inverse_result.has_value()) {
-            return std::nullopt;
-        }
-        return static_cast<T>(T{1} / inverse_result.value());
-    }
-
-    //
-    // At this point, error conditions are finished, and we can proceed with the "core" algorithm.
-    //
-
-    // Always use `long double` for intermediate computations.  We don't ever expect people to be
-    // calling this at runtime, so we want maximum accuracy.
-    long double lo = 1.0;
-    long double hi = static_cast<long double>(x);
-
-    // Do a binary search to find the closest value such that `checked_int_pow` recovers the input.
-    //
-    // Because we know `n > 1`, and `x > 1`, and x^n is monotonically increasing, we know that
-    // `checked_int_pow(lo, n) < x < checked_int_pow(hi, n)`.  We will preserve this as an
-    // invariant.
-    while (lo < hi) {
-        long double mid = lo + (hi - lo) / 2;
-
-        auto result = checked_int_pow(mid, n);
-
-        if (!result.has_value()) {
-            return std::nullopt;
-        }
-
-        // Early return if we get lucky with an exact answer.
-        if (result.value() == x) {
-            return static_cast<T>(mid);
-        }
-
-        // Check for stagnation.
-        if (mid == lo || mid == hi) {
-            break;
-        }
-
-        // Preserve the invariant that `checked_int_pow(lo, n) < x < checked_int_pow(hi, n)`.
-        if (result.value() < x) {
-            lo = mid;
-        } else {
-            hi = mid;
-        }
-    }
-
-    // Pick whichever one gets closer to the target.
-    const auto lo_diff = x - checked_int_pow(lo, n).value();
-    const auto hi_diff = checked_int_pow(hi, n).value() - x;
-    return static_cast<T>(lo_diff < hi_diff ? lo : hi);
+  // Pick whichever one gets closer to the target.
+  const auto lo_diff = x - checked_int_pow(lo, n).value();
+  const auto hi_diff = checked_int_pow(hi, n).value() - x;
+  return static_cast<T>(lo_diff < hi_diff ? lo : hi);
 }
 
 template<typename T>
@@ -444,13 +444,11 @@ template<typename T>
     const auto final_result = (exp.den > 1) ? root(pow_result.value(), static_cast<uintmax_t>(exp.den)) : pow_result;
     if (final_result.has_value()) {
       return final_result.value();
+    } else {
+      std::abort();  // Root computation failed.
     }
-    else {
-      std::abort(); // Root computation failed.
-    }
-  }
-  else {
-    std::abort(); // Power computation failed.
+  } else {
+    std::abort();  // Power computation failed.
   }
 }
 

--- a/src/core/include/mp-units/framework/magnitude.h
+++ b/src/core/include/mp-units/framework/magnitude.h
@@ -439,9 +439,11 @@ template<typename T>
     }
   }
 
-  const auto pow_result = checked_int_pow(static_cast<widen_t<T>>(get_base_value(el)), static_cast<uintmax_t>(exp.num));
+  const auto pow_result =
+    checked_int_pow(static_cast<widen_t<T>>(get_base_value(el)), static_cast<std::uintmax_t>(exp.num));
   if (pow_result.has_value()) {
-    const auto final_result = (exp.den > 1) ? root(pow_result.value(), static_cast<uintmax_t>(exp.den)) : pow_result;
+    const auto final_result =
+      (exp.den > 1) ? root(pow_result.value(), static_cast<std::uintmax_t>(exp.den)) : pow_result;
     if (final_result.has_value()) {
       return final_result.value();
     } else {

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -23,8 +23,14 @@
 find_package(Catch2 3 REQUIRED)
 
 add_executable(
-    unit_tests_runtime distribution_test.cpp fixed_string_test.cpp fmt_test.cpp math_test.cpp atomic_test.cpp
-                       truncation_test.cpp
+    unit_tests_runtime
+    distribution_test.cpp
+    fixed_string_test.cpp
+    fmt_test.cpp
+    math_test.cpp
+    atomic_test.cpp
+    truncation_test.cpp
+    quantity_test.cpp
 )
 if(${projectPrefix}BUILD_CXX_MODULES)
     target_compile_definitions(unit_tests_runtime PUBLIC ${projectPrefix}MODULES)

--- a/test/runtime/quantity_test.cpp
+++ b/test/runtime/quantity_test.cpp
@@ -25,6 +25,7 @@
 import std;
 #else
 #include <atomic>
+#include <numbers>
 #endif
 #ifdef MP_UNITS_MODULES
 import mp_units;

--- a/test/runtime/quantity_test.cpp
+++ b/test/runtime/quantity_test.cpp
@@ -1,0 +1,74 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Chip Hogg
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <catch2/catch_test_macros.hpp>
+#ifdef MP_UNITS_IMPORT_STD
+import std;
+#else
+#include <atomic>
+#endif
+#ifdef MP_UNITS_MODULES
+import mp_units;
+#else
+#include <mp-units/math.h>
+#include <mp-units/systems/si.h>
+#endif
+
+using namespace mp_units;
+using namespace mp_units::si::unit_symbols;
+
+namespace {
+
+template<typename T>
+constexpr bool within_4_ulps(T a, T b)
+{
+  static_assert(std::is_floating_point_v<T>);
+  auto walk_ulps = [](T x, int n) {
+    while (n > 0) {
+      x = std::nextafter(x, std::numeric_limits<T>::infinity());
+      --n;
+    }
+    while (n < 0) {
+      x = std::nextafter(x, -std::numeric_limits<T>::infinity());
+      ++n;
+    }
+    return x;
+  };
+
+  return (walk_ulps(a, -4) <= b) && (b <= walk_ulps(a, 4));
+}
+
+}  // namespace
+
+// conversion requiring radical magnitudes
+TEST_CASE("unit conversions support radical magnitudes", "[conversion][radical]")
+{
+  REQUIRE(within_4_ulps(sqrt((1.0 * m) * (1.0 * km)).numerical_value_in(m), sqrt(1000.0)));
+}
+
+// Reproducing issue #474 exactly:
+TEST_CASE("Issue 474 is fixed", "[conversion][radical]")
+{
+  constexpr auto val_issue_474 = 8.0 * si::si2019::boltzmann_constant * 1000.0 * K / (std::numbers::pi * 10 * Da);
+  REQUIRE(within_4_ulps(sqrt(val_issue_474).numerical_value_in(m / s),
+                        sqrt(val_issue_474.numerical_value_in(m * m / s / s))));
+}

--- a/test/static/quantity_test.cpp
+++ b/test/static/quantity_test.cpp
@@ -24,7 +24,6 @@
 #include <mp-units/bits/hacks.h>
 #include <mp-units/ext/fixed_string.h>
 #include <mp-units/ext/type_traits.h>
-#include <mp-units/math.h>
 #include <mp-units/systems/isq/mechanics.h>
 #include <mp-units/systems/isq/space_and_time.h>
 #include <mp-units/systems/si.h>
@@ -52,25 +51,6 @@ using namespace mp_units::si::unit_symbols;
 //////////////////////////////
 // quantity class invariants
 //////////////////////////////
-
-template<typename T>
-constexpr bool within_4_ulps(T a, T b)
-{
-  static_assert(std::is_floating_point_v<T>);
-  auto walk_ulps = [](T x, int n) {
-    while (n > 0) {
-      x = std::nextafter(x, std::numeric_limits<T>::infinity());
-      --n;
-    }
-    while (n < 0) {
-      x = std::nextafter(x, -std::numeric_limits<T>::infinity());
-      ++n;
-    }
-    return x;
-  };
-
-  return (walk_ulps(a, -4) <= b) && (b <= walk_ulps(a, 4));
-}
 
 static_assert(sizeof(quantity<si::metre>) == sizeof(double));
 static_assert(sizeof(quantity<isq::length[m]>) == sizeof(double));
@@ -218,15 +198,6 @@ static_assert(std::constructible_from<quantity<isq::length[m]>, quantity<isq::le
 static_assert(std::convertible_to<quantity<isq::length[km], int>, quantity<isq::length[m]>>);
 static_assert(std::constructible_from<quantity<isq::length[km]>, quantity<isq::length[m], int>>);
 static_assert(std::convertible_to<quantity<isq::length[m], int>, quantity<isq::length[km]>>);
-
-// conversion requiring radical magnitudes
-static_assert(within_4_ulps(sqrt((1.0 * m) * (1.0 * km)).numerical_value_in(m), sqrt(1000.0)));
-
-// Reproducing issue #494 exactly:
-constexpr auto val_issue_494 = 8.0 * si::si2019::boltzmann_constant * 1000.0 * K / (std::numbers::pi * 10 * Da);
-static_assert(within_4_ulps(sqrt(val_issue_494).numerical_value_in(m / s),
-                            sqrt(val_issue_494.numerical_value_in(m* m / s / s))));
-
 
 ///////////////////////
 // obtaining a number

--- a/test/static/quantity_test.cpp
+++ b/test/static/quantity_test.cpp
@@ -53,8 +53,9 @@ using namespace mp_units::si::unit_symbols;
 // quantity class invariants
 //////////////////////////////
 
-template <typename T>
-constexpr bool within_4_ulps(T a, T b) {
+template<typename T>
+constexpr bool within_4_ulps(T a, T b)
+{
   static_assert(std::is_floating_point_v<T>);
   auto walk_ulps = [](T x, int n) {
     while (n > 0) {
@@ -223,10 +224,8 @@ static_assert(within_4_ulps(sqrt((1.0 * m) * (1.0 * km)).numerical_value_in(m), 
 
 // Reproducing issue #494 exactly:
 constexpr auto val_issue_494 = 8.0 * si::si2019::boltzmann_constant * 1000.0 * K / (std::numbers::pi * 10 * Da);
-static_assert(
-  within_4_ulps(
-    sqrt(val_issue_494).numerical_value_in(m / s),
-    sqrt(val_issue_494.numerical_value_in(m * m / s / s))));
+static_assert(within_4_ulps(sqrt(val_issue_494).numerical_value_in(m / s),
+                            sqrt(val_issue_494.numerical_value_in(m* m / s / s))));
 
 
 ///////////////////////


### PR DESCRIPTION
Since this will only ever be done at compile time (as guaranteed by
using `consteval`), we can afford to prioritize precision over speed. To
compute an Nth root, we simply do a binary search over representable
floating point numbers, looking for the number whose Nth power most
closely matches the original number.

Fixes #474.  We have included a test case reproducing the original
problem exactly.  All tests use "within 4 ULPs" as the criterion, which
is (I believe) equivalent to the googletest `EXPECT_DOUBLE_EQ`
criterion.