### PR TITLE
Run test on macOS 14 with upstream clang

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -144,6 +144,20 @@ jobs:
               conan-config: "",
             }
           - {
+              name: "Clang-18 on Apple M1 (arm64)",
+              os: macos-14,
+              compiler:
+                {
+                  type: CLANG,
+                  version: 18,
+                  cc: "/opt/homebrew/opt/llvm@18/bin/clang-18",
+                  cxx: "/opt/homebrew/opt/llvm@18/bin/clang++",
+                },
+              lib: "libc++",
+              cxx_modules: "False",
+              std_format_support: "True"
+            }
+          - {
               name: "Apple Clang 15",
               os: macos-13,
               compiler:
@@ -196,8 +210,8 @@ jobs:
         shell: bash
         run: |
           sudo apt install -y g++-${{ matrix.config.compiler.version }}
-      - name: Install Clang
-        if: matrix.config.compiler.type == 'CLANG'
+      - name: Install Clang with apt
+        if: matrix.config.compiler.type == 'CLANG' && matrix.config.os != 'macos-14'
         shell: bash
         working-directory: ${{ env.HOME }}
         run: |
@@ -205,8 +219,13 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.config.compiler.version }}
           sudo apt install -y clang-tools-${{ matrix.config.compiler.version }}
+      - name: Install Clang using homebrew
+        if: matrix.config.compiler.type == 'CLANG' && matrix.config.os == 'macos-14'
+        shell: bash
+        run: |
+          brew install llvm@18
       - name: Install Libc++
-        if: matrix.config.compiler.type == 'CLANG' && matrix.config.lib == 'libc++'
+        if: matrix.config.compiler.type == 'CLANG' && matrix.config.lib == 'libc++' && matrix.config.os != 'macos-14'
         shell: bash
         run: |
           sudo apt install -y libc++-${{ matrix.config.compiler.version }}-dev libc++abi-${{ matrix.config.compiler.version }}-dev libunwind-${{ matrix.config.compiler.version }}-dev

--- a/.github/workflows/ci-test-package-cmake.yml
+++ b/.github/workflows/ci-test-package-cmake.yml
@@ -137,6 +137,20 @@ jobs:
               std_format_support: "True"
             }
           - {
+              name: "Clang-18 on Apple M1 (arm64)",
+              os: macos-14,
+              compiler:
+                {
+                  type: CLANG,
+                  version: 18,
+                  cc: "/opt/homebrew/opt/llvm@18/bin/clang-18",
+                  cxx: "/opt/homebrew/opt/llvm@18/bin/clang++",
+                },
+              lib: "libc++",
+              cxx_modules: "False",
+              std_format_support: "True"
+            }
+          - {
               name: "Apple Clang 15",
               os: macos-14,
               compiler:
@@ -188,8 +202,8 @@ jobs:
         shell: bash
         run: |
           sudo apt install -y g++-${{ matrix.config.compiler.version }}
-      - name: Install Clang
-        if: matrix.config.compiler.type == 'CLANG'
+      - name: Install Clang with apt
+        if: matrix.config.compiler.type == 'CLANG' && matrix.config.os != 'macos-14'
         shell: bash
         working-directory: ${{ env.HOME }}
         run: |
@@ -197,8 +211,13 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.config.compiler.version }}
           sudo apt install -y clang-tools-${{ matrix.config.compiler.version }}
+      - name: Install Clang using homebrew
+        if: matrix.config.compiler.type == 'CLANG' && matrix.config.os == 'macos-14'
+        shell: bash
+        run: |
+          brew install llvm@18
       - name: Install Libc++
-        if: matrix.config.compiler.type == 'CLANG' && matrix.config.lib == 'libc++'
+        if: matrix.config.compiler.type == 'CLANG' && matrix.config.lib == 'libc++' && matrix.config.os != 'macos-14'
         shell: bash
         run: |
           sudo apt install -y libc++-${{ matrix.config.compiler.version }}-dev libc++abi-${{ matrix.config.compiler.version }}-dev libunwind-${{ matrix.config.compiler.version }}-dev

--- a/test/runtime/almost_equals.h
+++ b/test/runtime/almost_equals.h
@@ -35,7 +35,7 @@ namespace mp_units {
 
 template<Quantity T>
 struct AlmostEqualsMatcher : Catch::Matchers::MatcherGenericBase {
-  explicit AlmostEqualsMatcher(const T& target) : target_{target} {}
+  explicit AlmostEqualsMatcher(const T& target, int n_eps) : target_{target}, n_eps_{n_eps} {}
 
   template<std::convertible_to<T> U>
     requires std::same_as<typename T::rep, typename U::rep>
@@ -48,7 +48,7 @@ struct AlmostEqualsMatcher : Catch::Matchers::MatcherGenericBase {
     const auto y = common(other).numerical_value_in(common::unit);
     if constexpr (treat_as_floating_point<rep>) {
       const auto maxXYOne = std::max({rep{1}, abs(x), abs(y)});
-      return abs(x - y) <= std::numeric_limits<rep>::epsilon() * maxXYOne;
+      return abs(x - y) <= (n_eps_ * std::numeric_limits<rep>::epsilon()) * maxXYOne;
     } else {
       if (x >= 0) {
         return x - 1 <= y && y - 1 <= x;
@@ -71,12 +71,13 @@ struct AlmostEqualsMatcher : Catch::Matchers::MatcherGenericBase {
 
 private:
   const T& target_;
+  int n_eps_;
 };
 
 template<Quantity T>
-AlmostEqualsMatcher<T> AlmostEquals(const T& target)
+AlmostEqualsMatcher<T> AlmostEquals(const T& target, int n_eps = 1)
 {
-  return AlmostEqualsMatcher<T>{target};
+  return AlmostEqualsMatcher<T>{target, n_eps};
 }
 
 

--- a/test/runtime/math_test.cpp
+++ b/test/runtime/math_test.cpp
@@ -448,7 +448,7 @@ TEST_CASE("Angle trigonometric functions", "[trig][angle]")
 
     REQUIRE_THAT(sin(0 * angle[grad]), AlmostEquals(0. * one));
     REQUIRE_THAT(sin(100 * angle[grad]), AlmostEquals(1. * one));
-    REQUIRE_THAT(sin(200 * angle[grad]), AlmostEquals(0. * one));
+    REQUIRE_THAT(sin(200 * angle[grad]), AlmostEquals(0. * one, 2));
     REQUIRE_THAT(sin(300 * angle[grad]), AlmostEquals(-1. * one));
   }
 
@@ -475,7 +475,7 @@ TEST_CASE("Angle trigonometric functions", "[trig][angle]")
     REQUIRE_THAT(tan(0 * angle[grad]), AlmostEquals(0. * one));
     REQUIRE_THAT(tan(50 * angle[grad]), AlmostEquals(1. * one));
     REQUIRE_THAT(tan(150 * angle[grad]), AlmostEquals(-1. * one));
-    REQUIRE_THAT(tan(200 * angle[grad]), AlmostEquals(0. * one));
+    REQUIRE_THAT(tan(200 * angle[grad]), AlmostEquals(0. * one, 2));
   }
 }
 


### PR DESCRIPTION
macOS 14 is the only platform that tests on arm64 on GitHub Actions (and is available for public repos). We already test on macOS 14, but so far only with Apple Clang. Apple Clang isn't a widely known compiler in terms of standards compliance, so test with upstream clang should be valuable. In particular, Apply Clang doesn't seem to warn about prevision loss from `long` to `long double`, but upstream clang does. Thus, with this PR, we actually detect the causes of issue #611. #611 is already fixed on master, so the (fast-forward) merge should fix the CI issues that will appear.
