### PR TITLE
Bug: Overflow in comparison ops

### DIFF
--- a/test/static/international_test.cpp
+++ b/test/static/international_test.cpp
@@ -38,6 +38,8 @@ using namespace mp_units::international::unit_symbols;
 
 // Mass
 static_assert(100'000'000 * isq::mass[lb] == 45'359'237 * isq::mass[si::kilogram]);
+// 10^14 easily fits into int64 (which has about a range 10^19); but converted to the gcd, it doesn't!
+static_assert(100'000'000'000'000 * isq::mass[lb] == 45'359'237'000'000 * isq::mass[si::kilogram]);
 static_assert(1 * isq::mass[lb] == 16 * isq::mass[oz]);
 static_assert(1 * isq::mass[oz] == 16 * isq::mass[dr]);
 static_assert(7'000 * isq::mass[gr] == 1 * isq::mass[lb]);


### PR DESCRIPTION
Found this while working on #580. This one is in some sense related, but even a fix to #580 doesn't fix this one. In the current implementation, both operands are converted to their "common_type", which is currently defined as `quantity<gcd_unit, common_repr>`. If the conversion ratio between the two has a large numerator or denominator, the conversion to the gcd unit may easily overflow. These are the same situations in which the direct conversion currently overflows, but the result would still fit (if implemented differently). The conversion to gcd on the other hand would potentially require a significantly larger representations.

In the first commit here, I add a test case, where such a comparison overflow happens even for int64. Interestingly enough, I believe there is already a test case which overflows for int32. It just happens that, due to the internal conversion to the gcd unit currently being done in 64bit, it doesn't immediately overflow (which would fail in the constexpr context here), and the subsequent static_cast to the output overflows silently. Because the overflow happens "on both sides" of the comparison operator, the ultimate comparison results happens to turn out as expected here.