### PR TITLE
Faster CI: Sparse run matrix, cancel previous jobs on the same branch

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,6 @@ ignore =
     E712,
     # line break before binary operator
     W503
+per-file-ignores =
+    # flake8 is just plain wrong here, contradicting black
+    .github/generate-job-matrix.py:E225,E231

--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -89,7 +89,7 @@ configs = {
     for c in [make_gcc_config(ver) for ver in [12, 13, 14]]
     + [
         make_clang_config(ver, platform)
-        for ver in [16, 17, 18, 19]
+        for ver in [16, 17, 18]
         for platform in ["x86-64", "arm64"]
     ]
     + [make_apple_clang_config(ver) for ver in [15]]

--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -41,7 +41,7 @@ def make_clang_config(
     )
     match platform:
         case "x86-64":
-            ret.os = "ubuntu-24.04"
+            ret.os = "ubuntu-22.04" if version < 17 else "ubuntu-24.04"
         case "arm64":
             ret.os = "macos-14"
             pfx = f"/opt/homebrew/opt/llvm@{version}/bin/"

--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -4,7 +4,7 @@ import random
 import typing
 from types import SimpleNamespace
 
-from job_matrix import CombinationCollector, Compiler, Configuration, dataclass_to_json
+from job_matrix import CombinationCollector, Compiler, Configuration
 
 
 def make_gcc_config(version: int) -> Configuration:
@@ -155,20 +155,20 @@ def main():
 
     data = sorted(collector.combinations)
 
+    json_data = [e.as_json() for e in data]
+
     if not args.suppress_output:
-        print(
-            f"::set-output name=matrix::{json.dumps(data, default=dataclass_to_json)}"
-        )
+        print(f"::set-output name=matrix::{json.dumps(json_data)}")
 
     for dbg in args.debug:
         match dbg:
             case "yaml":
                 import yaml
 
-                json_data = json.loads(json.dumps(data, default=dataclass_to_json))
+                json_data = json.loads(json.dumps(json_data))
                 print(yaml.safe_dump(json_data))
             case "json":
-                print(json.dumps(data, default=dataclass_to_json, indent=4))
+                print(json.dumps(json_data, indent=4))
             case "combinations":
                 for e in data:
                     print(

--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -119,7 +119,12 @@ def main():
 
     rgen = random.Random(args.seed)
 
-    collector = CombinationCollector(full_matrix)
+    collector = CombinationCollector(
+        full_matrix,
+        hard_excludes=lambda e: (
+            e.formatting == "std::format" and not e.config.std_format_support
+        ),
+    )
     match args.preset:
         case None:
             pass
@@ -143,7 +148,11 @@ def main():
         case "clang-tidy":
             collector.all_combinations(config=configs["Clang-18 (x86-64)"])
         case "freestanding":
+            # TODO For some reason Clang-18 Debug with -ffreestanding does not pass CMakeTestCXXCompiler
             collector.all_combinations(
+                filter=lambda e: not (
+                    e.config.name.startswith("Clang-18") and e.build_type == "Debug"
+                ),
                 config=[configs[c] for c in ["GCC-14", "Clang-18 (x86-64)"]],
                 contracts="none",
                 std=23,

--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import random
 import typing
 from types import SimpleNamespace
@@ -157,8 +158,14 @@ def main():
 
     json_data = [e.as_json() for e in data]
 
+    output_file = os.environ.get("GITHUB_OUTPUT")
     if not args.suppress_output:
-        print(f"::set-output name=matrix::{json.dumps(json_data)}")
+        if output_file:
+            print(f"Writing outputs to {output_file}")
+            with open(output_file, "wt") as fh:
+                fh.write(f"matrix={json.dumps(json_data)}")
+        else:
+            print("No output file received!")
 
     for dbg in args.debug:
         match dbg:

--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -1,0 +1,168 @@
+import argparse
+import json
+import typing
+import itertools
+import random
+import dataclasses
+from types import SimpleNamespace
+from dataclasses import dataclass
+
+from job_matrix import Configuration, Compiler, MatrixElement, CombinationCollector, dataclass_to_json
+
+def make_gcc_config(version: int) -> Configuration:
+    return Configuration(
+        name=f"GCC-{version}",
+        os="ubuntu-24.04",
+        compiler=Compiler(
+            type="GCC",
+            version=version,
+            cc=f"gcc-{version}",
+            cxx=f"g++-{version}",
+        ),
+        cxx_modules=False,
+        std_format_support=version >= 13,
+    )
+
+
+def make_clang_config(version: int, platform: typing.Literal["x86-64", "arm64"] = "x86-64") -> Configuration:
+    ret = SimpleNamespace(
+        name=f"Clang-{version} ({platform})",
+        os=None,  # replaced below
+        compiler=SimpleNamespace(
+            type="CLANG",
+            version=version,
+            cc=f"clang-{version}",
+            cxx=f"clang++-{version}",
+        ),
+        lib="libc++",
+        cxx_modules=version >= 17,
+        std_format_support=version >= 17,
+    )
+    match platform:
+        case "x86-64":
+            ret.os = "ubuntu-24.04"
+        case "arm64":
+            ret.os = "macos-14"
+            pfx = f"/opt/homebrew/opt/llvm@{version}/bin/"
+            ret.compiler.cc = pfx + ret.compiler.cc
+            ret.compiler.cxx = pfx + ret.compiler.cxx
+        case _:
+            raise KeyError(f"Unsupported platform {platform!r} for Clang")
+    ret.compiler = Compiler(**vars(ret.compiler))
+    return Configuration(**vars(ret))
+
+
+def make_apple_clang_config(version: int) -> Configuration:
+    ret = Configuration(
+        name=f"Apple Clang {version}",
+        os="macos-13",
+        compiler=Compiler(
+            type="APPLE_CLANG",
+            version=f"{version}.0",
+            cc="clang",
+            cxx="clang++",
+        ),
+        cxx_modules=False,
+        std_format_support=False,
+    )
+    return ret
+
+
+def make_msvc_config(release: str, version: int) -> Configuration:
+    ret = Configuration(
+        name=f"MSVC {release}",
+        os="windows-2022",
+        compiler=Compiler(
+            type="MSVC",
+            version=version,
+            cc="",
+            cxx="",
+        ),
+        cxx_modules=False,
+        std_format_support=True,
+    )
+    return ret
+
+
+configs = {c.name: c for c in [make_gcc_config(ver) for ver in [12, 13, 14]]
+           + [make_clang_config(ver, platform) for ver in [16, 17, 18, 19] for platform in ["x86-64", "arm64"]]
+           + [make_apple_clang_config(ver) for ver in [15]]
+           + [make_msvc_config(release="14.4", version=194)]}
+
+full_matrix = dict(
+    config=list(configs.values()),
+    std=[20, 23],
+    formatting=["std::format", "fmtlib"],
+    contracts=["none", "gsl-lite", "ms-gsl"],
+    build_type=["Release", "Debug"],
+)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    #    parser.add_argument("-I","--include",nargs="+",action="append")
+    #    parser.add_argument("-X","--exclude",nargs="+",action="append")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--preset", default=None)
+    parser.add_argument("--debug", nargs="+", default=["combinations"])
+    parser.add_argument("--suppress-output", default=False, action="store_true")
+
+    args = parser.parse_args()
+
+    rgen = random.Random(args.seed)
+
+    collector = CombinationCollector(full_matrix)
+    match args.preset:
+        case None:
+            pass
+        case "all":
+            collector.all_combinations()
+        case "conan" | "cmake":
+            collector.all_combinations(formatting="std::format", contracts="gsl-lite", build_type="Debug", std=20)
+            collector.all_combinations(
+                filter=lambda me: not me.config.std_format_support,
+                formatting="fmtlib", contracts="gsl-lite", build_type="Debug", std=20,
+            )
+            collector.sample_combinations(rgen=rgen, min_samples_per_value=2)
+        case "clang-tidy":
+            collector.all_combinations(config=configs["Clang-18 (x86-64)"])
+        case "freestanding":
+            collector.all_combinations(
+                config=[configs[c] for c in ["GCC-14", "Clang-18 (x86-64)"]],
+                contracts="none",
+                std=23,
+            )
+        case _:
+            raise KeyError(f"Unsupported preset {args.preset!r}")
+
+    if not collector.combinations:
+        raise ValueError(f"No combination has been produced")
+
+    data = sorted(collector.combinations)
+
+    if not args.suppress_output:
+        print(f"::set-output name=matrix::{json.dumps(data, default=dataclass_to_json)}")
+
+    for dbg in args.debug:
+        match dbg:
+            case "yaml":
+                import yaml
+                json_data = json.loads(json.dumps(data, default=dataclass_to_json))
+                print(yaml.safe_dump(json_data))
+            case "json":
+                print(json.dumps(data, default=dataclass_to_json, indent=4))
+            case "combinations":
+                for e in data:
+                    print(f"{e.config!s:17s}  c++{e.std:2d}  {e.formatting:11s}  {e.contracts:8s}  {e.build_type:8s}")
+            case "counts":
+                print(f"Total combinations {len(data)}")
+                for (k, v), n in sorted(collector.per_value_counts.items()):
+                    print(f"  {k}={v}: {n}")
+            case "none":
+                pass
+            case _:
+                raise KeyError(f"Unknown debug mode {dbg!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/job_matrix.py
+++ b/.github/job_matrix.py
@@ -1,0 +1,113 @@
+import argparse
+import json
+import typing
+import itertools
+import random
+import dataclasses
+from types import SimpleNamespace
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, order=True)
+class Compiler:
+    type: typing.Literal["GCC", "CLANG", "APPLE_CLANG", "MSVC"]
+    version: str | int
+    cc: str
+    cxx: str
+
+
+@dataclass(frozen=True, order=True)
+class Configuration:
+    name: str
+    os: str
+    compiler: Compiler
+    cxx_modules: bool
+    std_format_support: bool
+    conan_config: str = ""
+    lib: typing.Literal["libc++", "libstdc++"] | None = None
+
+    def __str__(self):
+        return self.name
+
+@dataclass(frozen=True, order=True)
+class MatrixElement:
+    config: Configuration
+    std: typing.Literal[20, 23]
+    formatting: typing.Literal["std::format", "fmtlib"]
+    contracts: typing.Literal["none", "gsl-lite", "ms-gsl"]
+    build_type: typing.Literal["Release", "Debug"]
+
+
+def dataclass_to_json(obj):
+    """ Convert dataclasses to something json-serialisable """
+    if dataclasses.is_dataclass(obj):
+        return dataclasses.asdict(obj)
+    raise TypeError(f"Unknown object of type {type(obj).__name__}")
+
+
+class CombinationCollector:
+    """ Incremental builder of MatrixElements, allowing successive selection of entries.
+    """
+
+    def __init__(self, full_matrix: dict[str, list[typing.Any]]):
+        self.full_matrix = full_matrix
+        self.combinations: set[MatrixElement] = set()
+        self.per_value_counts: dict[tuple[str, typing.Any], int] = {(k, v): 0 for k, options in full_matrix.items() for
+                                                                    v in options}
+
+    def _make_submatrix(self, **overrides):
+        new_matrix = dict(self.full_matrix)
+        for k, v in overrides.items():
+            if not isinstance(v, list):
+                v = [v]
+            new_matrix[k] = v
+        return new_matrix
+
+    def _add_combination(self, e: MatrixElement):
+        if e in self.combinations or (e.formatting == "std::format" and not e.config.std_format_support):
+            return
+        self.combinations.add(e)
+        # update per_value_counts
+        for k, v in vars(e).items():
+            idx = (k, v)
+            self.per_value_counts[idx] = self.per_value_counts.get(idx, 0) + 1
+
+    def all_combinations(self, *, filter: typing.Callable[[MatrixElement], bool] | None = None, **overrides):
+        """ Adds all combinations in the submatrix defined by `overrides`. """
+        matrix = self._make_submatrix(**overrides)
+        keys = tuple(matrix.keys())
+        for combination in itertools.product(*matrix.values()):
+            cand = MatrixElement(**dict(zip(keys, combination)))
+            if filter and not filter(cand):
+                continue
+            self._add_combination(cand)
+
+    def sample_combinations(self, *, rgen: random.Random, min_samples_per_value: int = 1,
+                            filter: typing.Callable[[MatrixElement], bool] | None = None, **overrides):
+        """ Adds samples from the submatrix defined by `overrides`, ensuring each individual value appears at least n times. """
+        matrix = self._make_submatrix(**overrides)
+        missing: dict[tuple[str, typing.Any], int] = {}
+        for key, options in matrix.items():
+            for value in options:
+                idx = (key, value)
+                missing[idx] = min_samples_per_value - self.per_value_counts.get(idx, 0)
+        while missing:
+            (force_key, force_option), remaining = next(iter(missing.items()))
+            if remaining <= 0:
+                missing.pop((force_key, force_option))
+                continue
+            choice = {}
+            for key, options in matrix.items():
+                choice[key] = force_option if key == force_key else rgen.choice(options)
+            cand = MatrixElement(**choice)
+            if filter and not filter(cand):
+                continue
+            self._add_combination(cand)
+            for idx in choice.items():
+                if missing.pop(idx, 0) <= 0:
+                    continue
+                remaining = min_samples_per_value - self.per_value_counts.get(idx, 0)
+                if remaining > 0:
+                    missing[idx] = remaining
+
+

--- a/.github/job_matrix.py
+++ b/.github/job_matrix.py
@@ -55,8 +55,14 @@ class MatrixElement:
 class CombinationCollector:
     """Incremental builder of MatrixElements, allowing successive selection of entries."""
 
-    def __init__(self, full_matrix: dict[str, list[typing.Any]]):
+    def __init__(
+        self,
+        full_matrix: dict[str, list[typing.Any]],
+        *,
+        hard_excludes: typing.Callable[[MatrixElement], bool] | None = None,
+    ):
         self.full_matrix = full_matrix
+        self.hard_excludes = hard_excludes
         self.combinations: set[MatrixElement] = set()
         self.per_value_counts: dict[tuple[str, typing.Any], int] = {
             (k, v): 0 for k, options in full_matrix.items() for v in options
@@ -72,7 +78,7 @@ class CombinationCollector:
 
     def _add_combination(self, e: MatrixElement):
         if e in self.combinations or (
-            e.formatting == "std::format" and not e.config.std_format_support
+            self.hard_excludes is not None and self.hard_excludes(e)
         ):
             return
         self.combinations.add(e)

--- a/.github/job_matrix.py
+++ b/.github/job_matrix.py
@@ -35,12 +35,21 @@ class MatrixElement:
     contracts: typing.Literal["none", "gsl-lite", "ms-gsl"]
     build_type: typing.Literal["Release", "Debug"]
 
+    def as_json(self):
+        def dataclass_to_json(obj):
+            """Convert dataclasses to something json-serialisable"""
+            if dataclasses.is_dataclass(obj):
+                return {
+                    k: dataclass_to_json(v) for k, v in dataclasses.asdict(obj).items()
+                }
+            return obj
 
-def dataclass_to_json(obj):
-    """Convert dataclasses to something json-serialisable"""
-    if dataclasses.is_dataclass(obj):
-        return dataclasses.asdict(obj)
-    raise TypeError(f"Unknown object of type {type(obj).__name__}")
+        ret = dataclass_to_json(self)
+        # patch boolean conan configuration options
+        config = ret["config"]
+        for k in ["cxx_modules"]:
+            config[k] = "True" if config[k] else "False"
+        return ret
 
 
 class CombinationCollector:

--- a/.github/workflows/ci-clang-tidy.yml
+++ b/.github/workflows/ci-clang-tidy.yml
@@ -35,32 +35,33 @@ on:
       - "docs/**"
 
 jobs:
+  cancel-previous:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
+  generate-matrix:
+    name: "Generate build matrix for ${{ github.workflow }}"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-24.04
+    needs: cancel-previous
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - id: set-matrix
+        run: python .github/generate-job-matrix.py --preset clang-tidy --seed 42 --debug combinations counts
   build:
     name: "${{ matrix.formatting }} ${{ matrix.contracts }} C++${{ matrix.std }} ${{ matrix.config.name }} ${{ matrix.build_type }}"
     runs-on: ${{ matrix.config.os }}
+    needs: generate-matrix
     strategy:
       fail-fast: false
       matrix:
-        formatting: ["std::format", "fmtlib"]
-        contracts: ["none", "gsl-lite", "ms-gsl"]
-        std: [20, 23]
-        config:
-          - {
-              name: "Clang-18",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 18,
-                  cc: "clang-18",
-                  cxx: "clang++-18",
-                },
-              lib: "libc++",
-              cxx_modules: "False",
-              std_format_support: "True",
-              conan-config: "",
-            }
-        build_type: ["Release", "Debug"]
+        include: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
 
     env:
       CC: ${{ matrix.config.compiler.cc }}

--- a/.github/workflows/ci-clang-tidy.yml
+++ b/.github/workflows/ci-clang-tidy.yml
@@ -46,6 +46,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci-clang-tidy.yml
+++ b/.github/workflows/ci-clang-tidy.yml
@@ -34,20 +34,17 @@ on:
     paths-ignore:
       - "docs/**"
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  cancel-previous:
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    runs-on: ubuntu-24.04
-    steps:
-      - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
   generate-matrix:
     name: "Generate build matrix for ${{ github.workflow }}"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-24.04
-    needs: cancel-previous
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci-clang-tidy.yml
+++ b/.github/workflows/ci-clang-tidy.yml
@@ -39,6 +39,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
   generate-matrix:

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -44,6 +44,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -38,6 +38,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
   generate-matrix:

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -34,148 +34,36 @@ env:
   CHANNEL: ${{ fromJSON('["testing", "stable"]')[github.ref_type == 'tag' && startsWith(github.ref_name, 'v')] }}
 
 jobs:
+  cancel-previous:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
+  generate-matrix:
+    name: "Generate build matrix for ${{ github.workflow }}"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-24.04
+    needs: cancel-previous
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - id: set-matrix
+        run: python .github/generate-job-matrix.py --preset conan --seed 42 --debug combinations counts
   build:
     name: "${{ matrix.formatting }} ${{ matrix.contracts }} C++${{ matrix.std }} ${{ matrix.config.name }} ${{ matrix.build_type }}"
     runs-on: ${{ matrix.config.os }}
+    needs: generate-matrix
     strategy:
       fail-fast: false
       matrix:
-        formatting: ["std::format", "fmtlib"]
-        contracts: ["none", "gsl-lite", "ms-gsl"]
-        std: [20, 23]
-        config:
-          - {
-              name: "MSVC 14.4",
-              os: windows-2022,
-              compiler: { type: MSVC, version: 194, cc: "", cxx: "" },
-              cxx_modules: "False",
-              std_format_support: "True",
-              conan-config: "",
-            }
-          - {
-              name: "GCC-12",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: GCC,
-                  version: 12,
-                  cc: "gcc-12",
-                  cxx: "g++-12",
-                },
-              cxx_modules: "False",
-              std_format_support: "False",
-              conan-config: "",
-            }
-          - {
-              name: "GCC-13",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: GCC,
-                  version: 13,
-                  cc: "gcc-13",
-                  cxx: "g++-13",
-                },
-              cxx_modules: "False",
-              std_format_support: "True",
-              conan-config: "",
-            }
-          - {
-              name: "GCC-14",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: GCC,
-                  version: 14,
-                  cc: "gcc-14",
-                  cxx: "g++-14",
-                },
-              cxx_modules: "False",
-              std_format_support: "True",
-              conan-config: "",
-            }
-          - {
-              name: "Clang-16",
-              os: ubuntu-22.04,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 16,
-                  cc: "clang-16",
-                  cxx: "clang++-16",
-                },
-              lib: "libc++",
-              cxx_modules: "False",
-              std_format_support: "False",
-              conan-config: "",
-            }
-          - {
-              name: "Clang-17",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 17,
-                  cc: "clang-17",
-                  cxx: "clang++-17",
-                },
-              lib: "libc++",
-              cxx_modules: "True",
-              std_format_support: "True",
-              conan-config: "",
-            }
-          - {
-              name: "Clang-18",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 18,
-                  cc: "clang-18",
-                  cxx: "clang++-18",
-                },
-              lib: "libc++",
-              cxx_modules: "True",
-              std_format_support: "True",
-              conan-config: "",
-            }
-          - {
-              name: "Clang-18 on Apple M1 (arm64)",
-              os: macos-14,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 18,
-                  cc: "/opt/homebrew/opt/llvm@18/bin/clang-18",
-                  cxx: "/opt/homebrew/opt/llvm@18/bin/clang++",
-                },
-              lib: "libc++",
-              cxx_modules: "False",
-              std_format_support: "True"
-            }
-          - {
-              name: "Apple Clang 15",
-              os: macos-13,
-              compiler:
-                {
-                  type: APPLE_CLANG,
-                  version: "15.0",
-                  cc: "clang",
-                  cxx: "clang++",
-                },
-              cxx_modules: "False",
-              std_format_support: "False",
-              conan-config: "",
-            }
-        build_type: ["Release", "Debug"]
-        exclude:
-          - formatting: "std::format"
-            config: { std_format_support: "False" }
-
+        include: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
     env:
       CC: ${{ matrix.config.compiler.cc }}
       CXX: ${{ matrix.config.compiler.cxx }}
-
     steps:
       - uses: actions/checkout@v4
       - name: Generate unique cache id
@@ -265,14 +153,14 @@ jobs:
         run: |
           conan create . --user mpusz --channel ${CHANNEL} --lockfile-out=package.lock \
                          -b mp-units/* -b missing -c tools.cmake.cmaketoolchain:generator="Ninja Multi-Config" -c user.mp-units.build:all=True \
-                         -o '&:cxx_modules=${{ matrix.config.cxx_modules }}' -o '&:import_std=${{ env.import_std }}' -o '&:std_format=${{ env.std_format }}' -o '&:contracts=${{ matrix.contracts }}' ${{ matrix.config.conan-config }}
+                         -o '&:cxx_modules=${{ matrix.config.cxx_modules }}' -o '&:import_std=${{ env.import_std }}' -o '&:std_format=${{ env.std_format }}' -o '&:contracts=${{ matrix.contracts }}' ${{ matrix.config.conan_config }}
       - name: Create Conan package
         if: matrix.config.compiler.type == 'MSVC'
         shell: bash
         run: |
           conan create . --user mpusz --channel ${CHANNEL} --lockfile-out=package.lock \
                          -b mp-units/* -b missing -c tools.cmake.cmaketoolchain:generator="Ninja Multi-Config" -c user.mp-units.build:all=False \
-                         -o '&:cxx_modules=${{ matrix.config.cxx_modules }}' -o '&:import_std=${{ env.import_std }}' -o '&:std_format=${{ env.std_format }}' -o '&:contracts=${{ matrix.contracts }}' ${{ matrix.config.conan-config }}
+                         -o '&:cxx_modules=${{ matrix.config.cxx_modules }}' -o '&:import_std=${{ env.import_std }}' -o '&:std_format=${{ env.std_format }}' -o '&:contracts=${{ matrix.contracts }}' ${{ matrix.config.conan_config }}
       - name: Obtain package reference
         id: get-package-ref
         shell: bash

--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -33,20 +33,16 @@ on:
 env:
   CHANNEL: ${{ fromJSON('["testing", "stable"]')[github.ref_type == 'tag' && startsWith(github.ref_name, 'v')] }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  cancel-previous:
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    runs-on: ubuntu-24.04
-    steps:
-      - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
   generate-matrix:
     name: "Generate build matrix for ${{ github.workflow }}"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-24.04
-    needs: cancel-previous
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci-formatting.yml
+++ b/.github/workflows/ci-formatting.yml
@@ -24,6 +24,10 @@ name: Formatting CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci-freestanding.yml
+++ b/.github/workflows/ci-freestanding.yml
@@ -45,6 +45,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci-freestanding.yml
+++ b/.github/workflows/ci-freestanding.yml
@@ -35,46 +35,33 @@ on:
       - "docs/**"
 
 jobs:
+  cancel-previous:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
+  generate-matrix:
+    name: "Generate build matrix for ${{ github.workflow }}"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-24.04
+    needs: cancel-previous
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - id: set-matrix
+        run: python .github/generate-job-matrix.py --preset freestanding --seed 42 --debug combinations counts
   build:
     name: "${{ matrix.formatting }} ${{ matrix.contracts }} C++${{ matrix.std }} ${{ matrix.config.name }} ${{ matrix.build_type }}"
     runs-on: ${{ matrix.config.os }}
+    needs: generate-matrix
     strategy:
       fail-fast: false
       matrix:
-        formatting: ["std::format", "fmtlib"]
-        contracts: ["none"]
-        std: [23]
-        config:
-          - {
-              name: "GCC-14",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: GCC,
-                  version: 14,
-                  cc: "gcc-14",
-                  cxx: "g++-14",
-                },
-              cxx_modules: "False",
-              std_format_support: "True",
-              conan-config: "",
-            }
-          - {
-              name: "Clang-18",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 18,
-                  cc: "clang-18",
-                  cxx: "clang++-18",
-                },
-              lib: "libc++",
-              cxx_modules: "True",
-              std_format_support: "True",
-              conan-config: "",
-            }
-        build_type: ["Release", "Debug"]
+        include: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
         # TODO For some reason Clang-18 Debug with -ffreestanding does not pass CMakeTestCXXCompiler
         exclude:
           - build_type: "Debug"

--- a/.github/workflows/ci-freestanding.yml
+++ b/.github/workflows/ci-freestanding.yml
@@ -39,6 +39,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
   generate-matrix:

--- a/.github/workflows/ci-freestanding.yml
+++ b/.github/workflows/ci-freestanding.yml
@@ -60,10 +60,6 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
-        # TODO For some reason Clang-18 Debug with -ffreestanding does not pass CMakeTestCXXCompiler
-        exclude:
-          - build_type: "Debug"
-            config: { name: "Clang-18" }
 
     env:
       CC: ${{ matrix.config.compiler.cc }}

--- a/.github/workflows/ci-freestanding.yml
+++ b/.github/workflows/ci-freestanding.yml
@@ -34,20 +34,16 @@ on:
     paths-ignore:
       - "docs/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  cancel-previous:
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    runs-on: ubuntu-24.04
-    steps:
-      - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
   generate-matrix:
     name: "Generate build matrix for ${{ github.workflow }}"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-24.04
-    needs: cancel-previous
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci-test-package-cmake.yml
+++ b/.github/workflows/ci-test-package-cmake.yml
@@ -39,135 +39,33 @@ on:
       - "test/**"
 
 jobs:
+  cancel-previous:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
+  generate-matrix:
+    name: "Generate build matrix for ${{ github.workflow }}"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-24.04
+    needs: cancel-previous
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - id: set-matrix
+        run: python .github/generate-job-matrix.py --preset conan --seed 42 --debug combinations counts
   test_package:
     name: "${{ matrix.formatting }} ${{ matrix.contracts }} C++${{ matrix.std }} ${{ matrix.config.name }} ${{ matrix.build_type }}"
     runs-on: ${{ matrix.config.os }}
+    needs: generate-matrix
     strategy:
       fail-fast: false
       matrix:
-        formatting: ["std::format", "fmtlib"]
-        contracts: ["none", "gsl-lite", "ms-gsl"]
-        std: [20, 23]
-        config:
-          - {
-              name: "MSVC 14.4",
-              os: windows-2022,
-              compiler: { type: MSVC, version: 194, cc: "", cxx: "" },
-              cxx_modules: "False",
-              std_format_support: "True",
-            }
-          - {
-              name: "GCC-12",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: GCC,
-                  version: 12,
-                  cc: "gcc-12",
-                  cxx: "g++-12",
-                },
-              cxx_modules: "False",
-              std_format_support: "False",
-            }
-          - {
-              name: "GCC-13",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: GCC,
-                  version: 13,
-                  cc: "gcc-13",
-                  cxx: "g++-13",
-                },
-              cxx_modules: "False",
-              std_format_support: "True",
-            }
-          - {
-              name: "GCC-14",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: GCC,
-                  version: 14,
-                  cc: "gcc-14",
-                  cxx: "g++-14",
-                },
-              cxx_modules: "False",
-              std_format_support: "True"
-            }
-          - {
-              name: "Clang-16",
-              os: ubuntu-22.04,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 16,
-                  cc: "clang-16",
-                  cxx: "clang++-16",
-                },
-              lib: "libc++",
-              cxx_modules: "False",
-              std_format_support: "False",
-            }
-          - {
-              name: "Clang-17",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 17,
-                  cc: "clang-17",
-                  cxx: "clang++-17",
-                },
-              lib: "libc++",
-              cxx_modules: "False",
-              std_format_support: "True",
-            }
-          - {
-              name: "Clang-18",
-              os: ubuntu-24.04,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 18,
-                  cc: "clang-18",
-                  cxx: "clang++-18",
-                },
-              lib: "libc++",
-              cxx_modules: "False",
-              std_format_support: "True"
-            }
-          - {
-              name: "Clang-18 on Apple M1 (arm64)",
-              os: macos-14,
-              compiler:
-                {
-                  type: CLANG,
-                  version: 18,
-                  cc: "/opt/homebrew/opt/llvm@18/bin/clang-18",
-                  cxx: "/opt/homebrew/opt/llvm@18/bin/clang++",
-                },
-              lib: "libc++",
-              cxx_modules: "False",
-              std_format_support: "True"
-            }
-          - {
-              name: "Apple Clang 15",
-              os: macos-14,
-              compiler:
-                {
-                  type: APPLE_CLANG,
-                  version: "15.0",
-                  cc: "clang",
-                  cxx: "clang++",
-                },
-              cxx_modules: "False",
-              std_format_support: "False",
-            }
-        build_type: ["Release", "Debug"]
-        exclude:
-          - formatting: "std::format"
-            config: { std_format_support: "False" }
+        include: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
 
     env:
       CC: ${{ matrix.config.compiler.cc }}

--- a/.github/workflows/ci-test-package-cmake.yml
+++ b/.github/workflows/ci-test-package-cmake.yml
@@ -43,6 +43,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
   generate-matrix:

--- a/.github/workflows/ci-test-package-cmake.yml
+++ b/.github/workflows/ci-test-package-cmake.yml
@@ -38,20 +38,16 @@ on:
       - "example/**"
       - "test/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  cancel-previous:
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    runs-on: ubuntu-24.04
-    steps:
-      - run: echo "Cancelling all previous runs of ${{ github.workflow }}-${{ github.ref }}"
   generate-matrix:
     name: "Generate build matrix for ${{ github.workflow }}"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-24.04
-    needs: cancel-previous
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci-test-package-cmake.yml
+++ b/.github/workflows/ci-test-package-cmake.yml
@@ -49,6 +49,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/citation.yml
+++ b/.github/workflows/citation.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - CITATION.cff
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Validate-CITATION-cff:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,10 @@ on:
     paths-ignore:
       - "docs/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,6 +36,11 @@ on:
       - "mkdocs.yml"
 permissions:
   contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR starts using a [dynamic run matrix](https://github.blog/changelog/2020-04-15-github-actions-new-workflow-features/#new-fromjson-method-in-expressions) in the four heavier workflows.

It uses a small python script to generate a subset of all possible combinations. For the two biggest workflows (Conan and CMake), it currently employs the following strategy:
1. Test each compiler/platform with a single configuration:
  - C++20
  - `std::format` where supported
  - contract checking with `gsl-lite`
  - Debug build
2. Then, it adds randomly selected combinations until each individual settings value appears in at least two combinations

This currently generates 26 different combinations, out of 261 total acceptable combinations (I added Clang 19 to the test-set).

Hopefully, the python code to generate the run matrix is readable enough. 

Another feature I added is [to use concurrency groups to cancel previous runs on the same branch that haven't completed yet](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs)