### PR TITLE
Update Xcode versions for apple-clang builds

### DIFF
--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -53,13 +53,13 @@ def make_clang_config(
     return Configuration(**vars(ret))
 
 
-def make_apple_clang_config(version: int) -> Configuration:
+def make_apple_clang_config(os: str, version: str) -> Configuration:
     ret = Configuration(
         name=f"Apple Clang {version}",
-        os="macos-13",
+        os=os,
         compiler=Compiler(
             type="APPLE_CLANG",
-            version=f"{version}.0",
+            version=version,
             cc="clang",
             cxx="clang++",
         ),
@@ -95,7 +95,8 @@ configs = {
         # arm64 runners are expensive; only consider one version
         if ver == 18 or platform != "arm64"
     ]
-    + [make_apple_clang_config(ver) for ver in [15]]
+    + [make_apple_clang_config("macos-13", ver) for ver in ["15.2"]]
+    + [make_apple_clang_config("macos-14", ver) for ver in ["15.4", "16.1"]]
     + [make_msvc_config(release="14.4", version=194)]
 }
 

--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -96,7 +96,7 @@ configs = {
         if ver == 18 or platform != "arm64"
     ]
     + [make_apple_clang_config("macos-13", ver) for ver in ["15.2"]]
-    + [make_apple_clang_config("macos-14", ver) for ver in ["15.4", "16.1"]]
+    + [make_apple_clang_config("macos-14", ver) for ver in ["16.1"]]
     + [make_msvc_config(release="14.4", version=194)]
 }
 


### PR DESCRIPTION
Since mp-units requires at least Xcode 15 we should have coverage on the latest compilers for operating system versions for macOS 13 (Ventura) and macOS 14 (Sequoia) as those are the operating systems with necessary compilers that our users would be using.

Now build with Xcode 15.2 instead of 15.0.1 which last version supported on macOS 13.

Add a build for Xcode 15.4 and Xcode 16.1 for testing macOS 14 builds. Since Xcode 16.1 is new most of our clients using macOS 14 would might more likely be using Xcode 15.4.

There might not be much C++ changes between Xcode 15.2 and Xcode 15.4 so perhaps we should drop 15.4 if adding three apple-clang builds is not worth the resources.