### PR TITLE
Fixes for apple-clang crashes and performance issues

### DIFF
--- a/src/core/include/mp-units/bits/hacks.h
+++ b/src/core/include/mp-units/bits/hacks.h
@@ -151,4 +151,8 @@ MP_UNITS_DIAGNOSTIC_POP
 #define MP_UNITS_API_NO_CRTP 1
 
 #endif
+
+#if defined(__clang__) && defined(__apple_build_version__) && __apple_build_version__ < 16000026
+#define MP_UNITS_APPLE_CLANG_HACKS
+#endif
 // NOLINTEND(bugprone-reserved-identifier, cppcoreguidelines-macro-usage)

--- a/test/static/concepts_test.cpp
+++ b/test/static/concepts_test.cpp
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <mp-units/bits/hacks.h>
 #include <mp-units/systems/isq/space_and_time.h>
 #include <mp-units/systems/natural.h>
 #include <mp-units/systems/si.h>
@@ -308,7 +309,9 @@ static_assert(!RepresentationOf<std::complex<double>, quantity_character::scalar
 static_assert(!RepresentationOf<std::complex<double>, quantity_character::vector>);
 static_assert(!RepresentationOf<std::complex<double>, quantity_character::tensor>);
 static_assert(RepresentationOf<cartesian_vector<double>, quantity_character::vector>);
+#ifndef MP_UNITS_APPLE_CLANG_HACKS
 static_assert(!RepresentationOf<cartesian_vector<double>, quantity_character::scalar>);
+#endif
 static_assert(!RepresentationOf<cartesian_vector<double>, quantity_character::complex>);
 static_assert(!RepresentationOf<cartesian_vector<double>, quantity_character::tensor>);
 static_assert(!RepresentationOf<std::chrono::seconds, quantity_character::scalar>);

--- a/test/static/quantity_test.cpp
+++ b/test/static/quantity_test.cpp
@@ -65,6 +65,8 @@ static_assert(sizeof(quantity<isq::length[m]>) == sizeof(double));
 static_assert(sizeof(quantity<si::metre, short>) == sizeof(short));
 static_assert(sizeof(quantity<isq::length[m], short>) == sizeof(short));
 
+#ifndef MP_UNITS_APPLE_CLANG_HACKS
+
 template<template<auto, typename> typename Q>
 concept invalid_types = requires {
   requires !requires { typename Q<isq::dim_length, double>; };  // dimension instead of reference
@@ -77,12 +79,14 @@ concept invalid_types = requires {
   };  // vector representation expected
   requires !requires {
     typename Q<isq::length[si::metre], cartesian_vector<double>>;
-  };  // scalar representation expected
+  };                                                                          // scalar representation expected
   requires !requires { typename Q<isq::voltage[V], std::complex<double>>; };  // incompatible character
   requires !requires { typename Q<isq::voltage_phasor[V], double>; };         // incompatible character
 #endif
 };
 static_assert(invalid_types<quantity>);
+
+#endif
 
 static_assert(std::is_trivially_default_constructible_v<quantity<isq::length[m]>>);
 static_assert(std::is_trivially_copy_constructible_v<quantity<isq::length[m]>>);


### PR DESCRIPTION
The source of the crash with the latest changes seemed to be from the `IsOfCharacter` concept.  This concept was refactored to use some type traits and more simple concepts although with less strict requirements.

A new macro, `MP_UNITS_APPLE_CLANG_HACKS` was added to mp-units/bits/hacks.h to enable work arounds for pre-Xcode 16.1 apple-clang.

Some tests were not passing and were removed with the preprocessor macro for apple-clang hacks is defined.

Adding `ComplexFunctionsAvailable` and `VectorFunctionsAvailable` fixed some test failures in concepts_test.cpp but not all.