### PR TITLE
Enable use of std::format for AppleClang / Xcode 16

### DIFF
--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -53,7 +53,9 @@ def make_clang_config(
     return Configuration(**vars(ret))
 
 
-def make_apple_clang_config(os: str, version: str) -> Configuration:
+def make_apple_clang_config(
+    os: str, version: str, std_format_support: bool
+) -> Configuration:
     ret = Configuration(
         name=f"Apple Clang {version}",
         os=os,
@@ -64,7 +66,7 @@ def make_apple_clang_config(os: str, version: str) -> Configuration:
             cxx="clang++",
         ),
         cxx_modules=False,
-        std_format_support=False,
+        std_format_support=std_format_support,
     )
     return ret
 
@@ -95,8 +97,15 @@ configs = {
         # arm64 runners are expensive; only consider one version
         if ver == 18 or platform != "arm64"
     ]
-    + [make_apple_clang_config("macos-13", ver) for ver in ["15.2"]]
-    + [make_apple_clang_config("macos-14", ver) for ver in ["16.1"]]
+    + [
+        make_apple_clang_config("macos-13", ver, std_format_support=False)
+        for ver in ["15.2"]
+    ]
+    # std::format is available in Xcode 16.1 or later
+    + [
+        make_apple_clang_config("macos-14", ver, std_format_support=True)
+        for ver in ["16.1"]
+    ]
     + [make_msvc_config(release="14.4", version=194)]
 }
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -99,7 +99,7 @@ class MPUnitsConan(ConanFile):
                 "compiler": {
                     "gcc": "13",
                     "clang": "17",
-                    "apple-clang": "",
+                    "apple-clang": "16",
                     "msvc": "194",
                 },
             },

--- a/docs/getting_started/cpp_compiler_support.md
+++ b/docs/getting_started/cpp_compiler_support.md
@@ -16,7 +16,7 @@ C++ feature:
 | C++ Feature                                               | C++ version | gcc  | clang | apple-clang |                   MSVC                    |
 |-----------------------------------------------------------|:-----------:|:----:|:-----:|:-----------:|:-----------------------------------------:|
 | **Minimum support**                                       |     20      |  12  |  16   |     15      | 194 :bug:{ title="BEWARE of MSVC Bugs!" } |
-| **`std::format`**                                         |     20      |  13  |  17   |    None     |                    194                    |
+| **`std::format`**                                         |     20      |  13  |  17   |     16      |                    194                    |
 | **C++ modules**                                           |     20      | None |  17   |    None     |                   None                    |
 | **`import std;`**                                         |     23      | None |  18   |    None     |                   None                    |
 | **Explicit `this` parameter**                             |     23      |  14  |  18   |    None     |                   None                    |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,13 +53,15 @@ check_cxx_feature_supported(__cpp_explicit_this_parameter ${projectPrefix}EXPLIC
 
 # libc++ has a basic supports for std::format but does not set __cpp_lib_format
 # https://github.com/llvm/llvm-project/issues/77773
-if(NOT ${projectPrefix}LIB_FORMAT_SUPPORTED
-   AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
-   AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "17"
-   AND ${projectPrefix}LIBCXX
-)
-    message(STATUS "Clang 17+ with libc++ detected, overriding `std::format` support")
-    set(${projectPrefix}LIB_FORMAT_SUPPORTED ON)
+if(NOT ${projectPrefix}LIB_FORMAT_SUPPORTED AND ${projectPrefix}LIBCXX)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "17")
+        message(STATUS "Clang 17+ with libc++ detected, overriding `std::format` support")
+        set(${projectPrefix}LIB_FORMAT_SUPPORTED ON)
+    endif()
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "16")
+        message(STATUS "AppleClang 16+ with libc++ detected, overriding `std::format` support")
+        set(${projectPrefix}LIB_FORMAT_SUPPORTED ON)
+    endif()
 endif()
 
 # clang++-18 supports explicit `this` parameter


### PR DESCRIPTION
Specified the minimum apple-clang version to support `std::format` to 16 for _connanfile.py_.  Xcode 16 does include the `<format>` header but does not seem to have the __cpp_lib_format compatibility macro defined so a similar override was needed as we had for Clang 17.

To be able to use `std::format` with Xcode 16 I had to pass `-DMP_UNITS_API_STD_FORMAT=AUTO` when calling `cmake`.  Is this expected or is this a sign I missed something in my changes to _CMakeLists.txt_?

- [x]  Wait until #651 merges and rebase this so we have Xcode 16 CI coverage