### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ CMakeUserPresets.json
 # cxxdraft-htmlgen
 docs/api_reference/src/source/
 docs/api_reference/gen
+
+# macOS files
+.DS_Store


### PR DESCRIPTION
This file is added by macOS (e.g. when browsing the directory in Finder).