### PR TITLE
fix: `quantity_spec` missing lint block end

### DIFF
--- a/src/core/include/mp-units/framework/quantity_spec.h
+++ b/src/core/include/mp-units/framework/quantity_spec.h
@@ -1081,6 +1081,7 @@ template<QuantitySpec From, QuantitySpec To>
     return detail::convertible_named(from, to);
   else
     return detail::are_ingredients_convertible(from, to);
+  // NOLINTEND(bugprone-branch-clone)
 }
 
 template<QuantitySpec From, QuantitySpec To>


### PR DESCRIPTION
Add a missing lint `bugprone-branch-clone` block closing for function `convertible_impl` in file `quantity_spec`. The following error is solved in consumer code:
```
[...]/mp-units-src/src/core/include/mp-units/framework/quantity_spec.h:1073:6:
error: unmatched 'NOLINTBEGIN' comment without a subsequent 'NOLINTEND' comment [clang-tidy-nolint]
 1073 |   // NOLINTBEGIN(bugprone-branch-clone)
      |      ^
```