### PR TITLE
Add static tests for concept DimensionOf

### DIFF
--- a/test/static/concepts_test.cpp
+++ b/test/static/concepts_test.cpp
@@ -98,7 +98,8 @@ static_assert(!DimensionOf<struct isq::time, isq::dim_length>);
 static_assert(!DimensionOf<struct isq::time, isq::length>);
 static_assert(DimensionOf<decltype(isq::dim_length / isq::dim_time), isq::speed.dimension>);
 static_assert(DimensionOf<decltype(isq::force.dimension * isq::time.dimension), isq::impulse.dimension>);
-static_assert(DimensionOf<decltype(isq::angular_momentum.dimension / isq::angular_velocity.dimension), isq::moment_of_inertia.dimension>);
+static_assert(DimensionOf<decltype(isq::angular_momentum.dimension / isq::angular_velocity.dimension),
+                          isq::moment_of_inertia.dimension>);
 
 // QuantitySpec
 inline constexpr auto speed = isq::length / isq::time;

--- a/test/static/concepts_test.cpp
+++ b/test/static/concepts_test.cpp
@@ -82,22 +82,23 @@ static_assert(!Dimension<struct si::metre>);
 static_assert(!Dimension<int>);
 
 // DimensionOf
-inline constexpr struct isq::dim_length tdimlength;
-inline constexpr struct isq::dim_time tdimtime;
-inline constexpr struct isq::length tlength;
-inline constexpr struct isq::time ttime;
-static_assert(DimensionOf<struct isq::dim_length, tdimlength>);
-static_assert(!DimensionOf<struct isq::dim_length, tdimtime>);
-static_assert(!DimensionOf<struct isq::dim_length, tlength>);
-static_assert(!DimensionOf<struct isq::dim_length, ttime>);
-static_assert(!DimensionOf<struct isq::dim_time, tdimlength>);
-static_assert(!DimensionOf<struct isq::dim_time, tlength>);
-static_assert(!DimensionOf<struct isq::length, tdimlength>);
-static_assert(!DimensionOf<struct isq::length, tdimtime>);
-static_assert(!DimensionOf<struct isq::length, tlength>);
-static_assert(!DimensionOf<struct isq::length, ttime>);
-static_assert(!DimensionOf<struct isq::time, tdimlength>);
-static_assert(!DimensionOf<struct isq::time, tlength>);
+static_assert(DimensionOf<struct isq::dim_length, isq::dim_length>);
+static_assert(DimensionOf<struct isq::dim_length, isq::height.dimension>);
+static_assert(DimensionOf<struct isq::dim_length, isq::radius.dimension>);
+static_assert(!DimensionOf<struct isq::dim_length, isq::length>);
+static_assert(!DimensionOf<struct isq::length, isq::dim_length>);
+static_assert(!DimensionOf<struct isq::length, isq::length>);
+static_assert(!DimensionOf<struct isq::dim_length, isq::dim_time>);
+static_assert(!DimensionOf<struct isq::dim_length, isq::time>);
+static_assert(!DimensionOf<struct isq::dim_time, isq::dim_length>);
+static_assert(!DimensionOf<struct isq::dim_time, isq::length>);
+static_assert(!DimensionOf<struct isq::length, isq::dim_time>);
+static_assert(!DimensionOf<struct isq::length, isq::time>);
+static_assert(!DimensionOf<struct isq::time, isq::dim_length>);
+static_assert(!DimensionOf<struct isq::time, isq::length>);
+static_assert(DimensionOf<decltype(isq::dim_length / isq::dim_time), isq::speed.dimension>);
+static_assert(DimensionOf<decltype(isq::force.dimension * isq::time.dimension), isq::impulse.dimension>);
+static_assert(DimensionOf<decltype(isq::angular_momentum.dimension / isq::angular_velocity.dimension), isq::moment_of_inertia.dimension>);
 
 // QuantitySpec
 inline constexpr auto speed = isq::length / isq::time;

--- a/test/static/concepts_test.cpp
+++ b/test/static/concepts_test.cpp
@@ -82,7 +82,22 @@ static_assert(!Dimension<struct si::metre>);
 static_assert(!Dimension<int>);
 
 // DimensionOf
-// TODO add tests
+inline constexpr struct isq::dim_length tdimlength;
+inline constexpr struct isq::dim_time tdimtime;
+inline constexpr struct isq::length tlength;
+inline constexpr struct isq::time ttime;
+static_assert(DimensionOf<struct isq::dim_length, tdimlength>);
+static_assert(!DimensionOf<struct isq::dim_length, tdimtime>);
+static_assert(!DimensionOf<struct isq::dim_length, tlength>);
+static_assert(!DimensionOf<struct isq::dim_length, ttime>);
+static_assert(!DimensionOf<struct isq::dim_time, tdimlength>);
+static_assert(!DimensionOf<struct isq::dim_time, tlength>);
+static_assert(!DimensionOf<struct isq::length, tdimlength>);
+static_assert(!DimensionOf<struct isq::length, tdimtime>);
+static_assert(!DimensionOf<struct isq::length, tlength>);
+static_assert(!DimensionOf<struct isq::length, ttime>);
+static_assert(!DimensionOf<struct isq::time, tdimlength>);
+static_assert(!DimensionOf<struct isq::time, tlength>);
 
 // QuantitySpec
 inline constexpr auto speed = isq::length / isq::time;


### PR DESCRIPTION
This commit adds some static tests for the concept DimensionOf as requested in issue #497 .