### PR TITLE
Fix Xcode long build times and/or crashes

### DIFF
--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -97,11 +97,10 @@ configs = {
         # arm64 runners are expensive; only consider one version
         if ver == 18 or platform != "arm64"
     ]
-    # TODO uncomment the below when apple-clang-15 crash is fixed
-    # + [
-    #     make_apple_clang_config("macos-13", ver, std_format_support=False)
-    #     for ver in ["15.2"]
-    # ]
+    + [
+        make_apple_clang_config("macos-13", ver, std_format_support=False)
+        for ver in ["15.2"]
+    ]
     # std::format is available in Xcode 16.1 or later
     + [
         make_apple_clang_config("macos-14", ver, std_format_support=True)

--- a/src/core/include/mp-units/framework/representation_concepts.h
+++ b/src/core/include/mp-units/framework/representation_concepts.h
@@ -44,12 +44,7 @@ namespace mp_units {
 namespace detail {
 
 template<typename T>
-concept WeaklyRegular =
-#ifndef MP_UNITS_XCODE15_HACKS
-  true;
-#else
-  std::copyable<T> && std::equality_comparable<T>;
-#endif
+concept WeaklyRegular = std::copyable<T> && std::equality_comparable<T>;
 
 template<typename T, typename S>
 concept ScalableWith = requires(const T v, const S s) {
@@ -175,13 +170,18 @@ template<typename T>
 concept ComplexScalar =
   // TODO should the below be provided?
   // (!disable_complex<T>) &&
-  Addable<T> && ScalableWith<T, T> && requires(const T v, const T& ref) {
+  Addable<T> && ScalableWith<T, T> &&
+  requires(const T v, const T& ref) {
     ::mp_units::real(v);
     ::mp_units::imag(v);
     ::mp_units::modulus(v);
     requires ScalableWith<T, decltype(::mp_units::modulus(v))>;
     requires std::constructible_from<T, decltype(::mp_units::real(ref)), decltype(::mp_units::imag(ref))>;
-  } && WeaklyRegular<T>;
+  }
+#ifndef MP_UNITS_XCODE15_HACKS
+  && WeaklyRegular<T>
+#endif
+  ;
 
 }  // namespace detail
 
@@ -197,8 +197,12 @@ MP_UNITS_INLINE constexpr bool disable_real<bool> = true;
 namespace detail {
 
 template<typename T>
-concept RealScalar = (!disable_real<T>) && Addable<T> && ScalableWith<T, T> && std::totally_ordered<T> &&
-                     (!ComplexScalar<T>) && WeaklyRegular<T>;
+concept RealScalar =
+  (!disable_real<T>) && Addable<T> && ScalableWith<T, T> && std::totally_ordered<T> && (!ComplexScalar<T>)
+#if MP_UNITS_COMP_GCC != 12 && !defined(MP_UNITS_XCODE15_HACKS)
+  && WeaklyRegular<T>
+#endif
+  ;
 
 template<typename T>
 concept Scalar = RealScalar<T> || ComplexScalar<T>;
@@ -250,15 +254,20 @@ MP_UNITS_EXPORT inline constexpr ::mp_units::detail::magnitude_impl::magnitude_t
 namespace detail {
 
 template<typename T>
-concept Vector = Addable<T> && requires(const T v) {
-  ::mp_units::magnitude(v);
-  requires ScalableWith<T, decltype(::mp_units::magnitude(v))>;
-  // TODO should we also check for the below (e.g., when `size() > 1` or `2`)
-  // ::mp_units::zero_vector<T>();
-  // ::mp_units::scalar_product(a, b);
-  // ::mp_units::vector_product(a, b);
-  // ::mp_units::tensor_product(a, b);
-} && WeaklyRegular<T>;
+concept Vector = Addable<T> &&
+                 requires(const T v) {
+                   ::mp_units::magnitude(v);
+                   requires ScalableWith<T, decltype(::mp_units::magnitude(v))>;
+                   // TODO should we also check for the below (e.g., when `size() > 1` or `2`)
+                   // ::mp_units::zero_vector<T>();
+                   // ::mp_units::scalar_product(a, b);
+                   // ::mp_units::vector_product(a, b);
+                   // ::mp_units::tensor_product(a, b);
+                 }
+#ifndef MP_UNITS_XCODE15_HACKS
+                 && WeaklyRegular<T>
+#endif
+  ;
 
 }  // namespace detail
 

--- a/src/core/include/mp-units/framework/representation_concepts.h
+++ b/src/core/include/mp-units/framework/representation_concepts.h
@@ -340,11 +340,22 @@ concept SomeRepresentation =
 
 }  // namespace detail
 
+#ifdef MP_UNITS_XCODE15_HACKS
+MP_UNITS_EXPORT template<typename T, auto V>
+concept RepresentationOf =
+  detail::SomeRepresentation<T> &&
+  ((QuantitySpec<MP_UNITS_REMOVE_CONST(decltype(V))> &&
+    (detail::QuantityKindSpec<MP_UNITS_REMOVE_CONST(decltype(V))> || detail::IsOfCharacter<T, V.character>)) ||
+   (std::same_as<quantity_character, decltype(V)> && detail::IsOfCharacter<T, V>));
+
+#else
+
 MP_UNITS_EXPORT template<typename T, auto V>
 concept RepresentationOf =
   ((QuantitySpec<MP_UNITS_REMOVE_CONST(decltype(V))> &&
     ((detail::QuantityKindSpec<MP_UNITS_REMOVE_CONST(decltype(V))> && detail::SomeRepresentation<T>) ||
      detail::IsOfCharacter<T, V.character>)) ||
    (std::same_as<quantity_character, decltype(V)> && detail::IsOfCharacter<T, V>));
+#endif
 
 }  // namespace mp_units


### PR DESCRIPTION
The first attempted fix for long build times with Xcode 15 was causing a compiler crash.

The refactor to remove `concept Representation` seemed to cause an unexplained long build time for Xcode 15 building Kalman filter examples. Reverting the changes to `concept RepresentationOf` in Xcode 15 seems to resolve the long build times. I'm not sure if we should revert this change just for Xcode 15 or in general.