### PR TITLE
fix/lvalue references + point origin does not compile

### DIFF
--- a/src/core/include/mp-units/framework/quantity_point.h
+++ b/src/core/include/mp-units/framework/quantity_point.h
@@ -68,7 +68,7 @@ struct point_origin_interface {
     return quantity_point{std::forward<FwdQ>(q), po};
   }
 
-  template<Quantity FwdQ, PointOrigin PO, QuantityOf<PO::_quantity_spec_> Q = std::remove_cvref_t<FwdQ>>
+  template<typename FwdQ, PointOrigin PO, QuantityOf<PO::_quantity_spec_> Q = std::remove_cvref_t<FwdQ>>
   [[nodiscard]] friend constexpr QuantityPoint auto operator+(FwdQ&& q, PO po)
   {
     return po + std::forward<FwdQ>(q);


### PR DESCRIPTION
fixes https://github.com/mpusz/mp-units/issues/707

Looked it over again and realized ref + point origin doesn't work but point origin + ref does so I just copied the working one's 'typename'.