### PR TITLE
Support ReSharper builtin for type name

### DIFF
--- a/src/core/include/mp-units/ext/type_name.h
+++ b/src/core/include/mp-units/ext/type_name.h
@@ -20,6 +20,10 @@ namespace mp_units::detail {
 template<typename T>
 [[nodiscard]] consteval std::string_view type_name()
 {
+#ifdef __RESHARPER__
+  return __rscpp_type_name<T>();
+#endif
+
   std::string_view name, prefix, suffix;
 #ifdef __clang__
   name = __PRETTY_FUNCTION__;


### PR DESCRIPTION
The function `type_name` is very compiler-dependent, its implementation already contains preprocessor branches for Clang, GCC and MSVC. In ReSharper (it's the [plugin for Visual Studio](https://www.jetbrains.com/resharper-cpp) and the language engine used in [CLion IDE](https://www.jetbrains.com/help/clion/clion-nova-introduction.html) and Rider) there is the special builtin `__rscpp_type_name` for getting type name. This builtin is more for efficient than extracting text from function signature on the one hand and avoids the need to exactly emulate macros `__PRETTY_FUNCTION__`/`__FUNCSIG__` in all compilers on the other hand.

The similar patch was [accepted](https://github.com/Neargye/magic_enum/pull/238) in another popular open-source C++ library [magic_enum](https://github.com/Neargye/magic_enum) few years ago.