### PR TITLE
Make quantity conversion to Rep constexpr

### DIFF
--- a/src/core/include/mp-units/framework/quantity.h
+++ b/src/core/include/mp-units/framework/quantity.h
@@ -329,7 +329,7 @@ public:
   // conversion operators
   template<typename V_, std::constructible_from<rep> Value = std::remove_cvref_t<V_>>
     requires detail::DimensionlessOne<reference>
-  [[nodiscard]] explicit operator V_() const& noexcept
+  [[nodiscard]] explicit constexpr operator V_() const& noexcept
   {
     return numerical_value_is_an_implementation_detail_;
   }


### PR DESCRIPTION
It looks like every other method in `quantity` is constexpr (notably, this includes `numerical_value_in()` and its variants), so this seems like an oversight.