### PR TITLE
Replace MP_UNITS_CONSTEVAL with constexpr in unit operations

### DIFF
--- a/src/core/include/mp-units/framework/unit.h
+++ b/src/core/include/mp-units/framework/unit.h
@@ -147,7 +147,7 @@ struct unit_interface {
    * Multiplication by `1` returns the same unit, otherwise `scaled_unit` is being returned.
    */
   template<UnitMagnitude M, Unit U>
-  [[nodiscard]] friend MP_UNITS_CONSTEVAL Unit auto operator*(M, U u)
+  [[nodiscard]] friend constexpr Unit auto operator*(M, U u)
   {
     if constexpr (std::is_same_v<M, MP_UNITS_NONCONST_TYPE(mp_units::mag<1>)>)
       return u;
@@ -171,7 +171,7 @@ struct unit_interface {
    * Returns the result of multiplication with an inverse unit.
    */
   template<UnitMagnitude M, Unit U>
-  [[nodiscard]] friend MP_UNITS_CONSTEVAL Unit auto operator/(M mag, U u)
+  [[nodiscard]] friend constexpr Unit auto operator/(M mag, U u)
   {
     return mag * inverse(u);
   }
@@ -182,7 +182,7 @@ struct unit_interface {
    * to the derived unit and the magnitude remains outside forming another scaled unit as a result of the operation.
    */
   template<Unit Lhs, Unit Rhs>
-  [[nodiscard]] friend MP_UNITS_CONSTEVAL Unit auto operator*(Lhs lhs, Rhs rhs)
+  [[nodiscard]] friend constexpr Unit auto operator*(Lhs lhs, Rhs rhs)
   {
     return expr_multiply<derived_unit, struct one>(lhs, rhs);
   }
@@ -193,7 +193,7 @@ struct unit_interface {
    * to the derived unit and the magnitude remains outside forming another scaled unit as a result of the operation.
    */
   template<Unit Lhs, Unit Rhs>
-  [[nodiscard]] friend MP_UNITS_CONSTEVAL Unit auto operator/(Lhs lhs, Rhs rhs)
+  [[nodiscard]] friend constexpr Unit auto operator/(Lhs lhs, Rhs rhs)
   {
     return expr_divide<derived_unit, struct one>(lhs, rhs);
   }
@@ -593,7 +593,7 @@ template<Unit T, typename... Expr>
 
 MP_UNITS_EXPORT_BEGIN
 
-[[nodiscard]] MP_UNITS_CONSTEVAL Unit auto inverse(Unit auto u) { return one / u; }
+[[nodiscard]] constexpr Unit auto inverse(Unit auto u) { return one / u; }
 
 /**
  * @brief Computes the value of a unit raised to the `Num/Den` power

--- a/test/runtime/math_test.cpp
+++ b/test/runtime/math_test.cpp
@@ -589,4 +589,31 @@ TEST_CASE("math operations", "[math]")
       REQUIRE_THAT(atan2(1. * isq::length[km], 1000. * isq::length[m]), AlmostEquals(45. * angle[deg]));
     }
   }
+
+  SECTION("inverse functions")
+  {
+    SECTION("inverse of time quantity returns frequency")
+    {
+      auto period = 2.0 * isq::time[s];
+      auto frequency = inverse<si::hertz>(period);
+      REQUIRE(frequency == 0.5 * isq::frequency[Hz]);
+    }
+
+    SECTION("inverse works with runtime values")
+    {
+      // Test the specific case that fails with consteval
+      double runtime_value = 3.0;
+      auto period = runtime_value * isq::time[s];
+      auto frequency = inverse<si::hertz>(period);
+      auto expected = (1.0 / 3.0) * isq::frequency[Hz];
+      REQUIRE_THAT(frequency, AlmostEquals(expected));
+    }
+
+    SECTION("inverse with different input units")
+    {
+      auto period_ms = 500.0 * isq::time[ms];
+      auto frequency = inverse<si::hertz>(period_ms);
+      REQUIRE(frequency == 2.0 * isq::frequency[Hz]);
+    }
+  }
 }


### PR DESCRIPTION
Changes MP_UNITS_CONSTEVAL to constexpr for unit multiplication, division, and `inverse` operations in unit.h.  This was discovered with feedback on PR #644 to use `inverse`.

Specifically fixes compilation error with clang (and likely other compilers?) where consteval functions cannot be called in non-constant contexts, such as:

```c++
  m_frequency = inverse<si::hertz>(period);
```

Added runtime tests for `inverse()` function covering time-to-frequency conversion, runtime parameters, and unit conversion.