### PR TITLE
fix: resolve CMake compiler test failure in freestanding CI builds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -272,6 +272,9 @@ class MPUnitsConan(ConanFile):
         # TODO remove the below when Conan will learn to handle C++ modules
         if opt.freestanding:
             tc.cache_variables["MP_UNITS_API_FREESTANDING"] = True
+            # Fix for freestanding builds: CMake compiler tests fail when linking with -ffreestanding
+            # Set CMAKE_TRY_COMPILE_TARGET_TYPE to STATIC_LIBRARY to avoid linking during compiler tests
+            tc.cache_variables["CMAKE_TRY_COMPILE_TARGET_TYPE"] = "STATIC_LIBRARY"
         else:
             tc.cache_variables["MP_UNITS_API_STD_FORMAT"] = opt.std_format
         tc.cache_variables["MP_UNITS_API_NO_CRTP"] = opt.no_crtp


### PR DESCRIPTION
The freestanding CI builds were failing during CMake's initial compiler test because the -ffreestanding flag was causing linker issues. The linker expected a main() function but freestanding environments may not have one.

This fix sets CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY when freestanding mode is enabled, which instructs CMake to skip the linking step during compiler tests and only compile to static libraries.

This resolves the undefined reference to main error in CI while maintaining proper freestanding compilation semantics.

🤖 Generated with [Claude Code](https://claude.ai/code)