### PR TITLE
build: MSVC workaround for empty base classes

### DIFF
--- a/src/core/include/mp-units/bits/hacks.h
+++ b/src/core/include/mp-units/bits/hacks.h
@@ -146,6 +146,16 @@ MP_UNITS_DIAGNOSTIC_POP
 
 #endif
 
+#if MP_UNITS_COMP_MSVC
+
+#define MP_UNITS_EMPTY_BASES_WORKAROUND __declspec(empty_bases)
+
+#else
+
+#define MP_UNITS_EMPTY_BASES_WORKAROUND
+
+#endif
+
 #if !defined MP_UNITS_API_NO_CRTP && __cpp_explicit_this_parameter
 
 #define MP_UNITS_API_NO_CRTP 1

--- a/src/core/include/mp-units/framework/unit.h
+++ b/src/core/include/mp-units/framework/unit.h
@@ -226,7 +226,7 @@ struct propagate_point_origin<U, true> {
 };
 
 template<UnitMagnitude auto M, Unit U>
-struct scaled_unit_impl : detail::unit_interface, detail::propagate_point_origin<U> {
+struct MP_UNITS_EMPTY_BASES_WORKAROUND scaled_unit_impl : detail::unit_interface, detail::propagate_point_origin<U> {
   using _base_type_ = scaled_unit_impl;  // exposition only
   static constexpr UnitMagnitude auto _mag_ = M;
   static constexpr U _reference_unit_{};
@@ -461,7 +461,9 @@ struct common_unit final : decltype(detail::get_common_scaled_unit(U1{}, U2{}, R
 namespace detail {
 
 template<typename... Expr>
-struct derived_unit_impl : detail::unit_interface, detail::expr_fractions<one, Expr...> {
+struct MP_UNITS_EMPTY_BASES_WORKAROUND derived_unit_impl :
+    detail::unit_interface,
+    detail::expr_fractions<one, Expr...> {
   using _base_type_ = derived_unit_impl;  // exposition only
 };
 


### PR DESCRIPTION
MSVC is knocking out bugs to get `mp-units` building. One of those bugs occurs here in `unit.h`:
```cpp
template<typename... Us, Unit U>
[[nodiscard]] consteval Unit auto get_common_unit_in(common_unit<Us...>, U u)
{
  // ...
  constexpr auto canonical_u = get_canonical_unit(u);
  // ...
}
```

The call to `get_canonical_unit` tries to copy `u`, which is outside the evaluation context of `canonical_u`. Normally this would be an error, but since `Unit` types have no members to copy (they are "empty"), this is actually permitted by the C++ standard.

We get this wrong due to an age-old layout problem. The structs `scaled_unit_impl` and `derived_unit_impl` inherit from empty base classes, so they should be considered empty as well. But due to historical reasons, we don't grant this if there are multiple base classes.

This is fixable on the compiler side. In the meantime, adding `__declspec(empty_bases)` is the workaround to get standard behavior ([MSVC docs](https://learn.microsoft.com/en-us/cpp/cpp/empty-bases), introduced in Visual Studio 2015).