### PR TITLE
build: MSVC fix for unspecified std::chrono::duration type

### DIFF
--- a/test/static/quantity_test.cpp
+++ b/test/static/quantity_test.cpp
@@ -474,7 +474,8 @@ static_assert(quantity{v{1., 2., 3}}.quantity_spec == kind_of<dimensionless>);
 
 using namespace std::chrono_literals;
 static_assert(std::is_same_v<decltype(quantity{123s})::rep, std::chrono::seconds::rep>);
-static_assert(std::is_same_v<decltype(quantity{123.s})::rep, decltype(::operator""s(static_cast<long double>(123.)))::rep>);
+static_assert(
+  std::is_same_v<decltype(quantity{123.s})::rep, decltype(::operator""s(static_cast<long double>(123.)))::rep>);
 static_assert(quantity{24h}.unit == si::hour);
 static_assert(quantity{24h}.quantity_spec == kind_of<isq::time>);
 #endif


### PR DESCRIPTION
Another patch to get the MSVC build going.

The `chrono_literals` `operator""s` actually has an unspecified return type (https://eel.is/c++draft/time.duration.literals). 
So library implementations can end up with either `double` or `long double` as the duration rep. For instance,

Clang's implementation:
```cpp
_LIBCPP_HIDE_FROM_ABI constexpr chrono::duration<long double> operator""s(long double __s) {
  return chrono::duration<long double>(__s);
}
```
MSVC's implementation:
```cpp
_EXPORT_STD _NODISCARD constexpr _CHRONO duration<double> operator""s(long double _Val) noexcept
/* strengthened */ {
    return _CHRONO duration<double>(_Val);
}
```

I changed the assertion to grab the rep from the result of calling the operator. Looks a bit tautological, but it works.
 