### PR TITLE
fix: __cpp_deleted_function issue with Apple-clang 17

### DIFF
--- a/src/core/include/mp-units/bits/hacks.h
+++ b/src/core/include/mp-units/bits/hacks.h
@@ -111,7 +111,8 @@ inline constexpr from_range_t from_range{};
 #endif
 
 // TODO https://github.com/llvm/llvm-project/issues/110224
-#if MP_UNITS_COMP_CLANG >= 19 && __cplusplus <= 202302
+#if (MP_UNITS_COMP_CLANG >= 19 || (defined(__apple_build_version__) && MP_UNITS_COMP_CLANG >= 17)) && \
+  __cplusplus <= 202302
 
 MP_UNITS_DIAGNOSTIC_PUSH
 MP_UNITS_DIAGNOSTIC_IGNORE_BUILTIN_MACRO_REDEFINED


### PR DESCRIPTION
Apple-clang 17 (i.e. Xcode 16.3 or later) has the same issue with `__cpp_deleted_function` being set with C++20.

I'm not sure if this fix is valuable / necessary since Apple-clang 17 has the same bug as Clang 19 that prevents us from building mp-units.