### PR TITLE
fix: freestanding build error in Conan package_info()

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -353,7 +353,9 @@ class MPUnitsConan(ConanFile):
                 if not self.options.std_format:
                     self.cpp_info.components["core"].requires.append("fmt::fmt")
                 self.cpp_info.components["core"].defines.append(
-                    "MP_UNITS_API_STD_FORMAT=" + str(int(self.options.std_format == True)))
+                    "MP_UNITS_API_STD_FORMAT="
+                    + str(int(self.options.std_format == True))
+                )
 
             # handle import std
             if self.options.import_std:

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -50,7 +50,7 @@ constexpr QuantityOf<MP_UNITS_IS_VALUE_WORKAROUND(isq::speed)> auto avg_speed(
 int main()
 {
   using namespace mp_units::si::unit_symbols;
-#if defined(MP_UNITS_HOSTED) && MP_UNITS_HOSTED == 1
+#if MP_UNITS_HOSTED
   std::cout << MP_UNITS_STD_FMT::format("Average speed = {}\n", avg_speed(240 * km, 2 * h));
 #else
   [[maybe_unused]] auto value = avg_speed(240 * km, 2 * h);


### PR DESCRIPTION
# 📋 Pull Request Description

This PR fixes a Conan installation error when using `freestanding=True` option. The `package_info()` method was attempting to access the `std_format` option even in freestanding builds, despite that option being removed for such configurations, causing the installation to fail with "option 'std_format' doesn't exist".

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Build system / CI changes
- [x] 🧪 Test improvements
- [ ] ♻️ Code refactoring
- [ ] 🎨 Code style improvements

## 🔗 Related Issues
<!-- Link any related issues using "Closes #xxx", "Resolves #xxx", or "Relates to #xxx" -->

Closes #734

## 📝 Changes Made

### Conan Package Info (`conanfile.py`)

- Restructured the `package_info()` method to properly handle freestanding builds
- Added explicit `MP_UNITS_HOSTED=0` define for freestanding builds
- Moved `MP_UNITS_API_STD_FORMAT` define and fmt dependency inside the hosted (`not freestanding`) block, preventing the `std_format` option access.

### Test Package (`test_package/test_package.cpp`)

- Added conditional compilation guards to handle freestanding environments
- Wrapped format and iostream includes with `MP_UNITS_HOSTED` checks
- Added fallback code path for freestanding builds that computes the value without I/O operations

## 🌟 Additional Context

Testing was performed using the following command variations:

```bash
conan create . -pr llvm20 -pr mac -b missing -o "*:cxx_modules=True" -o "*:freestanding=True" -o "*:contracts=none"
conan create . -pr llvm20 -pr mac -b missing -o "*:cxx_modules=True" -o "*:freestanding=False" -o "*:contracts=none"
conan create . -pr llvm20 -pr mac -b missing -o "*:cxx_modules=False" -o "*:freestanding=True" -o "*:contracts=none"
conan create . -pr llvm20 -pr mac -b missing -o "*:cxx_modules=False" -o "*:freestanding=False" -o "*:contracts=none"
```

For context my profiles llvm20 uses my llvm-toolchain tool package and mac sets my target profile to mac. 

All configurations built successfully.

## ✅ Checklist
<!-- Final checklist before submitting -->

- [x] I have read the [Contributing Guidelines](https://mpusz.github.io/mp-units/latest/getting_started/contributing/)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the project's documentation to cover the modified or new functionality
      (if this change affects user-facing features)

---

**By submitting this pull request, I confirm that my contribution is made under the terms
of the project's MIT license.**
