### PR TITLE
Replace wstring_view with basic_string_view<wchar_t>

### DIFF
--- a/src/core/include/mp-units/ext/fixed_string.h
+++ b/src/core/include/mp-units/ext/fixed_string.h
@@ -299,8 +299,13 @@ template<std::size_t N>
 struct std::hash<mp_units::fixed_u16string<N>> : std::hash<std::u16string_view> {};
 template<std::size_t N>
 struct std::hash<mp_units::fixed_u32string<N>> : std::hash<std::u32string_view> {};
+
+// NOTE: We use std::basic_string_view<wchar_t> instead of std::wstring_view because LLVM only makes std::wstring_view
+// available when the macro _LIBCPP_HAS_WIDE_CHARACTERS is set to 1. The `wchar_t` type can continue to be used
+// without that macro definition. To avoid requiring an additional macro, we simply use std::basic_string_view<wchar_t>,
+// which is the underlying definition of std::wstring_view.
 template<std::size_t N>
-struct std::hash<mp_units::fixed_wstring<N>> : std::hash<std::wstring_view> {};
+struct std::hash<mp_units::fixed_wstring<N>> : std::hash<std::basic_string_view<wchar_t>> {};
 
 #if MP_UNITS_HOSTED
 // formatting support


### PR DESCRIPTION
# 📋 Pull Request Description

This PR fixes a compilation error when building mp-units with LLVM 20.1.0 for ARM embedded targets. The issue occurs because `std::wstring_view` is gated by the `_LIBCPP_HAS_WIDE_CHARACTERS` macro in libc++, which is disabled for ARM embedded builds.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Build system / CI changes
- [ ] 🧪 Test improvements
- [ ] ♻️ Code refactoring
- [ ] 🎨 Code style improvements

## 🔗 Related Issues

Resolves #753 

## 📝 Changes Made

- Replaced `std::wstring_view` with `std::basic_string_view<wchar_t>` in the `std::hash` specialization for `mp_units::fixed_wstring<N>` in [fixed_string.h:307](src/core/include/mp-units/ext/fixed_string.h#L307)

## ✅ Checklist

- [x] I have read the [Contributing Guidelines](https://mpusz.github.io/mp-units/latest/getting_started/contributing/)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the project's documentation to cover the modified or new functionality
      (if this change affects user-facing features)

---

**By submitting this pull request, I confirm that my contribution is made under the terms
of the project's MIT license.**
