### PR TITLE
fix(doc): change erroneous subtraction to addition in tutorial example

### DIFF
--- a/docs/tutorials/type_safety/quantity_specifications.md
+++ b/docs/tutorials/type_safety/quantity_specifications.md
@@ -96,7 +96,7 @@ int main()
   static_assert(sum1.quantity_spec == isq::length);
 
   // Thickness is a child of width, so width + thickness = width
-  quantity sum2 = width - thickness;
+  quantity sum2 = width + thickness;
   std::cout << "width + thickness = " << sum2 << "\n";
   static_assert(sum2.quantity_spec == isq::width);
 


### PR DESCRIPTION
# 📋 Pull Request Description

There is a mismatch in the code example `Quantity Specification > Operations Across the Hierarchy`  between comment, variable name and actual operation. This PR fixes the tutorial example.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Build system / CI changes
- [ ] 🧪 Test improvements
- [ ] ♻️ Code refactoring
- [ ] 🎨 Code style improvements

## 🔗 Related Issues

None

## 📝 Changes Made

Changed `-` to `+`

## 🌟 Additional Context

None

## ✅ Checklist

- [x] I have read the [Contributing Guidelines](https://mpusz.github.io/mp-units/latest/getting_started/contributing/)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the project's documentation to cover the modified or new functionality
      (if this change affects user-facing features)

---

**By submitting this pull request, I confirm that my contribution is made under the terms
of the project's MIT license.**
