### PR TITLE
ci: enable g++-16 in the build matrix

### DIFF
--- a/.github/generate-job-matrix.py
+++ b/.github/generate-job-matrix.py
@@ -146,7 +146,7 @@ def make_msvc_config(release: str) -> Toolchain:
 
 toolchains = {
     t.name: t
-    for t in [make_gcc_config(ver) for ver in [12, 13, 14, 15]]
+    for t in [make_gcc_config(ver) for ver in [12, 13, 14, 15, 16]]
     + [
         make_clang_config(ver, architecture)
         for ver in [16, 17, 18, 20, 21]


### PR DESCRIPTION
Add GCC 16 to the toolchain list driving the conan, freestanding, and cmake CI matrices. The existing install step already pulls g++>=15 from ppa:ubuntu-toolchain-r/test on the ubuntu-24.04 runner, so no other changes are needed (no ubuntu-26.04 runner image exists yet).

# 📋 Pull Request Description

<!-- Provide a brief description of what this PR does -->

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Build system / CI changes
- [ ] 🧪 Test improvements
- [ ] ♻️ Code refactoring
- [ ] 🎨 Code style improvements

## 🔗 Related Issues
<!-- Link any related issues using "Closes #xxx", "Resolves #xxx", or "Relates to #xxx" -->

## 📝 Changes Made
<!-- Describe the changes you've made -->

## 🌟 Additional Context
<!-- Add any additional context, screenshots, or notes for reviewers -->

## ✅ Checklist
<!-- Final checklist before submitting -->

- [ ] I have read the [Contributing Guidelines](https://mpusz.github.io/mp-units/latest/getting_started/contributing/)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the project's documentation to cover the modified or new functionality
      (if this change affects user-facing features)

---

**By submitting this pull request, I confirm that my contribution is made under the terms
of the project's MIT license.**
