### PR TITLE
feat: external linear algebra libraries integrations + `quantity::magnitude()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ This page documents the version history and changes for the **mp-units** library
 - feat: `hep` system refactored to be similar to leading projects in the HEP domain
 - feat: `hep` system extended with new constants and specialized quantities
 - feat: `unit_for`, `reference_for`, and `rep_for` added
+- feat: linear algebra integrations added (headers `mp-units/integrations/{eigen,glm,blaze}.h`
+        and modules `mp_units.integrations.{eigen,glm,blaze}`) so Eigen, GLM, and Blaze vectors
+        and matrices can be used directly as quantity representations
+- feat: `representation_canonical_type` customization point added (materializes
+        expression-template representations before storing them in a `quantity`)
 - feat: type conversions improved to raise compile-time warnings on truncation
 - feat: `natural_point_origin<QuantitySpec>` added (replaces `zeroth_point_origin<QuantitySpec>`)
 - feat: `is_natural_point_origin<T>` added (replaces `is_zeroth_point_origin<T>`)

--- a/conanfile.py
+++ b/conanfile.py
@@ -71,6 +71,11 @@ class MPUnitsConan(ConanFile):
         "contracts": "gsl-lite",
         "freestanding": False,
     }
+    # third-party libraries exercised by the linear algebra integration example and tests. These are
+    # never runtime requirements of mp-units: the integration headers are dependency-free (guarded
+    # by `__has_include`) and always ship; only the optional C++ modules are compiled against a
+    # library, and only when it happens to be available (e.g. in the `build_all` developer build).
+    _linear_algebra_libs = ["eigen/5.0.1", "glm/1.0.1", "blaze/3.8.2"]
     implements = ["auto_header_only"]
     exports = "LICENSE.md"
     exports_sources = (
@@ -218,9 +223,16 @@ class MPUnitsConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=4.3.0 <5]")
+        if self.options.freestanding:
+            return
         if self._build_all:
-            if not self.options.freestanding:
-                self.test_requires("catch2/3.11.0")
+            self.test_requires("catch2/3.11.0")
+        # Make the linear algebra libraries available in the BUILD context
+        # A consumer that later uses an integration pulls its library in via
+        # `find_package(mp-units-integrations-<lib>)`, not via mp-units itself.
+        if self._build_all or self.options.get_safe("cxx_modules"):
+            for ref in self._linear_algebra_libs:
+                self.test_requires(ref)
 
     def validate(self):
         compiler = self.settings.compiler
@@ -413,6 +425,21 @@ class MPUnitsConan(ConanFile):
                 self.cpp_info.components["core"].cxxflags.append("/utf-8")
 
             self.cpp_info.components["systems"].requires = ["core"]
+
+            # The dependency-free integration headers (`mp-units::integrations`). Mirrors the CMake
+            # target exported in `mp-unitsTargets`. The third-party backends stay out of the dependency
+            # graph: they are pulled in only by the separate `find_package(mp-units-integrations-<lib>)`
+            # packages, never by mp-units itself.
+            #
+            # The per-backend `mp-units::integrations-<lib>` targets are intentionally NOT surfaced as
+            # Conan components. They are a CMake-level feature for source consumers (`add_subdirectory`/
+            # FetchContent) and raw `cmake --install` users, where the backend is found at configure time
+            # and the module is built from source. Conan consumers instead link `mp-units::integrations`
+            # (always-shipped, dependency-free headers) plus their own copy of the linear algebra library
+            # (see `test_package`). Making them Conan components would force opt-in host dependencies on
+            # mp-units for a benefit that only fully lands once module consumption from an installed
+            # package is supported - revisit then.
+            self.cpp_info.components["integrations"].requires = ["core"]
 
             # https://github.com/llvm/llvm-project/issues/131410
             if (

--- a/docs/examples/linear_algebra.md
+++ b/docs/examples/linear_algebra.md
@@ -1,0 +1,100 @@
+---
+tags:
+- Level - Intermediate
+- System - SI
+- System - ISQ
+- Feature - Custom Representation Types
+- Feature - Vector Quantities
+- Feature - Unit Conversions
+- Domain - Robotics
+- Domain - Physics
+---
+
+# Using a Linear Algebra Library as the Representation
+
+## Overview
+
+This example shows how a linear algebra library can be used **directly** as the
+[representation type](../users_guide/framework_basics/representation_types.md) of a vector
+_quantity_. The exact same **mp-units** code is compiled against four different vector
+types: three mainstream third-party libraries
+([Eigen](https://eigen.tuxfamily.org), [GLM](https://github.com/g-truc/glm), and
+[Blaze](https://bitbucket.org/blaze-lib/blaze)) and the library's own built-in
+[`cartesian_vector`](../users_guide/framework_basics/character_of_a_quantity.md); only the
+small shim that names the vector type and constructs it differs.
+
+The key idea is that a 3D vector — `Eigen::Vector3d`, `glm::dvec3`,
+`blaze::StaticVector<double, 3>`, or `cartesian_vector<double>` — becomes the
+representation, so the _quantity_ carries **both** a unit and a direction:
+
+```cpp
+quantity velocity = isq::velocity(la::make_vec3(30, 40, 0) * km / h);
+```
+
+## Enabling the Integration
+
+For each third-party library, **mp-units** ships an opt-in plugin that wires the library's
+vector type into the representation
+[customization points](../users_guide/framework_basics/representation_types.md)
+automatically, with no adapter code of your own. It is available both as a header and a named
+module:
+
+```cpp
+#include <mp-units/integrations/eigen.h>   // or <mp-units/integrations/glm.h>, or .../blaze.h>
+// in module mode instead: import mp_units.integrations.eigen;
+```
+
+Each header is guarded with `__has_include`, so it is a harmless no-op when the corresponding
+library is not available. The built-in `cartesian_vector` needs no plugin at all — it ships
+with the library and is a representation type out of the box. This example is compiled against
+all four backends, in both header and module modes.
+
+## Key Concepts
+
+### Unit conversion of a whole vector
+
+Converting the unit scales every component at once:
+
+```cpp
+print("velocity [m/s]   ", velocity.in(m / s));   // [8.33333, 11.1111, 0] m/s
+```
+
+### Vector quantity × scalar quantity
+
+Multiplying a _velocity_ vector by a _duration_ produces a _displacement_ vector, with the
+units combined automatically:
+
+```cpp
+quantity displacement = velocity * (2. * h);   // [60, 80, 0] km
+```
+
+This is where expression-template libraries (Eigen, Blaze) need care: their `operator*`
+returns a lazy proxy that holds references to its operands. **mp-units** materializes such
+a proxy into the concrete vector type before storing it, so no dangling references are possible.
+
+### Magnitude as a scalar quantity
+
+The library's `magnitude()` customization point recognizes the `norm()` (or `length()`) that
+linear algebra libraries provide. A vector _quantity_ supports `magnitude()` directly, returning
+the Euclidean magnitude as a scalar _quantity_ in the same unit:
+
+```cpp
+quantity speed = magnitude(velocity);   // 50 km/h
+```
+
+## What About Other Libraries?
+
+The same recipe applies to any library whose vector type is _weakly regular_ (copyable and
+**`bool`-returning** equality-comparable) and provides a Euclidean norm. Note that
+[Armadillo](https://arma.sourceforge.net) is **not** supported: its `operator==` returns an
+element-wise mask rather than a `bool`, so its types are not `std::equality_comparable` and
+cannot satisfy the representation requirements.
+
+## See Also
+
+- [Representation Types](../users_guide/framework_basics/representation_types.md) - the customization
+  points used here
+- [Using Custom Representation Types](../how_to_guides/integration/using_custom_representation_types.md) -
+  how to integrate your own type
+- [Character of a Quantity](../users_guide/framework_basics/character_of_a_quantity.md) - scalars vs
+  vectors vs tensors

--- a/docs/getting_started/project_structure.md
+++ b/docs/getting_started/project_structure.md
@@ -77,6 +77,21 @@ flowchart TD
     - [`MP_UNITS_BUILD_CXX_MODULES`](installation_and_usage.md#MP_UNITS_BUILD_CXX_MODULES)
       CMake option is set to `ON`.
 
+In addition, `./src/integrations` hosts optional, self-contained **integrations with third-party
+libraries**. Each component owns its `mp-units/integrations/<lib>.h` header and, in a C++
+modules build, the matching `mp_units.integrations.<lib>` module:
+
+| C++ Module                    | CMake Target                   | Third-party library                            |
+|-------------------------------|--------------------------------|------------------------------------------------|
+| `mp_units.integrations.eigen` | `mp-units::integrations-eigen` | [Eigen](https://eigen.tuxfamily.org)           |
+| `mp_units.integrations.glm`   | `mp-units::integrations-glm`   | [GLM](https://github.com/g-truc/glm)           |
+| `mp_units.integrations.blaze` | `mp-units::integrations-blaze` | [Blaze](https://bitbucket.org/blaze-lib/blaze) |
+
+Each depends only on `mp_units.core` and is built solely when the matching third-party library
+is found (the module is added on top in a C++ modules build). A component is **exported separately**
+(`find_package(mp-units-integrations-<lib>)`), never through `mp-unitsTargets`, so that
+`find_package(mp-units)` never gains a dependency on a third-party library.
+
 ## Header files
 
 All of the project's header files can be found in the `mp-units/...` subdirectory.
@@ -101,6 +116,21 @@ All of the project's header files can be found in the `mp-units/...` subdirector
     - `mp-units/bits/...` provides private implementation details only (no public definitions),
     - `mp-units/ext/...` contains external dependencies that at some point in the future
       should be replaced with C++ standard library facilities.
+
+### Third-party library integrations
+
+Optional, opt-in headers under `mp-units/integrations/` that adapt a third-party library to
+**mp-units**. Each is guarded with `__has_include` (a harmless no-op when its library is unavailable)
+and has a [module counterpart](#modules) (`mp_units.integrations.<lib>`). Currently these adapt
+linear algebra libraries, letting their vector and matrix types be used directly as
+quantity representations:
+
+- `mp-units/integrations/eigen.h` integrates [Eigen](https://eigen.tuxfamily.org),
+- `mp-units/integrations/glm.h` integrates [GLM](https://github.com/g-truc/glm),
+- `mp-units/integrations/blaze.h` integrates [Blaze](https://bitbucket.org/blaze-lib/blaze).
+
+See [Representation Types](../users_guide/framework_basics/representation_types.md#third-party-library-integrations)
+for usage.
 
 ### Systems and associated utilities
 

--- a/docs/how_to_guides/integration/using_custom_representation_types.md
+++ b/docs/how_to_guides/integration/using_custom_representation_types.md
@@ -176,6 +176,22 @@ public:
     (e.g. Eigen, Armadillo), so you avoid redundant adapters. Both names produce identical
     behavior; `norm()` is simply recognized as a zero-friction fallback.
 
+Once your representation type provides `magnitude()` (or a `norm()` fallback), a **vector
+quantity** built on it supports `magnitude()` at the quantity level automatically — no extra
+code — returning the Euclidean magnitude as a scalar quantity:
+
+```cpp
+quantity v = my_vector_type<double>{3, 4, 0} * isq::velocity[m / s];
+quantity speed = magnitude(v);  // 5 m/s
+```
+
+!!! warning "V2 limitation: result type"
+
+    The magnitude result drops the precise _quantity spec_ down to the unit's kind, and
+    quantity-level `scalar_product()` / `vector_product()` (dot/cross) are **not** provided in
+    V2 — they would need to return a _different_ quantity kind, which V2 _references_ cannot
+    express. Compute those on the raw representation and re-attach the reference yourself.
+
 ### Step 3: Add Formatting Support (optional)
 
 Enable formatting with `std::format`:

--- a/docs/users_guide/framework_basics/representation_types.md
+++ b/docs/users_guide/framework_basics/representation_types.md
@@ -360,6 +360,38 @@ used in mixed conversions.
 
 ---
 
+#### `representation_canonical_type<T>` { #representation_canonical_type }
+
+A specializable class template that maps a representation **value type** to the
+concrete type a `quantity` should *store*. The primary template simply decays the type:
+
+```cpp
+template<typename T>
+struct mp_units::representation_canonical_type {
+  using type = std::remove_cvref_t<T>;
+};
+
+template<typename T>
+using mp_units::representation_canonical_type_t = /* ... decays a top-level const ... */;
+```
+
+**Why it exists:** expression-template linear algebra libraries (e.g. Eigen, Blaze)
+return lazy proxy types from their arithmetic operators. Such a proxy keeps references
+to its operands and must be evaluated to a concrete type before being stored inside a
+`quantity`; otherwise the `quantity` would retain dangling references once the operands
+(often temporaries) go out of scope. The `quantity` deduction guides and the concepts
+that compute the representation type resulting from an arithmetic operation consult this
+trait, so the stored representation is always a materialized concrete type.
+
+**When to specialize:** to teach the library how to evaluate a specific
+expression-template type. The ready-made
+[third-party integration plugins](#third-party-library-integrations) do this for you
+(e.g. mapping Eigen's `PlainObject` and Blaze's `ResultType`). For a type whose operators
+already return a concrete value (arithmetic types, `cartesian_vector`, GLM) the default
+is correct and no specialization is needed.
+
+---
+
 #### Scaling operators { #scaling-operators }
 
 The library scales a representation value by calling `value * factor` and `value / factor`,
@@ -875,6 +907,65 @@ character. At minimum this means:
 See [Using Custom Representation Types](../../how_to_guides/integration/using_custom_representation_types.md)
 for a step-by-step walkthrough, including the complete set of customization points and working
 examples.
+
+
+## Third-Party Library Integrations { #third-party-library-integrations }
+
+You usually do not need to wire up the customization points yourself for a mainstream
+third-party library. **mp-units** ships opt-in integration plugins, each available as a header
+(header mode) and as a named module (module mode). The currently available plugins adapt linear
+algebra libraries, so their vector and matrix types can be used **directly** as vector/tensor
+representations (the same mechanism can adapt other kinds of libraries — e.g. safe numeric
+types — in the future):
+
+| Header                            | Module                        | Library                                        |
+|-----------------------------------|-------------------------------|------------------------------------------------|
+| `<mp-units/integrations/eigen.h>` | `mp_units.integrations.eigen` | [Eigen](https://eigen.tuxfamily.org)           |
+| `<mp-units/integrations/glm.h>`   | `mp_units.integrations.glm`   | [GLM](https://github.com/g-truc/glm)           |
+| `<mp-units/integrations/blaze.h>` | `mp_units.integrations.blaze` | [Blaze](https://bitbucket.org/blaze-lib/blaze) |
+
+```cpp
+#include <Eigen/Core>
+#include <mp-units/integrations/eigen.h>  // header mode; or: import mp_units.integrations.eigen;
+#include <mp-units/systems/si.h>
+
+using namespace mp_units;
+using namespace mp_units::si::unit_symbols;
+
+quantity v = Eigen::Vector3d{30, 40, 0} * isq::velocity[km / h];
+quantity speed = magnitude(v);  // 50 km/h (a vector quantity supports magnitude() directly)
+```
+
+Each header is guarded with `__has_include`, so it is a harmless no-op when its library is not
+available — it is always safe to include. The matching module is built only when C++ modules and
+the library are both available. See the
+[linear algebra example](../../examples/linear_algebra.md) for the same scenario compiled against
+all three libraries in both modes.
+
+!!! note "Expression templates"
+
+    Eigen and Blaze evaluate lazily: their arithmetic operators return proxy expression types
+    that reference their operands. The plugin headers map each such proxy to its evaluated
+    concrete type (via [`representation_canonical_type`](#representation_canonical_type)) so a
+    `quantity` never stores a dangling proxy.
+
+!!! warning "Armadillo is not supported"
+
+    [Armadillo](https://arma.sourceforge.net)'s `operator==` returns an element-wise mask rather
+    than a `bool`, so its vector/matrix types are not `std::equality_comparable` and therefore do
+    not satisfy the [weakly-regular](#representation-requirements) requirement that every
+    representation must meet.
+
+!!! warning "V2 limitation: vector-operation result types"
+
+    A vector quantity supports `magnitude()` directly, but the result drops the precise quantity
+    spec down to the unit's kind — V2 cannot yet express a dedicated scalar-magnitude quantity
+    spec. As a result the magnitude keeps `vector` character whenever the unit is tied to a vector
+    quantity spec (e.g. `N` is `kind_of<isq::force>`), and only collapses to scalar character for
+    units built from scalar base units (e.g. `km/h`). For the same reason quantity-level
+    `scalar_product()` / `vector_product()` (dot/cross) are **not** provided in V2 — they must
+    return a *different* quantity kind, which V2 references cannot name. Compute those on the raw
+    representation and re-attach the reference yourself.
 
 
 ## See Also

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -78,5 +78,46 @@ add_example(strong_angular_quantities)
 add_example(total_energy)
 add_example(unmanned_aerial_vehicle example_utils)
 
+#
+# Linear algebra integration examples
+#
+# The same `linear_algebra.cpp` source is compiled once per available third-party linear algebra
+# library (the source self-selects the backend via `__has_include`, and each target links exactly
+# one library). The `mp-units::integrations-<backend>` target carries both the adapter header/module
+# and the third-party library, so we link it and gate on it. It is defined by `src/integrations`
+# only when the corresponding library is found.
+function(add_linear_algebra_example backend)
+    if(NOT TARGET mp-units::integrations-${backend})
+        message(STATUS "Skipping the '${backend}' linear algebra example (integration not available)")
+        return()
+    endif()
+    # module-mode variant: `import mp_units.integrations.<backend>`
+    if(MP_UNITS_BUILD_CXX_MODULES)
+        add_executable(linear_algebra-${backend} linear_algebra.cpp)
+        target_compile_definitions(linear_algebra-${backend} PRIVATE MP_UNITS_MODULES)
+        target_link_libraries(linear_algebra-${backend} PRIVATE mp-units::mp-units mp-units::integrations-${backend})
+    endif()
+    # header-mode variant: `#include <mp-units/integrations/<backend>.h>`
+    add_executable(linear_algebra-${backend}-headers linear_algebra.cpp)
+    target_link_libraries(
+        linear_algebra-${backend}-headers PRIVATE mp-units::mp-units mp-units::integrations-${backend}
+    )
+endfunction()
+
+add_linear_algebra_example(eigen)
+add_linear_algebra_example(glm)
+add_linear_algebra_example(blaze)
+
+# The built-in `cartesian_vector` backend ships with `mp-units::mp-units` (no third-party dependency
+# and no integration plugin), so it is always built and forced via `MP_UNITS_LA_USE_CARTESIAN`.
+if(MP_UNITS_BUILD_CXX_MODULES)
+    add_executable(linear_algebra-cartesian linear_algebra.cpp)
+    target_compile_definitions(linear_algebra-cartesian PRIVATE MP_UNITS_MODULES MP_UNITS_LA_USE_CARTESIAN)
+    target_link_libraries(linear_algebra-cartesian PRIVATE mp-units::mp-units)
+endif()
+add_executable(linear_algebra-cartesian-headers linear_algebra.cpp)
+target_compile_definitions(linear_algebra-cartesian-headers PRIVATE MP_UNITS_LA_USE_CARTESIAN)
+target_link_libraries(linear_algebra-cartesian-headers PRIVATE mp-units::mp-units)
+
 add_subdirectory(glide_computer_lib)
 add_subdirectory(kalman_filter)

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -1,0 +1,156 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!! Before you commit any changes to this file please make sure to check if it !!!
+// !!! renders correctly in the documentation "Examples" section.                 !!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+// This single source file demonstrates that the very same mp-units scenario compiles and runs
+// against several linear algebra libraries used as the quantity *representation type*. The build
+// system compiles it once per backend it found (one executable each), in both header and module
+// modes. The mp-units code in `drone_flight()` is identical for every backend - only the thin shim
+// that names the vector type and constructs it differs.
+
+// Backend selection. The third-party libraries are included textually (they are not modularized and
+// we need their vector type directly); a backend is selected from whatever is available. mp-units'
+// own `cartesian_vector` is the built-in baseline: it ships with the library, needs no third-party
+// dependency and no integration plugin, and is used when forced (`MP_UNITS_LA_USE_CARTESIAN`) or
+// when no linear algebra library is found.
+#if defined(MP_UNITS_LA_USE_CARTESIAN)
+#define MP_UNITS_LA_CARTESIAN
+#elif __has_include(<Eigen/Core>)
+#include <Eigen/Core>
+#define MP_UNITS_LA_EIGEN
+#elif __has_include(<glm/vec3.hpp>)
+#include <glm/geometric.hpp>
+#include <glm/vec3.hpp>
+#define MP_UNITS_LA_GLM
+#elif __has_include(<blaze/math/StaticVector.h>)
+#include <blaze/math/StaticVector.h>
+#define MP_UNITS_LA_BLAZE
+#else
+#define MP_UNITS_LA_CARTESIAN
+#endif
+
+#ifdef MP_UNITS_IMPORT_STD
+import std;
+#else
+#include <exception>
+#include <iostream>
+#include <string_view>
+#endif
+
+// mp-units and the matching opt-in integration adapter. For a third-party backend the
+// `mp-units/integrations/<lib>.h` header (or its `mp_units.integrations.<lib>` module) wires the
+// library's vector type into mp-units' representation customization points; user code then uses the
+// library's native types directly. The built-in `cartesian_vector` needs no adapter - it ships with
+// the library and is a representation type out of the box.
+#ifdef MP_UNITS_MODULES
+import mp_units;
+#if defined(MP_UNITS_LA_EIGEN)
+import mp_units.integrations.eigen;
+#elif defined(MP_UNITS_LA_GLM)
+import mp_units.integrations.glm;
+#elif defined(MP_UNITS_LA_BLAZE)
+import mp_units.integrations.blaze;
+#endif
+#else
+#include <mp-units/math.h>
+#include <mp-units/systems/isq/mechanics.h>
+#include <mp-units/systems/isq/space_and_time.h>
+#include <mp-units/systems/si.h>
+#if defined(MP_UNITS_LA_EIGEN)
+#include <mp-units/integrations/eigen.h>
+#elif defined(MP_UNITS_LA_GLM)
+#include <mp-units/integrations/glm.h>
+#elif defined(MP_UNITS_LA_BLAZE)
+#include <mp-units/integrations/blaze.h>
+#elif defined(MP_UNITS_LA_CARTESIAN)
+#include <mp-units/cartesian_vector.h>
+#endif
+#endif
+
+namespace {
+
+using namespace mp_units;
+using namespace mp_units::si::unit_symbols;
+
+#if defined(MP_UNITS_LA_EIGEN)
+inline constexpr const char* backend_name = "Eigen";
+using vec3 = Eigen::Vector3d;
+#elif defined(MP_UNITS_LA_GLM)
+inline constexpr const char* backend_name = "GLM";
+using vec3 = glm::dvec3;
+#elif defined(MP_UNITS_LA_BLAZE)
+inline constexpr const char* backend_name = "Blaze";
+using vec3 = blaze::StaticVector<double, 3>;
+#elif defined(MP_UNITS_LA_CARTESIAN)
+inline constexpr const char* backend_name = "cartesian_vector (built-in)";
+using vec3 = cartesian_vector<double>;
+#endif
+
+[[nodiscard]] vec3 make_vec3(double x, double y, double z) { return {x, y, z}; }
+
+template<Quantity Q>
+void print(std::string_view name, const Q& q)
+{
+  const auto& v = q.numerical_value_in(q.unit);
+  std::cout << name << " = [" << v[0] << ", " << v[1] << ", " << v[2] << "] " << unit_symbol(Q::unit) << "\n";
+}
+
+void drone_flight()
+{
+  std::cout << "*** Linear algebra backend: " << backend_name << " ***\n\n";
+
+  // a 3D velocity, stored as a vector quantity (vector representation x reference)
+  const quantity velocity = isq::velocity(make_vec3(30, 40, 0) * km / h);
+  print("velocity        ", velocity);
+
+  // unit conversion of a vector quantity (exercises magnitude-ratio scaling of the rep)
+  print("velocity [m/s]  ", velocity.in(m / s));
+
+  // vector quantity x scalar quantity -> vector quantity (the rep arithmetic is materialized)
+  const quantity time = 2. * h;
+  const quantity displacement = velocity * time;
+  print("displacement    ", displacement.in(km));
+
+  // vector + vector, with an automatic unit conversion of one of the operands
+  const quantity wind_drift = make_vec3(500, 0, 0) * isq::displacement[m];
+  print("with wind drift ", (displacement + wind_drift).in(km));
+
+  // scalar magnitude of a vector quantity
+  std::cout << "speed            = " << magnitude(velocity).in(km / h) << "\n";
+}
+
+}  // namespace
+
+int main()
+{
+  try {
+    drone_flight();
+  } catch (const std::exception& ex) {
+    std::cerr << "Unhandled std exception caught: " << ex.what() << '\n';
+  } catch (...) {
+    std::cerr << "Unhandled unknown exception caught\n";
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -255,6 +255,7 @@ nav:
           - trade_execution: examples/trade_execution.md
           - strong_angular_quantities: examples/strong_angular_quantities.md
           - total_energy: examples/total_energy.md
+          - linear_algebra: examples/linear_algebra.md
       - Advanced:
           - unmanned_aerial_vehicle: examples/unmanned_aerial_vehicle.md
           - glide_computer: examples/glide_computer.md

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,7 @@ include(import-std-setup)
 include(MPUnitsContracts)
 add_subdirectory(core)
 add_subdirectory(systems)
+add_subdirectory(integrations)
 
 # project-wide wrapper
 add_mp_units_module(mp-units mp-units DEPENDENCIES mp-units::core mp-units::systems MODULE_INTERFACE_UNIT mp-units.cpp)

--- a/src/core/include/mp-units/framework/customization_points.h
+++ b/src/core/include/mp-units/framework/customization_points.h
@@ -140,6 +140,38 @@ MP_UNITS_EXPORT template<typename T>
   requires requires { typename representation_underlying_type<T>::type; }
 using representation_underlying_type_t = typename representation_underlying_type<T>::type;
 
+/**
+ * @brief Maps a representation value type to the concrete type a quantity should store.
+ *
+ * Expression-template linear algebra libraries (e.g. Eigen, Blaze, Armadillo) return lazy proxy
+ * types from their arithmetic operators. Such a proxy keeps references to its operands and must
+ * be evaluated to a concrete type before being stored inside a `quantity`; otherwise the quantity
+ * would retain dangling references once the operands (often temporaries) go out of scope.
+ *
+ * The `quantity` deduction guides and the concepts that compute the representation type resulting
+ * from an arithmetic operation use this trait so that the stored representation is always a
+ * materialized concrete type. The primary template simply decays the type, which is correct for
+ * scalars and for vector/matrix types whose operators return a concrete value (e.g. `cartesian_vector`,
+ * GLM). Specialize it for an expression-template type to name its evaluated type (for example to
+ * `Eigen::Matrix`'s `PlainObject`, or Blaze's `ResultType`) — see the integration guide.
+ *
+ * @tparam T the representation value type (possibly an expression-template proxy)
+ */
+MP_UNITS_EXPORT template<typename T>
+struct representation_canonical_type {
+  using type = std::remove_cvref_t<T>;
+};
+
+// A top-level `const` is forwarded to the unqualified type (mirroring `representation_underlying_type`
+// above) so that library specializations only need to handle the unqualified type. This matters
+// because expression-template libraries return their proxies by `const` value (e.g.
+// `decltype(Eigen::Vector3d{} * 2.0)` is a `const Eigen::CwiseBinaryOp<...>`).
+template<typename T>
+struct representation_canonical_type<const T> : representation_canonical_type<T> {};
+
+MP_UNITS_EXPORT template<typename T>
+using representation_canonical_type_t = typename representation_canonical_type<T>::type;
+
 namespace detail {
 
 template<typename T>

--- a/src/core/include/mp-units/framework/quantity.h
+++ b/src/core/include/mp-units/framework/quantity.h
@@ -126,9 +126,12 @@ concept ImplicitFromNumber =
 template<typename Q>
 concept ImplicitFromNumberQuantity = Quantity<Q> && ImplicitFromNumber<Q::reference>;
 
+// The invocation result is canonicalized (see `representation_canonical_type`) so that
+// expression-template results (e.g. Eigen, Blaze) are checked and stored as their evaluated
+// concrete type rather than the lazy proxy type.
 template<auto QS, typename Func, typename T, typename U>
 concept InvokeResultOf = QuantitySpec<MP_UNITS_REMOVE_CONST(decltype(QS))> && std::regular_invocable<Func, T, U> &&
-                         RepresentationOf<std::invoke_result_t<Func, T, U>, QS>;
+                         RepresentationOf<representation_canonical_type_t<std::invoke_result_t<Func, T, U>>, QS>;
 
 template<typename Func, typename Q1, typename Q2,
          auto QS = std::invoke_result_t<Func, MP_UNITS_NONCONST_TYPE(Q1::quantity_spec),
@@ -140,8 +143,9 @@ template<auto R1, auto R2>
 concept HaveCommonReference = requires { mp_units::get_common_reference(R1, R2); };
 
 template<typename Func, Quantity Q1, Quantity Q2>
-using common_quantity_for = quantity<mp_units::get_common_reference(Q1::reference, Q2::reference),
-                                     std::invoke_result_t<Func, typename Q1::rep, typename Q2::rep>>;
+using common_quantity_for =
+  quantity<mp_units::get_common_reference(Q1::reference, Q2::reference),
+           representation_canonical_type_t<std::invoke_result_t<Func, typename Q1::rep, typename Q2::rep>>>;
 
 template<typename Rep, Unit U1, Unit U2>
 [[nodiscard]] consteval bool overflows_non_zero_common_values(U1 u1, U2 u2)
@@ -156,7 +160,9 @@ concept CommonlyInvocableQuantities =
   std::convertible_to<Q1, common_quantity_for<Func, Q1, Q2>> &&
   std::convertible_to<Q2, common_quantity_for<Func, Q1, Q2>> &&
   InvocableQuantities<Func, Q1, Q2, mp_units::get_common_quantity_spec(Q1::quantity_spec, Q2::quantity_spec)> &&
-  !overflows_non_zero_common_values<std::invoke_result_t<Func, typename Q1::rep, typename Q2::rep>>(Q1::unit, Q2::unit);
+  !overflows_non_zero_common_values<
+    representation_canonical_type_t<std::invoke_result_t<Func, typename Q1::rep, typename Q2::rep>>>(Q1::unit,
+                                                                                                     Q2::unit);
 
 // Returns true if the unit ratio between Q1 and Q2, when scaled to the common unit, fits within
 // the double-width integer type for ct_rep.  For floating-point or already-widest integer
@@ -597,6 +603,25 @@ public:
     return value_cast<ToU{}, ToRep>(*this);
   }
 
+  // magnitude (Euclidean norm) of a vector quantity, returned as a scalar quantity in the same unit.
+  // Returning `* unit` (rather than `* reference`) intentionally drops the precise `quantity_spec`
+  // down to the unit's kind. This is purely a convenience workaround so users do not have to write
+  // their own `magnitude_of` helper - V2 simply cannot express the correct result type. The right
+  // type is a scalar-magnitude quantity spec (a future V3 feature): `magnitude(quantity<isq::force[N]>)`
+  // should yield something like `vec_mag<isq::force>[N]` whose `quantity_spec` has `real_scalar`
+  // character.
+  //
+  // Dropping to the unit's kind does NOT fix the character in general. It collapses to `real_scalar`
+  // only when the unit derives purely from scalar base units (e.g. `km/h` -> length/time). For a unit
+  // associated with a vector quantity spec (e.g. `N` is `kind_of<isq::force>`) the result keeps
+  // `vector` character - and since `double`/`int` are valid 1D vector representations, one could even
+  // take the magnitude of a magnitude of a magnitude. That is a known V2 limitation, not a goal.
+  [[nodiscard]] constexpr Quantity auto magnitude() const
+    requires(quantity_spec.character == quantity_character::vector)
+  {
+    return ::mp_units::magnitude(numerical_value_is_an_implementation_detail_) * unit;
+  }
+
   // data access
   template<Unit U>
     requires(equivalent(U{}, unit))
@@ -793,11 +818,16 @@ public:
 };
 
 // CTAD
-template<Reference R, RepresentationOf<get_quantity_spec(R{})> Value>
-quantity(Value v, R) -> quantity<R{}, Value>;
+// The stored representation is canonicalized (see `representation_canonical_type`) so that an
+// expression-template value (e.g. the result of `Eigen::Vector3d * double`) is materialized to
+// its evaluated concrete type instead of being stored as a proxy holding dangling references.
+template<Reference R, typename Value>
+  requires RepresentationOf<representation_canonical_type_t<Value>, get_quantity_spec(R{})>
+quantity(Value v, R) -> quantity<R{}, representation_canonical_type_t<Value>>;
 
-template<Reference auto R = one, RepresentationOf<get_quantity_spec(R)> Value>
-quantity(Value) -> quantity<R, Value>;
+template<Reference auto R = one, typename Value>
+  requires RepresentationOf<representation_canonical_type_t<Value>, get_quantity_spec(R)>
+quantity(Value) -> quantity<R, representation_canonical_type_t<Value>>;
 
 template<QuantityLike Q>
 quantity(Q) -> quantity<quantity_like_traits<Q>::reference, typename quantity_like_traits<Q>::rep>;

--- a/src/core/include/mp-units/framework/representation_concepts.h
+++ b/src/core/include/mp-units/framework/representation_concepts.h
@@ -73,6 +73,34 @@ using wider_int_for =
                      std::conditional_t<(sizeof(element_t) <= sizeof(std::uint32_t)), std::uint64_t,
                                         conditional<(sizeof(element_t) < sizeof(uint128_t)), uint128_t, element_t>>>;
 
+// `ScalableWith` and `Addable` describe the representation type's *public algebra*, so each
+// operation's result is required to be `common_with<T>`. `common_with` is the right relation here
+// precisely because it is *symmetric*: it asserts the result and `T` share a common type without
+// privileging a lossy direction.
+//
+//  - `constructible_from<T, result>` (or `convertible_to<result, T>`) would instead bless
+//    truncation: for a widening operation (`int16_t + int16_t -> int`, or a fixed-point type that
+//    widens) it "validates" by checking the wide result narrows back into the narrow `T`.
+//  - the non-narrowing directional check `convertible_to<T, result>` ("T widens into the result")
+//    rejects expression-template results - e.g. `Eigen::Vector3d` is not convertible to its own
+//    `CwiseBinaryOp` sum.
+//
+// `common_with` accepts both promotion (common type = the wider type) and expression templates
+// (common type = the evaluated vector) while rejecting `void` / unrelated junk, and without
+// asserting any narrowing. It is deliberately a bit stronger than the bare mechanics of a single
+// operation (much as `std::totally_ordered` requires `equality_comparable`, and as mp-units requires
+// every representation to be `WeaklyRegular`): a promoting type satisfies it by providing the
+// matching `std::common_type` specialization - the type author's part of the contract.
+//
+// This is a representation-validity gate only; the quantity operators do NOT consume it. `operator+`
+// materializes results via `common_quantity_for` (`get_common_reference` +
+// `representation_canonical_type_t<invoke_result_t<...>>`), and the comparison operators enforce
+// their own `std::common_type<Rep1, Rep2>` requirement (`CommonlyComparableQuantities`).
+//
+// It is also distinct from the *internal* scaling concepts (`UsesFloatingPointScaling` /
+// `UsesIntegerScaling`): those use `constructible_from` because the integer path *deliberately*
+// widens to a transient and `static_cast`s back to `To` - there the narrowing is the intended
+// operation, not a silent truncation. See the note on those concepts.
 template<typename T, typename S>
 concept ScalableWith = requires(const T v, const S s) {
   { v * s / s } -> std::common_with<T>;
@@ -317,12 +345,25 @@ concept NotQuantity = !is_quantity_like<T>;
 // The concept also covers container types whose element type is floating-point (e.g.
 // cartesian_vector<double>): treat_as_floating_point<value_type_t<T>> is checked so that
 // the FP scaling path is taken even when T itself is not floating-point.
+//
+// The scaled result need not be `T` itself, nor even weakly-regular: expression-template
+// linear algebra libraries (e.g. Eigen, Blaze) return lazy proxy types from `operator*` /
+// `operator/` rather than a materialized vector/matrix.  `scale()` always materializes the
+// result via `static_cast<To>` (direct-initialization), so it is sufficient that `T` be
+// constructible from the scaled result.
+//
+// `constructible_from` (rather than the `common_with` used by `Addable` / `ScalableWith`) is
+// deliberate: it is the exact precondition of `static_cast<To>` and nothing more. In particular it
+// admits explicit-only conversions - e.g. the rational integer path widens `safe_int<int>` to
+// `safe_int<int64_t>` and narrows back, which is `constructible_from` but neither `convertible_to`
+// nor required to be `common_with`. `Addable` uses `common_with` because its results instead feed
+// the `common_type`-based quantity machinery, where a common-reference relationship is what matters.
 template<typename T>
 concept UsesFloatingPointScaling =
   (treat_as_floating_point<T> || treat_as_floating_point<value_type_t<T>>) &&
   std::constructible_from<value_type_t<T>, long double> && requires(T value, value_type_t<T> f) {
-    { value * f } -> WeaklyRegular;
-    { value / f } -> WeaklyRegular;
+    requires std::constructible_from<T, decltype(value * f)>;
+    requires std::constructible_from<T, decltype(value / f)>;
   };
 
 // detail::integral (not std::integral) is required so that int128_t / uint128_t are
@@ -343,10 +384,15 @@ concept UsesFloatingPointScaling =
 // wider_int_for<element_t> (e.g. int64_t for signed int16_t, uint64_t for uint16_t) to
 // avoid overflowing the intermediate. The concept therefore requires `value * WF` and
 // `value / WF` for the wider factor.
+//
+// As in UsesFloatingPointScaling, the result is materialized via `static_cast<To>`, so we require
+// `T` to be constructible from it rather than (implicitly) convertible.  This matters because the
+// integer path deliberately produces a *wider* result (e.g. safe_int<int> * int64_t yields
+// safe_int<int64_t>) that narrows back to `T` only explicitly.
 template<typename T>
 concept UsesIntegerScaling = integral<value_type_t<T>> && requires(T value, wider_int_for<value_type_t<T>> wf) {
-  { value * wf };
-  { value / wf };
+  requires std::constructible_from<T, decltype(value * wf)>;
+  requires std::constructible_from<T, decltype(value / wf)>;
 };
 
 // A type that provides its own magnitude-aware operator*(T, UnitMagnitude) customization

--- a/src/integrations/CMakeLists.txt
+++ b/src/integrations/CMakeLists.txt
@@ -1,0 +1,134 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Mateusz Pusz
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+include(GNUInstallDirs)
+
+#
+# Optional integrations with third-party libraries.
+#
+# An integration adapts a third-party library to mp-units.
+#
+# The integration HEADERS are dependency-free (guarded by `__has_include`) and are therefore ALWAYS
+# shipped - mp-units never takes a runtime dependency on a third-party library. They live in a header
+# `FILE_SET` on the always-present `mp-units-integrations` target (installed via `mp-unitsTargets`);
+# `mp-units::core` already exposes the install include directory, so no extra include path is needed.
+#
+# Only the optional C++ module (`mp_units.integrations.<lib>`) is compiled against a library, and
+# only when that library happens to be available at configure time (e.g. in the `build_all` developer
+# build or any modules build). Those module targets are exported separately (NOT through
+# `mp-unitsTargets`), so `find_package(mp-units)` never gains a dependency on a third-party library.
+#
+
+# Always-present, dependency-free integration headers (shipped via a header FILE_SET).
+add_library(mp-units-integrations INTERFACE)
+target_link_libraries(mp-units-integrations INTERFACE mp-units::core)
+target_sources(
+    mp-units-integrations
+    INTERFACE
+        FILE_SET
+        HEADERS
+        BASE_DIRS
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        FILES
+        include/mp-units/integrations/blaze.h
+        include/mp-units/integrations/eigen.h
+        include/mp-units/integrations/glm.h
+)
+set_target_properties(mp-units-integrations PROPERTIES EXPORT_NAME integrations)
+add_library(mp-units::integrations ALIAS mp-units-integrations)
+
+if(MP_UNITS_BUILD_INSTALL)
+    install(TARGETS mp-units-integrations EXPORT mp-unitsTargets FILE_SET HEADERS)
+endif()
+
+find_package(Eigen3 QUIET)
+find_package(glm QUIET)
+find_package(blaze QUIET)
+
+#
+# add_mp_units_integration(name DEPENDENCY <find_package_name> <imported_target>)
+#
+function(add_mp_units_integration name)
+    set(multiValues DEPENDENCY)
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "" "" "${multiValues}")
+    list(GET ARG_DEPENDENCY 0 dep_package)
+    list(GET ARG_DEPENDENCY 1 dep_target)
+
+    if(NOT TARGET ${dep_target})
+        message(STATUS "Skipping the 'mp_units.integrations.${name}' integration (${dep_package} not found)")
+        return()
+    endif()
+
+    set(target mp-units-integrations-${name})
+    if(MP_UNITS_TARGET_SCOPE STREQUAL INTERFACE)
+        add_library(${target} INTERFACE)
+    else()
+        add_library(${target})
+    endif()
+
+    if(DEFINED CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD GREATER 20)
+        target_compile_features(${target} ${MP_UNITS_TARGET_SCOPE} cxx_std_${CMAKE_CXX_STANDARD})
+    else()
+        target_compile_features(${target} ${MP_UNITS_TARGET_SCOPE} cxx_std_20)
+    endif()
+
+    # The headers (and their include path) come from `mp-units::integrations`; this target only adds
+    # the third-party dependency and, in a modules build, the compiled module.
+    target_link_libraries(${target} ${MP_UNITS_TARGET_SCOPE} mp-units::integrations ${dep_target})
+
+    if(MP_UNITS_BUILD_CXX_MODULES)
+        target_sources(${target} PUBLIC FILE_SET CXX_MODULES FILES mp-units-integrations-${name}.cpp)
+    endif()
+
+    set_target_properties(${target} PROPERTIES EXPORT_NAME integrations-${name})
+    add_library(mp-units::integrations-${name} ALIAS ${target})
+
+    if(MP_UNITS_BUILD_INSTALL)
+        # The component is a separate CMake package `mp-units-integrations-<name>` so it lives in its
+        # own `cmake/` subdirectory where `find_package(mp-units-integrations-<name>)` looks.
+        set(export_name mp-units-integrations-${name}-targets)
+        set(config_dir ${CMAKE_INSTALL_LIBDIR}/cmake/mp-units-integrations-${name})
+        if(MP_UNITS_BUILD_CXX_MODULES)
+            install(TARGETS ${target}
+                    EXPORT ${export_name}
+                    FILE_SET CXX_MODULES
+                    DESTINATION ${CMAKE_INSTALL_LIBDIR}/miu
+            )
+        else()
+            install(TARGETS ${target} EXPORT ${export_name})
+        endif()
+        install(EXPORT ${export_name} DESTINATION ${config_dir} NAMESPACE mp-units::)
+
+        set(MP_UNITS_INTEGRATION_NAME ${name})
+        set(MP_UNITS_INTEGRATION_DEP_PACKAGE ${dep_package})
+        set(MP_UNITS_INTEGRATION_TARGETS_FILE ${export_name})
+        configure_file(
+            ${CMAKE_CURRENT_SOURCE_DIR}/mp-units-integration-config.cmake.in mp-units-integrations-${name}Config.cmake
+            @ONLY
+        )
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mp-units-integrations-${name}Config.cmake DESTINATION ${config_dir})
+    endif()
+endfunction()
+
+add_mp_units_integration(eigen DEPENDENCY Eigen3 Eigen3::Eigen)
+add_mp_units_integration(glm DEPENDENCY glm glm::glm)
+add_mp_units_integration(blaze DEPENDENCY blaze blaze::blaze)

--- a/src/integrations/include/mp-units/integrations/blaze.h
+++ b/src/integrations/include/mp-units/integrations/blaze.h
@@ -1,0 +1,106 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// Opt-in integration that lets Blaze vectors and matrices be used directly as mp-units
+// `quantity` representation types.
+//
+// What Blaze already provides out of the box:
+//   - free `norm()` -> the `magnitude()` CPO uses it (via ADL) for the Euclidean magnitude
+// What this header adds:
+//   - `representation_underlying_type` from Blaze's `ElementType` (Blaze does not expose the
+//     `value_type`/`element_type` names the library detects automatically)
+//   - `representation_canonical_type` mapping every Blaze expression to its evaluated `ResultType`
+//     so a `quantity` never stores a lazy expression template
+//   - a `blaze::IsScalar` opt-out for the library's compile-time unit-magnitude tag: Blaze treats
+//     every unknown type as a scalar, so without this its greedy `vector * scalar` operator would
+//     match the `value * unit_magnitude` probe and hard-error deep inside `MultTrait`
+//
+// The whole header is inert unless Blaze is actually available, so it is always safe to include.
+//
+// The header is dual-mode: included textually for header-mode consumers, and pulled into the
+// `mp_units.integrations.blaze` module interface unit otherwise. It only declares trait
+// specializations (which are reachable to importers without `export`); in module mode the Blaze
+// headers live in the module's global module fragment and the mp-units customization points come
+// from `import mp_units.core`, so none of those are included from the module purview here.
+
+#if __has_include(<blaze/math/StaticVector.h>)
+
+#ifndef MP_UNITS_IN_MODULE_INTERFACE
+#include <blaze/math/DynamicMatrix.h>
+#include <blaze/math/DynamicVector.h>
+#include <blaze/math/StaticMatrix.h>
+#include <blaze/math/StaticVector.h>
+#include <blaze/math/typetraits/IsMatrix.h>
+#include <blaze/math/typetraits/IsScalar.h>
+#include <blaze/math/typetraits/IsVector.h>
+#include <blaze/util/IntegralConstant.h>  // blaze::FalseType
+#include <mp-units/framework/customization_points.h>
+#include <mp-units/framework/unit_magnitude_concepts.h>
+#ifdef MP_UNITS_IMPORT_STD
+import std;
+#else
+#include <type_traits>
+#endif
+#endif
+
+namespace mp_units {
+
+namespace detail {
+
+// A Blaze dense/sparse vector or matrix - the shared guard for the trait specializations below.
+// `blaze::IsVector_v` / `IsMatrix_v` are defined (and `false`) for every type, so this is
+// SFINAE-safe to evaluate for arbitrary representation types such as `int`.
+template<typename T>
+concept blaze_tensor = blaze::IsVector_v<T> || blaze::IsMatrix_v<T>;
+
+}  // namespace detail
+
+// Blaze does not expose the `value_type`/`element_type` names the library detects automatically,
+// so map its `ElementType` explicitly.
+template<typename T>
+  requires detail::blaze_tensor<T> && requires { typename T::ElementType; }
+struct representation_underlying_type<T> {
+  using type = std::remove_cv_t<typename T::ElementType>;
+};
+
+// Blaze arithmetic operators return lazy expression templates; store their evaluated `ResultType`.
+template<typename T>
+  requires detail::blaze_tensor<T> && requires { typename T::ResultType; }
+struct representation_canonical_type<T> {
+  using type = std::remove_cvref_t<typename T::ResultType>;
+};
+
+}  // namespace mp_units
+
+namespace blaze {
+
+// The library probes `value * unit_magnitude{}` to detect a magnitude-aware scaling operator.
+// Tell Blaze that the unit-magnitude tag is not one of its scalars so its `DenseVector * scalar`
+// operator is not even considered for that probe.
+template<mp_units::UnitMagnitude T>
+struct IsScalar<T> : public FalseType {};
+
+}  // namespace blaze
+
+#endif  // __has_include(<blaze/math/StaticVector.h>)

--- a/src/integrations/include/mp-units/integrations/eigen.h
+++ b/src/integrations/include/mp-units/integrations/eigen.h
@@ -1,0 +1,74 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// Opt-in integration that lets Eigen vectors and matrices be used directly as mp-units
+// `quantity` representation types. Include this header (instead of `<Eigen/...>` alone) and the
+// library's customization points are wired up automatically.
+//
+// What Eigen already provides out of the box:
+//   - `value_type`           -> `representation_underlying_type` is detected automatically
+//   - `norm()` member        -> the `magnitude()` CPO uses it for the Euclidean magnitude
+// What this header adds:
+//   - `representation_canonical_type` for every Eigen expression, mapping it to the evaluated
+//     `PlainObject` so a `quantity` never stores a lazy expression template (which would hold
+//     dangling references to its operands).
+//
+// The whole header is inert unless Eigen is actually available, so it is always safe to include.
+//
+// The header is dual-mode: included textually for header-mode consumers, and pulled into the
+// `mp_units.integrations.eigen` module interface unit otherwise. In module mode, `<Eigen/Core>`
+// lives in the module's global module fragment and the customization points come from
+// `import mp_units.core`, so neither is included from the module purview here.
+
+#if __has_include(<Eigen/Core>)
+
+#ifndef MP_UNITS_IN_MODULE_INTERFACE
+#include <Eigen/Core>
+#include <mp-units/framework/customization_points.h>
+#ifdef MP_UNITS_IMPORT_STD
+import std;
+#else
+#include <concepts>
+#include <type_traits>
+#endif
+#endif
+
+namespace mp_units {
+
+// Eigen arithmetic operators return lazy expression templates; store their evaluated concrete
+// type (`PlainObject`) in a quantity instead. Concrete matrices/vectors map to themselves.
+//
+// The `typename T::PlainObject` requirement is checked first and short-circuits the rest of the
+// constraint: `representation_canonical_type` is instantiated for every representation type
+// (including `int`, `double`, ...), and `Eigen::EigenBase<T>` is ill-formed for a non-Eigen `T`,
+// so it must not be instantiated unless `T` already looks like an Eigen type.
+template<typename T>
+  requires requires { typename T::PlainObject; } && std::derived_from<T, Eigen::EigenBase<T>>
+struct representation_canonical_type<T> {
+  using type = std::remove_cvref_t<typename T::PlainObject>;
+};
+
+}  // namespace mp_units
+
+#endif  // __has_include(<Eigen/Core>)

--- a/src/integrations/include/mp-units/integrations/glm.h
+++ b/src/integrations/include/mp-units/integrations/glm.h
@@ -1,0 +1,62 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// Opt-in integration that lets GLM vectors be used directly as mp-units `quantity`
+// representation types.
+//
+// GLM evaluates eagerly (its operators return concrete `glm::vec`, not expression templates), so
+// no `representation_canonical_type` specialization is needed, and `glm::vec` already exposes a
+// `value_type` member that `representation_underlying_type` detects automatically. The only thing
+// missing is the Euclidean magnitude: GLM spells it `glm::length()` rather than `norm()`, so this
+// header adds a `magnitude()` overload (found by ADL) that the library's `magnitude()` CPO picks up.
+//
+// The whole header is inert unless GLM is actually available, so it is always safe to include.
+//
+// The header is dual-mode: included textually for header-mode consumers, and pulled into the
+// `mp_units.integrations.glm` module interface unit otherwise. The `magnitude()` overload is
+// exported so that the `magnitude()` CPO can find it by ADL across the module boundary; in module
+// mode the GLM headers live in the module's global module fragment, so they are not included here.
+
+#if __has_include(<glm/geometric.hpp>)
+
+#include <mp-units/bits/module_macros.h>
+
+#ifndef MP_UNITS_IN_MODULE_INTERFACE
+#include <glm/geometric.hpp>  // glm::length
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
+#endif
+
+namespace glm {
+
+MP_UNITS_EXPORT template<length_t L, typename T, qualifier Q>
+[[nodiscard]] constexpr T magnitude(const vec<L, T, Q>& v)
+{
+  return length(v);
+}
+
+}  // namespace glm
+
+#endif  // __has_include(<glm/geometric.hpp>)

--- a/src/integrations/mp-units-integration-config.cmake.in
+++ b/src/integrations/mp-units-integration-config.cmake.in
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Mateusz Pusz
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Config for the optional `mp_units.integrations.@MP_UNITS_INTEGRATION_NAME@` component.
+# Exported separately from `mp-unitsConfig` so that `find_package(mp-units)` never pulls in a
+# third-party linear algebra dependency.
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(mp-units)
+find_dependency(@MP_UNITS_INTEGRATION_DEP_PACKAGE@)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@MP_UNITS_INTEGRATION_TARGETS_FILE@.cmake")

--- a/src/integrations/mp-units-integrations-blaze.cpp
+++ b/src/integrations/mp-units-integrations-blaze.cpp
@@ -1,0 +1,44 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+module;
+
+#include <blaze/math/DynamicMatrix.h>
+#include <blaze/math/DynamicVector.h>
+#include <blaze/math/StaticMatrix.h>
+#include <blaze/math/StaticVector.h>
+#include <blaze/math/typetraits/IsMatrix.h>
+#include <blaze/math/typetraits/IsScalar.h>
+#include <blaze/math/typetraits/IsVector.h>
+#include <blaze/util/IntegralConstant.h>
+#include <mp-units/bits/core_gmf.h>
+
+export module mp_units.integrations.blaze;
+
+import mp_units.core;
+#ifdef MP_UNITS_IMPORT_STD
+import std;
+#endif
+
+#define MP_UNITS_IN_MODULE_INTERFACE
+
+#include <mp-units/integrations/blaze.h>

--- a/src/integrations/mp-units-integrations-eigen.cpp
+++ b/src/integrations/mp-units-integrations-eigen.cpp
@@ -1,0 +1,37 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+module;
+
+#include <Eigen/Core>
+#include <mp-units/bits/core_gmf.h>
+
+export module mp_units.integrations.eigen;
+
+import mp_units.core;
+#ifdef MP_UNITS_IMPORT_STD
+import std;
+#endif
+
+#define MP_UNITS_IN_MODULE_INTERFACE
+
+#include <mp-units/integrations/eigen.h>

--- a/src/integrations/mp-units-integrations-glm.cpp
+++ b/src/integrations/mp-units-integrations-glm.cpp
@@ -1,0 +1,40 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+module;
+
+#include <glm/geometric.hpp>
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
+#include <mp-units/bits/core_gmf.h>
+
+export module mp_units.integrations.glm;
+
+import mp_units.core;
+#ifdef MP_UNITS_IMPORT_STD
+import std;
+#endif
+
+#define MP_UNITS_IN_MODULE_INTERFACE
+
+#include <mp-units/integrations/glm.h>

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -50,3 +50,38 @@ endif()
 
 include(Catch)
 catch_discover_tests(unit_tests_runtime)
+
+#
+# Linear algebra integration tests
+#
+# The same `linear_algebra_test.cpp` source is compiled once per available third-party linear
+# algebra library (the source self-selects the backend via `__has_include`), as a separate
+# executable each. The `mp-units::integrations-<backend>` target carries the adapter header and the
+# third-party library, and is defined by `src/integrations` only when the library is found.
+#
+# Tests are header-mode only (consistent with the rest of the suite, which favors textual includes
+# for access to implementation details). Module-mode consumption is demonstrated by the example.
+function(add_linear_algebra_test backend)
+    if(NOT TARGET mp-units::integrations-${backend})
+        message(STATUS "Skipping the '${backend}' linear algebra test (integration not available)")
+        return()
+    endif()
+    add_executable(linear_algebra_test-${backend} linear_algebra_test.cpp)
+    target_link_libraries(
+        linear_algebra_test-${backend} PRIVATE mp-units::mp-units mp-units::integrations-${backend}
+                                               Catch2::Catch2WithMain
+    )
+    catch_discover_tests(linear_algebra_test-${backend})
+endfunction()
+
+add_linear_algebra_test(eigen)
+add_linear_algebra_test(glm)
+add_linear_algebra_test(blaze)
+
+# The built-in `cartesian_vector` backend ships with `mp-units::mp-units` (no third-party dependency
+# and no integration plugin), so it is always built and forced via `MP_UNITS_LA_USE_CARTESIAN`. It
+# additionally covers integral representations and `constexpr` evaluation.
+add_executable(linear_algebra_test-cartesian linear_algebra_test.cpp)
+target_compile_definitions(linear_algebra_test-cartesian PRIVATE MP_UNITS_LA_USE_CARTESIAN)
+target_link_libraries(linear_algebra_test-cartesian PRIVATE mp-units::mp-units Catch2::Catch2WithMain)
+catch_discover_tests(linear_algebra_test-cartesian)

--- a/test/runtime/linear_algebra_test.cpp
+++ b/test/runtime/linear_algebra_test.cpp
@@ -20,472 +20,333 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// Exercises a third-party linear algebra library used as an mp-units `quantity` representation
+// type. The backend is selected automatically from whichever library is available on the include
+// path; the build system compiles this file once per library it finds (one executable each).
+
+// 1. The third-party library headers are always included textually: the libraries are not
+//    modularized, and we need their vector type directly. A backend is selected here. mp-units'
+//    own `cartesian_vector` is the built-in baseline: it ships with the library, needs no
+//    third-party dependency and no integration plugin, and is used when forced
+//    (`MP_UNITS_LA_USE_CARTESIAN`) or when no linear algebra library is found.
+#if defined(MP_UNITS_LA_USE_CARTESIAN)
+#define MP_UNITS_LA_CARTESIAN
+#elif __has_include(<Eigen/Core>)
+#include <Eigen/Core>
+#include <Eigen/Geometry>  // cross()
+#define MP_UNITS_LA_EIGEN
+#elif __has_include(<glm/vec3.hpp>)
+#include <glm/geometric.hpp>
+#include <glm/vec3.hpp>
+#define MP_UNITS_LA_GLM
+#elif __has_include(<blaze/math/StaticVector.h>)
+#include <blaze/math/StaticVector.h>
+#define MP_UNITS_LA_BLAZE
+#else
+#define MP_UNITS_LA_CARTESIAN
+#endif
+
 #include <catch2/catch_test_macros.hpp>
-#include <mp-units/compat_macros.h>
-#include <mp-units/ext/format.h>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+// 2. When the build is configured with `import std;` the mp-units headers below consume the
+//    standard library as a module, so this TU must import it too (it is header-mode otherwise).
+//    All textual includes above stay before the import, which is the order libstdc++ requires.
 #ifdef MP_UNITS_IMPORT_STD
 import std;
-#else
-#include <matrix>
-#include <ostream>
 #endif
-#ifdef MP_UNITS_MODULES
-import mp_units;
-#else
+
+// 3. mp-units and the matching integration adapter. The test is header-mode only (module-mode
+//    consumption of the integration is demonstrated by the `linear_algebra` example).
 #include <mp-units/math.h>
 #include <mp-units/systems/isq/mechanics.h>
 #include <mp-units/systems/isq/space_and_time.h>
 #include <mp-units/systems/si.h>
+#if defined(MP_UNITS_LA_EIGEN)
+#include <mp-units/integrations/eigen.h>
+#elif defined(MP_UNITS_LA_GLM)
+#include <mp-units/integrations/glm.h>
+#elif defined(MP_UNITS_LA_BLAZE)
+#include <mp-units/integrations/blaze.h>
+#elif defined(MP_UNITS_LA_CARTESIAN)
+#include <mp-units/cartesian_vector.h>
 #endif
-
-template<typename Rep = double>
-using vector = STD_LA::fixed_size_column_vector<Rep, 3>;
-
-template<typename Rep>
-std::ostream& operator<<(std::ostream& os, const vector<Rep>& v)
-{
-  os << "|";
-  for (auto i = 0U; i < v.size(); ++i) {
-    os << MP_UNITS_STD_FMT::format(" {:>9}", v(i));
-  }
-  os << " |";
-  return os;
-}
 
 namespace {
 
 using namespace mp_units;
 using namespace mp_units::si::unit_symbols;
 
-template<QuantitySpec auto QS, QuantityOf<QS> Q>
-  requires(Q::quantity_spec.character == quantity_character::vector) &&
-          (QS.character == quantity_character::real_scalar)
-[[nodiscard]] constexpr QuantityOf<QS> auto get_magnitude(const Q& q)
+#if defined(MP_UNITS_LA_EIGEN)
+inline constexpr const char* backend = "Eigen";
+using vec3 = Eigen::Vector3d;
+#elif defined(MP_UNITS_LA_GLM)
+inline constexpr const char* backend = "GLM";
+using vec3 = glm::dvec3;
+#elif defined(MP_UNITS_LA_BLAZE)
+inline constexpr const char* backend = "Blaze";
+using vec3 = blaze::StaticVector<double, 3>;
+#elif defined(MP_UNITS_LA_CARTESIAN)
+inline constexpr const char* backend = "cartesian_vector (built-in)";
+using vec3 = cartesian_vector<double>;
+#endif
+
+[[nodiscard]] vec3 make_vec3(double x, double y, double z) { return {x, y, z}; }
+
+// Only the built-in `cartesian_vector` backend offers `constexpr` arithmetic; the third-party
+// cross products are runtime-only (e.g. `blaze::cross` materializes via a non-constexpr ctor), so
+// marking their helper `constexpr` would be an ill-formed never-constant-expression function.
+#if defined(MP_UNITS_LA_CARTESIAN)
+#define MP_UNITS_LA_CONSTEXPR constexpr
+#else
+#define MP_UNITS_LA_CONSTEXPR
+#endif
+
+// Euclidean cross product on the bare vector type. Every backend spells it differently, so the
+// difference is confined to this one helper; the quantity-level overload below is backend-agnostic.
+[[nodiscard]] MP_UNITS_LA_CONSTEXPR vec3 cross(const vec3& lhs, const vec3& rhs)
 {
-  const auto& v = q.numerical_value_ref_in(q.unit);
-  return hypot(v(0) * QS[Q::unit], v(1) * QS[Q::unit], v(2) * QS[Q::unit]);
+#if defined(MP_UNITS_LA_EIGEN)
+  return lhs.cross(rhs);
+#elif defined(MP_UNITS_LA_GLM)
+  return glm::cross(lhs, rhs);
+#elif defined(MP_UNITS_LA_BLAZE)
+  return blaze::cross(lhs, rhs);
+#elif defined(MP_UNITS_LA_CARTESIAN)
+  return vector_product(lhs, rhs);
+#endif
 }
 
-template<QuantitySpec auto QS, QuantityOf<QS> T>
-  requires(T::quantity_spec.character == quantity_character::vector) &&
-          (QS.character == quantity_character::real_scalar)
-[[nodiscard]] constexpr QuantityOf<QS> auto get_magnitude(const vector<T>& v)
-{
-  return hypot(QS(v(0)), QS(v(1)), QS(v(2)));
-}
-
-template<typename T, typename U>
-[[nodiscard]] constexpr vector<decltype(T{} * U{})> cross_product(const vector<T>& a, const vector<U>& b)
-{
-  return {a(1) * b(2) - a(2) * b(1), a(2) * b(0) - a(0) * b(2), a(0) * b(1) - a(1) * b(0)};
-}
-
+// Cross product of two vector quantities: cross the numerical values, then combine the references.
 template<Quantity Q1, Quantity Q2>
-[[nodiscard]] constexpr QuantityOf<Q1::quantity_spec * Q2::quantity_spec> auto cross_product(const Q1& q1, const Q2& q2)
+[[nodiscard]] MP_UNITS_LA_CONSTEXPR QuantityOf<Q1::quantity_spec * Q2::quantity_spec> auto cross(const Q1& q1,
+                                                                                                 const Q2& q2)
 {
-  return cross_product(q1.numerical_value_ref_in(q1.unit), q2.numerical_value_ref_in(q2.unit)) *
-         (Q1::reference * Q2::reference);
+  return cross(q1.numerical_value_in(q1.unit), q2.numerical_value_in(q2.unit)) * (Q1::reference * Q2::reference);
 }
+
+// --- compile-time guarantees -------------------------------------------------------------------
+
+// The library vector type is accepted as a vector representation.
+static_assert(RepresentationOf<vec3, quantity_character::vector>);
+
+// A library scalar multiplication may yield a lazy expression template; the representation
+// machinery must canonicalize it back to the concrete vector type rather than store the proxy
+// (which would dangle). `decltype(vec3{} * 2.0)` is exactly such a proxy for Eigen/Blaze.
+static_assert(std::same_as<representation_canonical_type_t<decltype(std::declval<vec3>() * 2.0)>, vec3>);
+
+// Consequently, arithmetic on vector quantities stores the concrete vector type, not a proxy.
+static_assert(std::same_as<decltype(make_vec3(1, 2, 3) * isq::velocity[m / s] * (2. * isq::duration[s]))::rep, vec3>);
+
+// A vector quantity models the `Vector` concept (so `magnitude(q)` works on it directly) ...
+static_assert(detail::Vector<decltype(make_vec3(0, 0, 0) * isq::velocity[m / s])>);
+// ... but is NOT a representation type: a quantity can never be nested as another quantity's
+// representation (`value_type_t<quantity>` is the quantity itself, which `NotQuantity` rejects).
+static_assert(!detail::VectorRepresentation<decltype(make_vec3(0, 0, 0) * isq::velocity[m / s])>);
+static_assert(!RepresentationOf<decltype(make_vec3(0, 0, 0) * isq::velocity[m / s]), quantity_character::vector>);
+// `magnitude()` of a vector quantity is a scalar quantity in the same unit.
+static_assert(QuantityOf<decltype(magnitude(make_vec3(3, 4, 0) * isq::velocity[m / s])), isq::speed>);
 
 }  // namespace
 
-TEST_CASE("vector quantity", "[la]")
+TEST_CASE("linear algebra type as a quantity representation")
 {
-  SECTION("cast of unit")
-  {
-    SECTION("non-truncating")
-    {
-      const auto v = vector<int>{3, 2, 1} * isq::displacement[km];
-      CHECK(v.numerical_value_in(m) == vector<int>{3000, 2000, 1000});
-    }
+  INFO("backend: " << backend);
 
-    SECTION("truncating")
-    {
-      const auto v = vector<int>{1001, 1002, 1003} * isq::displacement[m];
-      CHECK(v.force_numerical_value_in(km) == vector<int>{1, 1, 1});
-    }
+  SECTION("construction preserves the numerical value")
+  {
+    const quantity v = make_vec3(1, 2, 3) * isq::displacement[m];
+    const auto& nv = v.numerical_value_in(m);
+    CHECK(nv[0] == 1);
+    CHECK(nv[1] == 2);
+    CHECK(nv[2] == 3);
   }
 
-  SECTION("to scalar magnitude")
+  SECTION("exact unit conversion (km -> m) of a vector quantity")
   {
-    const auto v = vector<int>{2, 3, 6} * isq::velocity[km / h];
-    const auto speed = get_magnitude<isq::speed>(v);
-    CHECK(speed.numerical_value_ref_in(km / h) == 7);
+    const quantity v = make_vec3(3, 2, 1) * isq::displacement[km];
+    const auto& nv = v.numerical_value_in(m);
+    CHECK(nv[0] == 3000);
+    CHECK(nv[1] == 2000);
+    CHECK(nv[2] == 1000);
   }
 
-  SECTION("multiply by scalar value")
+  SECTION("multiplication by a scalar number, on either side")
   {
-    const auto v = vector<int>{1, 2, 3} * isq::displacement[m];
-
-    SECTION("integral")
-    {
-      SECTION("scalar on LHS") { CHECK((2 * v).numerical_value_in(m) == vector<int>{2, 4, 6}); }
-      SECTION("scalar on RHS") { CHECK((v * 2).numerical_value_in(m) == vector<int>{2, 4, 6}); }
-    }
-
-    SECTION("floating-point")
-    {
-      SECTION("scalar on LHS") { CHECK((0.5 * v).numerical_value_in(m) == vector<double>{0.5, 1., 1.5}); }
-      SECTION("scalar on RHS") { CHECK((v * 0.5).numerical_value_in(m) == vector<double>{0.5, 1., 1.5}); }
-    }
+    const quantity v = make_vec3(1, 2, 3) * isq::displacement[m];
+    const auto& left = (2. * v).numerical_value_in(m);
+    const auto& right = (v * 2.).numerical_value_in(m);
+    CHECK(left[0] == 2);
+    CHECK(left[1] == 4);
+    CHECK(left[2] == 6);
+    CHECK(right[0] == 2);
+    CHECK(right[1] == 4);
+    CHECK(right[2] == 6);
   }
 
-  SECTION("divide by scalar value")
+  SECTION("division by a scalar number")
   {
-    const auto v = vector<int>{2, 4, 6} * isq::displacement[m];
-
-    SECTION("integral") { CHECK((v / 2).numerical_value_in(m) == vector<int>{1, 2, 3}); }
-    SECTION("floating-point") { CHECK((v / 0.5).numerical_value_in(m) == vector<double>{4., 8., 12.}); }
+    const quantity v = make_vec3(2, 4, 6) * isq::displacement[m];
+    const auto& nv = (v / 2.).numerical_value_in(m);
+    CHECK(nv[0] == 1);
+    CHECK(nv[1] == 2);
+    CHECK(nv[2] == 3);
   }
 
-  SECTION("add")
+  SECTION("unary negation")
   {
-    const auto v = vector<int>{1, 2, 3} * isq::displacement[m];
-
-    SECTION("same unit")
-    {
-      const auto u = vector<int>{3, 2, 1} * isq::displacement[m];
-      CHECK((v + u).numerical_value_in(m) == vector<int>{4, 4, 4});
-    }
-    SECTION("different units")
-    {
-      const auto u = vector<int>{3, 2, 1} * isq::displacement[km];
-      CHECK((v + u).numerical_value_in(m) == vector<int>{3001, 2002, 1003});
-    }
+    const quantity v = make_vec3(1, -2, 3) * isq::displacement[m];
+    const auto& nv = (-v).numerical_value_in(m);
+    CHECK(nv[0] == -1);
+    CHECK(nv[1] == 2);
+    CHECK(nv[2] == -3);
   }
 
-  SECTION("subtract")
+  SECTION("vector quantity times scalar quantity yields a vector quantity")
   {
-    const auto v = vector<int>{1, 2, 3} * isq::displacement[m];
-
-    SECTION("same unit")
-    {
-      const auto u = vector<int>{3, 2, 1} * isq::displacement[m];
-      CHECK((v - u).numerical_value_in(m) == vector<int>{-2, 0, 2});
-    }
-    SECTION("different units")
-    {
-      const auto u = vector<int>{3, 2, 1} * isq::displacement[km];
-      CHECK((v - u).numerical_value_in(m) == vector<int>{-2999, -1998, -997});
-    }
+    const quantity velocity = make_vec3(30, 40, 0) * isq::velocity[km / h];
+    const quantity displacement = velocity * (2. * isq::duration[h]);
+    const auto& nv = displacement.in(km).numerical_value_in(km);
+    CHECK(nv[0] == 60);
+    CHECK(nv[1] == 80);
+    CHECK(nv[2] == 0);
   }
 
-  SECTION("multiply by scalar quantity")
+  SECTION("scalar quantity multiplication is symmetric and combines the quantity specifications")
   {
-    const auto v = vector<int>{1, 2, 3} * isq::velocity[m / s];
+    const quantity v = make_vec3(1, 2, 3) * isq::velocity[m / s];
+    const quantity mass = 2. * isq::mass[kg];
 
-    SECTION("integral")
-    {
-      const auto mass = 2 * isq::mass[kg];
+    // the result is a derived quantity (mass * velocity), with the same value on either side
+    const auto& lhs = (mass * v).numerical_value_in(kg * m / s);
+    const auto& rhs = (v * mass).numerical_value_in(kg * m / s);
+    CHECK(lhs[0] == 2);
+    CHECK(lhs[1] == 4);
+    CHECK(lhs[2] == 6);
+    CHECK(rhs[0] == 2);
+    CHECK(rhs[1] == 4);
+    CHECK(rhs[2] == 6);
 
-      SECTION("derived_quantity_spec")
-      {
-        SECTION("scalar on LHS") { CHECK((mass * v).numerical_value_in(kg * m / s) == vector<int>{2, 4, 6}); }
-        SECTION("scalar on RHS") { CHECK((v * mass).numerical_value_in(kg * m / s) == vector<int>{2, 4, 6}); }
-      }
-      SECTION("quantity_cast to momentum")
-      {
-        SECTION("scalar on LHS")
-        {
-          CHECK(quantity_cast<isq::momentum>(mass * v).numerical_value_in(N * s) == vector<int>{2, 4, 6});
-        }
-        SECTION("scalar on RHS")
-        {
-          CHECK(quantity_cast<isq::momentum>(v * mass).numerical_value_in(N * s) == vector<int>{2, 4, 6});
-        }
-      }
-      SECTION("quantity of momentum")
-      {
-        SECTION("scalar on LHS")
-        {
-          const quantity<isq::momentum[N * s], vector<int>> momentum = mass * v;
-          CHECK(momentum.numerical_value_ref_in(N * s) == vector<int>{2, 4, 6});
-        }
-        SECTION("scalar on RHS")
-        {
-          const quantity<isq::momentum[N * s], vector<int>> momentum = v * mass;
-          CHECK(momentum.numerical_value_ref_in(N * s) == vector<int>{2, 4, 6});
-        }
-      }
-    }
-
-    SECTION("floating-point")
-    {
-      const auto mass = 0.5 * isq::mass[kg];
-
-      SECTION("derived_quantity_spec")
-      {
-        SECTION("scalar on LHS") { CHECK((mass * v).numerical_value_in(kg * m / s) == vector<double>{0.5, 1., 1.5}); }
-        SECTION("scalar on RHS") { CHECK((v * mass).numerical_value_in(kg * m / s) == vector<double>{0.5, 1., 1.5}); }
-      }
-      SECTION("quantity_cast to momentum")
-      {
-        SECTION("scalar on LHS")
-        {
-          CHECK(quantity_cast<isq::momentum>(mass * v).numerical_value_in(N * s) == vector<double>{0.5, 1., 1.5});
-        }
-        SECTION("scalar on RHS")
-        {
-          CHECK(quantity_cast<isq::momentum>(v * mass).numerical_value_in(N * s) == vector<double>{0.5, 1., 1.5});
-        }
-      }
-      SECTION("quantity of momentum")
-      {
-        SECTION("scalar on LHS")
-        {
-          const quantity<isq::momentum[N * s], vector<double>> momentum = mass * v;
-          CHECK(momentum.numerical_value_ref_in(N * s) == vector<double>{0.5, 1., 1.5});
-        }
-        SECTION("scalar on RHS")
-        {
-          const quantity<isq::momentum[N * s], vector<double>> momentum = v * mass;
-          CHECK(momentum.numerical_value_ref_in(N * s) == vector<double>{0.5, 1., 1.5});
-        }
-      }
-    }
+    // the derived quantity can be cast to the named quantity it represents
+    const quantity<isq::momentum[N * s], vec3> momentum = quantity_cast<isq::momentum>(mass * v);
+    const auto& nv = momentum.numerical_value_in(N * s);
+    CHECK(nv[0] == 2);
+    CHECK(nv[1] == 4);
+    CHECK(nv[2] == 6);
   }
 
-  SECTION("divide by scalar quantity")
+  SECTION("vector quantity divided by a scalar quantity")
   {
-    const auto pos = vector<int>{30, 20, 10} * isq::displacement[km];
+    const quantity displacement = make_vec3(60, 80, 0) * isq::displacement[km];
+    const quantity velocity = displacement / (2. * isq::duration[h]);
+    const auto& nv = velocity.numerical_value_in(km / h);
+    CHECK(nv[0] == 30);
+    CHECK(nv[1] == 40);
+    CHECK(nv[2] == 0);
 
-    SECTION("integral")
-    {
-      const auto dur = 2 * isq::duration[h];
-
-      SECTION("derived_quantity_spec") { CHECK((pos / dur).numerical_value_in(km / h) == vector<int>{15, 10, 5}); }
-      SECTION("quantity_cast to velocity")
-      {
-        CHECK(quantity_cast<isq::velocity>(pos / dur).numerical_value_in(km / h) == vector<int>{15, 10, 5});
-      }
-      SECTION("quantity of velocity")
-      {
-        const quantity<isq::velocity[km / h], vector<int>> v = pos / dur;
-        CHECK(v.numerical_value_ref_in(km / h) == vector<int>{15, 10, 5});
-      }
-    }
-
-    SECTION("floating-point")
-    {
-      const auto dur = 0.5 * isq::duration[h];
-
-      SECTION("derived_quantity_spec") { CHECK((pos / dur).numerical_value_in(km / h) == vector<double>{60, 40, 20}); }
-      SECTION("quantity_cast to velocity")
-      {
-        CHECK(quantity_cast<isq::velocity>(pos / dur).numerical_value_in(km / h) == vector<double>{60, 40, 20});
-      }
-      SECTION("quantity of velocity")
-      {
-        const quantity<isq::velocity[km / h], vector<double>> v = pos / dur;
-        CHECK(v.numerical_value_ref_in(km / h) == vector<double>{60, 40, 20});
-      }
-    }
+    // the derived quantity (displacement / duration) can be cast to the named velocity quantity
+    const quantity<isq::velocity[km / h], vec3> casted = quantity_cast<isq::velocity>(velocity);
+    const auto& cnv = casted.numerical_value_in(km / h);
+    CHECK(cnv[0] == 30);
+    CHECK(cnv[1] == 40);
+    CHECK(cnv[2] == 0);
   }
 
-  SECTION("cross product with a vector quantity")
+  SECTION("cross product of two vector quantities combines their quantity specifications")
   {
-    const auto r = vector<int>{3, 0, 0} * isq::displacement[m];
-    const auto f = vector<int>{0, 10, 0} * isq::force[N];
+    const quantity position = make_vec3(3, 0, 0) * isq::position_vector[m];
+    const quantity force = make_vec3(0, 10, 0) * isq::force[N];
+    const quantity moment = cross(position, force);
+    const auto& nv = moment.numerical_value_in(N * m);
+    CHECK(nv[0] == 0);
+    CHECK(nv[1] == 0);
+    CHECK(nv[2] == 30);
+    // r x F has the quantity specification of a moment of force
+    static_assert(implicitly_convertible(decltype(moment)::quantity_spec, isq::moment_of_force));
+  }
 
-    CHECK(cross_product(r, f) == vector<int>{0, 0, 30} * isq::moment_of_force[N * m]);
+  SECTION("vector addition with an automatic unit conversion of one operand")
+  {
+    const quantity lhs = make_vec3(1, 2, 3) * isq::displacement[km];
+    const quantity rhs = make_vec3(500, 0, 0) * isq::displacement[m];
+    const auto& nv = (lhs + rhs).numerical_value_in(m);
+    CHECK(nv[0] == 1500);
+    CHECK(nv[1] == 2000);
+    CHECK(nv[2] == 3000);
+  }
+
+  SECTION("vector subtraction with an automatic unit conversion of one operand")
+  {
+    const quantity lhs = make_vec3(1, 2, 3) * isq::displacement[km];
+    const quantity rhs = make_vec3(500, 0, 0) * isq::displacement[m];
+    const auto& nv = (lhs - rhs).numerical_value_in(m);
+    CHECK(nv[0] == 500);
+    CHECK(nv[1] == 2000);
+    CHECK(nv[2] == 3000);
+  }
+
+  SECTION("Euclidean magnitude as a scalar quantity (via the norm() the library provides)")
+  {
+    const quantity velocity = make_vec3(30, 40, 0) * isq::velocity[km / h];
+    const quantity speed = magnitude(velocity);
+    CHECK_THAT(speed.numerical_value_in(km / h), Catch::Matchers::WithinAbs(50.0, 1e-9));
+  }
+
+  SECTION("equality of vector quantities")
+  {
+    const quantity lhs = make_vec3(1, 2, 3) * isq::displacement[km];
+    const quantity rhs = make_vec3(1000, 2000, 3000) * isq::displacement[m];
+    CHECK(lhs == rhs);
+    CHECK(lhs != make_vec3(1, 2, 4) * isq::displacement[km]);
   }
 }
 
-TEST_CASE("vector of quantities", "[la]")
+#if defined(MP_UNITS_LA_CARTESIAN)
+
+// The built-in `cartesian_vector` supports integral representations and `constexpr` evaluation,
+// which the floating-point, runtime-only third-party backends above cannot exercise. These checks
+// are therefore specific to the built-in backend.
+
+namespace {
+using vec3i = cartesian_vector<int>;
+[[nodiscard]] constexpr vec3i make_vec3i(int x, int y, int z) { return {x, y, z}; }
+}  // namespace
+
+TEST_CASE("built-in cartesian_vector with an integral representation")
 {
-  SECTION("cast of unit")
+  SECTION("exact (non-truncating) unit conversion preserves all components")
   {
-    SECTION("non-truncating")
-    {
-      const vector<quantity<isq::displacement[km], int>> v = {3 * km, 2 * km, 1 * km};
-
-      CHECK(vector<quantity<isq::displacement[m], int>>(v) ==
-            vector<quantity<isq::displacement[m], int>>{3000 * m, 2000 * m, 1000 * m});
-    }
-
-    // truncating not possible (no way to apply quantity_cast to sub-components of a vector)
+    const quantity v = make_vec3i(3, 2, 1) * isq::displacement[km];
+    CHECK(v.numerical_value_in(m) == vec3i{3000, 2000, 1000});
   }
 
-  SECTION("to scalar magnitude")
+  SECTION("truncating unit conversion requires the forcing interface")
   {
-    const vector<quantity<isq::velocity[km / h], int>> v = {2 * km / h, 3 * km / h, 6 * km / h};
-    const auto speed = get_magnitude<isq::speed>(v);
-    CHECK(speed.numerical_value_ref_in(km / h) == 7);
+    const quantity v = make_vec3i(1500, 1500, 1500) * isq::displacement[m];
+    CHECK(v.force_numerical_value_in(km) == vec3i{1, 1, 1});
   }
 
-  SECTION("multiply by scalar value")
+  SECTION("integral multiplication and division by a scalar number")
   {
-    const vector<quantity<isq::displacement[m], int>> v = {1 * m, 2 * m, 3 * m};
-
-    SECTION("integral")
-    {
-      const vector<quantity<isq::displacement[m], int>> result = {2 * m, 4 * m, 6 * m};
-
-      SECTION("scalar on LHS") { CHECK(2 * v == result); }
-      SECTION("scalar on RHS") { CHECK(v * 2 == result); }
-    }
-
-    SECTION("floating-point")
-    {
-      const vector<quantity<isq::displacement[m], double>> result = {0.5 * m, 1. * m, 1.5 * m};
-
-      SECTION("scalar on LHS") { CHECK(0.5 * v == result); }
-      SECTION("scalar on RHS") { CHECK(v * 0.5 == result); }
-    }
+    const quantity v = make_vec3i(1, 2, 3) * isq::displacement[m];
+    CHECK((2 * v).numerical_value_in(m) == vec3i{2, 4, 6});
+    CHECK((v * 2).numerical_value_in(m) == vec3i{2, 4, 6});
+    CHECK((v / 2).numerical_value_in(m) == vec3i{0, 1, 1});
   }
 
-  SECTION("divide by scalar value")
+  SECTION("integral addition and subtraction")
   {
-    const vector<quantity<isq::displacement[m], int>> v = {2 * m, 4 * m, 6 * m};
-
-    SECTION("integral") { CHECK(v / 2 == vector<quantity<isq::displacement[m], int>>{1 * m, 2 * m, 3 * m}); }
-    SECTION("floating-point")
-    {
-      CHECK(v / 0.5 == vector<quantity<isq::displacement[m], double>>{4. * m, 8. * m, 12. * m});
-    }
-  }
-
-  SECTION("add")
-  {
-    const vector<quantity<isq::displacement[m], int>> v = {1 * m, 2 * m, 3 * m};
-
-    SECTION("same unit")
-    {
-      const vector<quantity<isq::displacement[m], int>> u = {3 * m, 2 * m, 1 * m};
-
-      CHECK(v + u == vector<quantity<isq::displacement[m], int>>{4 * m, 4 * m, 4 * m});
-    }
-    SECTION("different units")
-    {
-      const vector<quantity<isq::displacement[km], int>> u = {3 * km, 2 * km, 1 * km};
-
-      CHECK(v + u == vector<quantity<isq::displacement[m], int>>{3001 * m, 2002 * m, 1003 * m});
-    }
-  }
-
-  SECTION("subtract")
-  {
-    const vector<quantity<isq::displacement[m], int>> v = {1 * m, 2 * m, 3 * m};
-
-    SECTION("same unit")
-    {
-      const vector<quantity<isq::displacement[m], int>> u = {3 * m, 2 * m, 1 * m};
-      CHECK(v - u == vector<quantity<isq::displacement[m], int>>{-2 * m, 0 * m, 2 * m});
-    }
-    SECTION("different units")
-    {
-      const vector<quantity<isq::displacement[km], int>> u = {3 * km, 2 * km, 1 * km};
-      CHECK(v - u == vector<quantity<isq::displacement[m], int>>{-2999 * m, -1998 * m, -997 * m});
-    }
-  }
-
-  SECTION("multiply by scalar quantity")
-  {
-    const vector<quantity<isq::velocity[m / s], int>> v = {1 * m / s, 2 * m / s, 3 * m / s};
-
-    SECTION("integral")
-    {
-      const auto mass = 2 * isq::mass[kg];
-      const auto result = vector<quantity<isq::momentum[N * s], int>>{2 * N * s, 4 * N * s, 6 * N * s};
-
-      SECTION("derived_quantity_spec")
-      {
-        SECTION("scalar on LHS") { CHECK(mass * v == result); }
-        SECTION("scalar on RHS") { CHECK(v * mass == result); }
-      }
-
-      // no way to apply quantity_cast to sub-components
-
-      SECTION("quantity of momentum")
-      {
-        SECTION("scalar on LHS")
-        {
-          const vector<quantity<isq::momentum[N * s], int>> momentum = mass * v;
-          CHECK(momentum == result);
-        }
-        SECTION("scalar on RHS")
-        {
-          const vector<quantity<isq::momentum[N * s], int>> momentum = v * mass;
-          CHECK(momentum == result);
-        }
-      }
-    }
-
-    SECTION("floating-point")
-    {
-      const auto mass = 0.5 * isq::mass[kg];
-      const auto result = vector<quantity<isq::momentum[N * s], double>>{0.5 * N * s, 1. * N * s, 1.5 * N * s};
-
-      SECTION("derived_quantity_spec")
-      {
-        SECTION("scalar on LHS") { CHECK(mass * v == result); }
-        SECTION("scalar on RHS") { CHECK(v * mass == result); }
-      }
-
-      // no way to apply quantity_cast to sub-components
-
-      SECTION("quantity of momentum")
-      {
-        SECTION("scalar on LHS")
-        {
-          const vector<quantity<isq::momentum[N * s], double>> momentum = mass * v;
-          CHECK(momentum == result);
-        }
-        SECTION("scalar on RHS")
-        {
-          const vector<quantity<isq::momentum[N * s], double>> momentum = v * mass;
-          CHECK(momentum == result);
-        }
-      }
-    }
-  }
-
-  SECTION("divide by scalar quantity")
-  {
-    const vector<quantity<isq::displacement[km], int>> pos = {30 * km, 20 * km, 10 * km};
-
-    SECTION("integral")
-    {
-      const auto dur = 2 * isq::duration[h];
-
-      SECTION("derived_quantity_spec")
-      {
-        CHECK(pos / dur == vector<quantity<isq::velocity[km / h], int>>{15 * km / h, 10 * km / h, 5 * km / h});
-      }
-
-      // no way to apply quantity_cast to sub-components
-
-      SECTION("quantity of velocity")
-      {
-        const vector<quantity<isq::velocity[km / h], int>> v = pos / dur;
-        CHECK(v == vector<quantity<isq::velocity[km / h], int>>{15 * km / h, 10 * km / h, 5 * km / h});
-      }
-    }
-
-    SECTION("floating-point")
-    {
-      const auto dur = 0.5 * isq::duration[h];
-
-      SECTION("derived_quantity_spec")
-      {
-        CHECK(pos / dur == vector<quantity<isq::velocity[km / h], double>>{60. * km / h, 40. * km / h, 20. * km / h});
-      }
-
-      // no way to apply quantity_cast to sub-components
-
-      SECTION("quantity of velocity")
-      {
-        const vector<quantity<isq::velocity[km / h], double>> v = pos / dur;
-        CHECK(v == vector<quantity<isq::velocity[km / h], double>>{60. * km / h, 40. * km / h, 20. * km / h});
-      }
-    }
-  }
-
-  SECTION("cross product with a vector of quantities")
-  {
-    const vector<quantity<isq::displacement[m], int>> r = {3 * m, 0 * m, 0 * m};
-    const vector<quantity<isq::force[N], int>> f = {0 * N, 10 * N, 0 * N};
-
-    CHECK(cross_product(r, f) == vector<quantity<isq::moment_of_force[N * m], int>>{0 * N * m, 0 * N * m, 30 * N * m});
+    const quantity lhs = make_vec3i(1, 2, 3) * isq::displacement[m];
+    const quantity rhs = make_vec3i(3, 2, 1) * isq::displacement[m];
+    CHECK((lhs + rhs).numerical_value_in(m) == vec3i{4, 4, 4});
+    CHECK((lhs - rhs).numerical_value_in(m) == vec3i{-2, 0, 2});
   }
 }
+
+// the whole pipeline (construction, scaling, arithmetic) is usable in a constant expression
+static_assert((make_vec3i(1, 2, 3) * isq::displacement[m] + make_vec3i(3, 2, 1) * isq::displacement[m])
+                .numerical_value_in(m) == vec3i{4, 4, 4});
+static_assert(cross(make_vec3i(3, 0, 0) * isq::position_vector[m], make_vec3i(0, 10, 0) * isq::force[N])
+                .numerical_value_in(N * m) == vec3i{0, 0, 30});
+
+#endif  // MP_UNITS_LA_CARTESIAN

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -38,3 +38,35 @@ if(MP_UNITS_BUILD_CXX_MODULES)
     # target_compile_definitions(test_package PRIVATE MP_UNITS_MODULES)
     target_link_libraries(test_package PRIVATE mp-units::mp-units)
 endif()
+
+#
+# Linear algebra integration consumers
+#
+# For each backing library found, verify the integration can be consumed from the installed
+# package: the header always ships (header-mode consumer), and in a modules build the
+# `mp_units.integrations.<lib>` module is consumed too (module-mode consumer).
+find_package(Eigen3 QUIET)
+find_package(glm QUIET)
+find_package(blaze QUIET)
+
+# The integration is verified in header mode: the header always ships and is consumable from any
+# package (header-only or modules). Module-mode consumption (`import mp_units.integrations.<lib>`)
+# is NOT exercised here for the same reason the main `test_package` does not `import mp_units;` -
+# rebuilding C++ module BMIs from an installed package is a known unsupported scenario (see the
+# `MP_UNITS_MODULES` TODO above). Module-mode use is covered in-tree by the `linear_algebra` example.
+function(add_integration_test_package backend dependency)
+    if(NOT TARGET ${dependency})
+        return()
+    endif()
+    add_executable(test_package_integration-${backend}-headers test_package_integration.cpp)
+    target_compile_features(
+        test_package_integration-${backend}-headers PRIVATE $<IF:$<BOOL:${CMAKE_CXX_MODULE_STD}>,cxx_std_23,cxx_std_20>
+    )
+    target_link_libraries(
+        test_package_integration-${backend}-headers PRIVATE mp-units::integrations mp-units::systems ${dependency}
+    )
+endfunction()
+
+add_integration_test_package(eigen Eigen3::Eigen)
+add_integration_test_package(glm glm::glm)
+add_integration_test_package(blaze blaze::blaze)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -31,8 +31,13 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps"
 
+    # backing libraries exercised by the linear algebra integration consumers
+    _linear_algebra_libs = ["eigen/5.0.1", "glm/1.0.1", "blaze/3.8.2"]
+
     def requirements(self):
         self.requires(self.tested_reference_str)
+        for ref in self._linear_algebra_libs:
+            self.requires(ref)
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=4.3.0 <5]")
@@ -60,9 +65,20 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if can_run(self):
-            if self.dependencies["mp-units"].options.cxx_modules:
-                bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+        if not can_run(self):
+            return
+        bindir = self.cpp.build.bindirs[0]
+        modules = bool(self.dependencies["mp-units"].options.cxx_modules)
+
+        names = ["test_package-headers"]
+        if modules:
+            names.append("test_package")
+        # Linear algebra integrations are verified in header mode (the headers always ship and are
+        # consumable from any package). Run whichever backends were found at build time.
+        for backend in ("eigen", "glm", "blaze"):
+            names.append(f"test_package_integration-{backend}-headers")
+
+        for name in names:
+            bin_path = os.path.join(bindir, name)
+            if os.path.exists(bin_path) or os.path.exists(bin_path + ".exe"):
                 self.run(bin_path, env="conanrun")
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package-headers")
-            self.run(bin_path, env="conanrun")

--- a/test_package/test_package_integration.cpp
+++ b/test_package/test_package_integration.cpp
@@ -1,0 +1,94 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Verifies that an installed linear algebra integration can be consumed - both as a header
+// (`#include <mp-units/integrations/<lib>.h>`) and, in a modules build, as a module
+// (`import mp_units.integrations.<lib>;`). The backend is selected from whatever library the
+// linked target makes available.
+
+#include <mp-units/compat_macros.h>
+
+#if __has_include(<Eigen/Core>)
+#include <Eigen/Core>
+#define MP_UNITS_LA_EIGEN
+#elif __has_include(<glm/vec3.hpp>)
+#include <glm/geometric.hpp>
+#include <glm/vec3.hpp>
+#define MP_UNITS_LA_GLM
+#elif __has_include(<blaze/math/StaticVector.h>)
+#include <blaze/math/StaticVector.h>
+#define MP_UNITS_LA_BLAZE
+#else
+#error "No supported linear algebra library found on the include path"
+#endif
+
+#if MP_UNITS_HOSTED
+#ifdef MP_UNITS_IMPORT_STD
+import std;
+#else
+#include <iostream>
+#endif
+#endif
+
+#ifdef MP_UNITS_MODULES
+import mp_units;
+#if defined(MP_UNITS_LA_EIGEN)
+import mp_units.integrations.eigen;
+#elif defined(MP_UNITS_LA_GLM)
+import mp_units.integrations.glm;
+#elif defined(MP_UNITS_LA_BLAZE)
+import mp_units.integrations.blaze;
+#endif
+#else
+#include <mp-units/math.h>
+#include <mp-units/systems/isq.h>
+#include <mp-units/systems/si.h>
+#if defined(MP_UNITS_LA_EIGEN)
+#include <mp-units/integrations/eigen.h>
+#elif defined(MP_UNITS_LA_GLM)
+#include <mp-units/integrations/glm.h>
+#elif defined(MP_UNITS_LA_BLAZE)
+#include <mp-units/integrations/blaze.h>
+#endif
+#endif
+
+using namespace mp_units;
+
+#if defined(MP_UNITS_LA_EIGEN)
+using vec3 = Eigen::Vector3d;
+#elif defined(MP_UNITS_LA_GLM)
+using vec3 = glm::dvec3;
+#elif defined(MP_UNITS_LA_BLAZE)
+using vec3 = blaze::StaticVector<double, 3>;
+#endif
+
+int main()
+{
+  using namespace mp_units::si::unit_symbols;
+  const quantity velocity = vec3{3., 4., 0.} * isq::velocity[km / h];
+  const quantity speed = magnitude(velocity.numerical_value_in(km / h)) * (km / h);
+#if MP_UNITS_HOSTED
+  std::cout << "speed = " << speed.numerical_value_in(km / h) << " km/h\n";
+#else
+  [[maybe_unused]] auto value = speed;
+#endif
+}


### PR DESCRIPTION
## Summary

Adds opt-in integrations that let mainstream linear algebra libraries (Eigen, GLM, Blaze) act
directly as `quantity` representation types, plus a `quantity::magnitude()` member for vector
quantities. Resolves #301.

## Linear algebra integrations

- New opt-in adapters, available both as headers (`mp-units/integrations/{eigen,glm,blaze}.h`)
  and named modules (`mp_units.integrations.{eigen,glm,blaze}`).
- Each header is guarded with `__has_include`, so it is a harmless no-op when its library is
  absent. The adapters only wire up the representation customization points. No user adapter code
  is needed, and the libraries' native vector and matrix types are used directly.
- The built-in `cartesian_vector` needs no plugin, and plain `double` and `int` work as
  one-dimensional vector representations.

## `representation_canonical_type` customization point

Materializes expression-template results (for example the Eigen and Blaze lazy proxies) into
their concrete type before they are stored in a `quantity`, so a `quantity` never holds a
dangling reference to an expired operand.

## `quantity::magnitude()` member

- A vector `quantity` now supports `magnitude()` directly (the `magnitude` CPO finds the member),
  returning the Euclidean magnitude as a scalar quantity. This removes the need for user-defined
  `magnitude_of` helpers.
- Known V2 limitation, documented in the code and the user guide: the result drops the precise
  quantity spec down to the unit's kind, because V2 cannot express a dedicated scalar-magnitude
  quantity spec. For the same reason, quantity-level `scalar_product()` and `vector_product()`
  are not provided. They would need to return a different quantity kind, which V2 references
  cannot name, so they remain available only on the raw representation.

## Packaging

Per-backend CMake targets `mp-units::integrations-<name>` are provided for source consumers
(`add_subdirectory` / FetchContent) and raw `cmake --install`. They are intentionally not
surfaced as Conan components (documented in `conanfile.py`): Conan consumers link
`mp-units::integrations` plus their own linear algebra library.

## Docs and tests

- User guide (`representation_types.md`), the custom-representation how-to guide, and a new
  annotated example (`docs/examples/linear_algebra.md` with `example/linear_algebra.cpp`)
  compiled against all backends in both header and module modes.
- `test/runtime/linear_algebra_test.cpp` reworked to exercise the integrations and the
  compile-time guarantees.
- `test_package` extended with header-mode integration consumers for each backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
