### PR TITLE
perf: compile-time performance fixes for 2.6.0

### DIFF
--- a/src/core/include/mp-units/bits/fixed_point.h
+++ b/src/core/include/mp-units/bits/fixed_point.h
@@ -24,6 +24,7 @@
 
 #include <mp-units/bits/hacks.h>  // IWYU pragma: keep
 #include <mp-units/bits/int_power.h>
+#include <mp-units/ext/algorithm.h>
 #include <mp-units/ext/type_traits.h>  // IWYU pragma: keep
 
 // `double_width_int` only emulates `int128_t` on platforms without native `__int128` (notably
@@ -36,7 +37,6 @@
 #ifdef MP_UNITS_IMPORT_STD
 import std;
 #else
-#include <algorithm>
 #include <bit>
 #include <concepts>
 #include <cstdint>
@@ -112,7 +112,7 @@ using make_signed_t = conditional<!is_same_v<T, uint128_t>, std::make_signed<T>,
 
 template<std::size_t N>
 using min_width_uint_t =
-  std::tuple_element_t<std::max<std::size_t>(4u, std::bit_width(N) + (std::has_single_bit(N) ? 0u : 1u)) - 4u,
+  std::tuple_element_t<detail::max<std::size_t>(4u, std::bit_width(N) + (std::has_single_bit(N) ? 0u : 1u)) - 4u,
                        std::tuple<std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t, uint128_t>>;
 
 template<std::size_t N>

--- a/src/core/include/mp-units/bits/hacks.h
+++ b/src/core/include/mp-units/bits/hacks.h
@@ -38,6 +38,14 @@
 
 // Adapted from https://github.com/ericniebler/range-v3/blob/master/include/range/v3/detail/config.hpp#L185.
 #define MP_UNITS_PRAGMA(X) _Pragma(#X)
+
+// `#warning` is C++23, and MSVC emits a hard error for it in earlier modes, so deprecated headers
+// use a compiler-specific pragma instead
+#if MP_UNITS_COMP_MSVC
+#define MP_UNITS_DEPRECATED_HEADER(Msg) MP_UNITS_PRAGMA(message(Msg))
+#else
+#define MP_UNITS_DEPRECATED_HEADER(Msg) MP_UNITS_PRAGMA(GCC warning Msg)
+#endif
 #if !MP_UNITS_COMP_MSVC
 #define MP_UNITS_DIAGNOSTIC_PUSH MP_UNITS_PRAGMA(GCC diagnostic push)
 #define MP_UNITS_DIAGNOSTIC_POP MP_UNITS_PRAGMA(GCC diagnostic pop)

--- a/src/core/include/mp-units/bits/int_power.h
+++ b/src/core/include/mp-units/bits/int_power.h
@@ -36,7 +36,8 @@ import std;
 // <cmath> becomes partially freestanding in C++26
 // before that, there is no guarantee about this header even existing
 // (GCC 14 has it, but actively #error's out)
-#if __STDC_HOSTED__
+// only needed for `std::ldexp`, which is used only when it is constexpr (C++23)
+#if __STDC_HOSTED__ && defined __cpp_lib_constexpr_cmath && __cpp_lib_constexpr_cmath >= 202202L
 #include <cmath>
 #endif
 #endif

--- a/src/core/include/mp-units/format.h
+++ b/src/core/include/mp-units/format.h
@@ -24,4 +24,6 @@
 
 #pragma once
 
-#warning "2.5.0: This header file is deprecated and does not have to be included anymore."
+#include <mp-units/bits/hacks.h>
+
+MP_UNITS_DEPRECATED_HEADER("2.5.0: This header file is deprecated and does not have to be included anymore.")

--- a/src/core/include/mp-units/framework/customization_points.h
+++ b/src/core/include/mp-units/framework/customization_points.h
@@ -439,6 +439,15 @@ constexpr bool disable_representation = detail::is_quantity_abstraction<detail::
 template<>
 MP_UNITS_INLINE constexpr bool disable_representation<bool> = true;
 
+// A representation carries a runtime value, which a stateless type cannot do. Rejecting empty tag
+// types here also short-circuits the whole representation-concept chain (`WeaklyRegular`, scaling,
+// and character detection) that overload resolution of symbolic expressions like `mag * unit` would
+// otherwise evaluate on every unit, magnitude, dimension, or quantity specification for each
+// candidate. An exotic stateless representation can still opt back in with an explicit
+// specialization, which takes precedence over this constrained one.
+template<detail::SymbolicConstant T>
+MP_UNITS_INLINE constexpr bool disable_representation<T> = true;
+
 MP_UNITS_EXPORT_BEGIN
 
 /**

--- a/src/core/include/mp-units/framework/quantity.h
+++ b/src/core/include/mp-units/framework/quantity.h
@@ -50,6 +50,7 @@ import std;
 #else
 #include <compare>  // IWYU pragma: export
 #include <concepts>
+#include <functional>
 #include <limits>
 #include <tuple>
 #include <type_traits>

--- a/src/core/include/mp-units/framework/representation_concepts.h
+++ b/src/core/include/mp-units/framework/representation_concepts.h
@@ -41,7 +41,6 @@ import std;
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
-#include <functional>
 #include <type_traits>
 #endif  // MP_UNITS_IMPORT_STD
 #endif  // MP_UNITS_IN_MODULE_INTERFACE

--- a/src/core/include/mp-units/framework/symbolic_expression.h
+++ b/src/core/include/mp-units/framework/symbolic_expression.h
@@ -33,7 +33,6 @@ import std;
 #else
 #include <concepts>
 #include <cstdint>
-#include <functional>
 #include <type_traits>
 #endif
 #endif
@@ -44,6 +43,16 @@ namespace detail {
 
 // `SymbolicArg` is provided because `SymbolicConstant` requires a complete type which is not the case
 // for `OneType` below.
+// resolves a dependent alias to the actual type when applied to a function call result
+// (a minimal stand-in for std `identity` that saves the whole <functional> include)
+struct identity_fn {
+  template<typename T>
+  [[nodiscard]] constexpr T operator()(T value) const
+  {
+    return value;
+  }
+};
+
 template<typename T>
 concept SymbolicArg = !std::is_const_v<T> && !std::is_reference_v<T>;
 
@@ -400,9 +409,9 @@ template<typename NumList, typename DenList, SymbolicArg OneType, template<typen
   using num_list = expr_consolidate<NumList>;
   using den_list = expr_consolidate<DenList>;
   using simple = expr_simplify<num_list, den_list, Pred>;
-  // the usage of `std::identity` below helps to resolve an using alias identifier to the actual
+  // the usage of `identity_fn` below helps to resolve an using alias identifier to the actual
   // type identifier in the clang compile-time errors
-  return std::identity{}(expr_make_spec_impl<typename simple::num, typename simple::den, OneType, To>());
+  return identity_fn{}(expr_make_spec_impl<typename simple::num, typename simple::den, OneType, To>());
 }
 
 /**
@@ -487,9 +496,9 @@ template<template<typename...> typename To, SymbolicArg OneType, typename T>
 [[nodiscard]] consteval auto expr_invert(T)
 {
   if constexpr (is_specialization_of<T, To>)
-    // the usage of `std::identity` below helps to resolve an using alias identifier to the actual
+    // the usage of `identity_fn` below helps to resolve an using alias identifier to the actual
     // type identifier in the clang compile-time errors
-    return std::identity{}(expr_make_spec_impl<typename T::_den_, typename T::_num_, OneType, To>());
+    return identity_fn{}(expr_make_spec_impl<typename T::_den_, typename T::_num_, OneType, To>());
   else
     return To<OneType, per<T>>{};
 }
@@ -615,7 +624,7 @@ template<template<typename> typename Proj, template<typename...> typename To, Sy
   using outer_den =
     type_list_merge_many_sorted<Pred, type_list<>, typename expr_map_contribution_t<Proj, To, OneType, Nums>::_den_...,
                                 typename expr_map_contribution_t<Proj, To, OneType, Dens>::_num_...>;
-  return std::identity{}(get_optimized_expression<outer_num, outer_den, OneType, Pred, To>());
+  return identity_fn{}(get_optimized_expression<outer_num, outer_den, OneType, Pred, To>());
 }
 
 /**

--- a/src/core/include/mp-units/framework/unit.h
+++ b/src/core/include/mp-units/framework/unit.h
@@ -171,7 +171,7 @@ constexpr bool is_positive_canonical_unit_mag = unit_mag_is_positive(U);
 }  // namespace detail
 
 template<UnitMagnitude auto M, Unit U>
-  requires(M != detail::unit_magnitude<>{} && M != mag<1>)
+  requires(M != mag<1>)  // `mag<1>` is the empty `unit_magnitude<>`, so a single check covers both spellings
 struct scaled_unit;
 
 template<detail::SymbolicConstant... Expr>
@@ -332,7 +332,7 @@ struct scaled_unit_impl : detail::unit_interface, detail::propagate_point_origin
  *       instantiate this type automatically based on the unit arithmetic equation provided by the user.
  */
 template<UnitMagnitude auto M, Unit U>
-  requires(M != detail::unit_magnitude<>{} && M != mag<1>)
+  requires(M != mag<1>)  // `mag<1>` is the empty `unit_magnitude<>`, so a single check covers both spellings
 struct scaled_unit final : detail::scaled_unit_impl<M, U> {};
 
 namespace detail {

--- a/src/core/include/mp-units/framework/unit.h
+++ b/src/core/include/mp-units/framework/unit.h
@@ -501,7 +501,9 @@ struct named_constant : decltype(U)::_base_type_ {
  */
 MP_UNITS_EXPORT template<symbol_text Symbol, UnitMagnitude auto M, PrefixableUnit auto U>
   requires(!Symbol.empty())
-struct prefixed_unit : decltype(M * U)::_base_type_ {
+// `PrefixableUnit` guarantees a named unit, so `M * U` always reduces to `scaled_unit<M, U>`; spelling the base
+// directly avoids instantiating the `operator*` machinery for every prefix and unit combination (e.g. unit_symbols.h)
+struct prefixed_unit : scaled_unit<M, MP_UNITS_REMOVE_CONST(decltype(U))>::_base_type_ {
   using _base_type_ = prefixed_unit;  // exposition only
   static constexpr auto _symbol_ = Symbol + U._symbol_;
 };

--- a/src/core/include/mp-units/framework/unit.h
+++ b/src/core/include/mp-units/framework/unit.h
@@ -130,6 +130,27 @@ template<Unit T, typename... Us>
 template<Unit U>
 constexpr auto get_canonical_unit_result = get_canonical_unit_impl(U{}, U{});
 
+template<symbol_text Symbol, auto... Args>
+[[nodiscard]] consteval bool unit_mag_is_positive(const named_unit<Symbol, Args...>&);
+
+template<symbol_text Symbol, Unit auto U, auto... Args>
+[[nodiscard]] consteval bool unit_mag_is_positive(const named_unit<Symbol, U, Args...>&);
+
+template<symbol_text Symbol, Unit auto U>
+[[nodiscard]] consteval bool unit_mag_is_positive(const named_constant<Symbol, U>&);
+
+template<typename F, int Num, int... Den>
+[[nodiscard]] consteval bool unit_mag_is_positive(const power<F, Num, Den...>&);
+
+template<typename... Expr>
+[[nodiscard]] consteval bool unit_mag_is_positive(const derived_unit_impl<Expr...>&);
+
+template<auto M, typename U>
+[[nodiscard]] consteval bool unit_mag_is_positive(const scaled_unit_impl<M, U>&);
+
+template<typename... Us>
+[[nodiscard]] consteval bool unit_mag_is_positive(const common_unit<Us...>&);
+
 }  // namespace detail
 
 // TODO this should really be in the `details` namespace and not exported but is used in `chrono.h`
@@ -141,8 +162,11 @@ MP_UNITS_EXPORT [[nodiscard]] consteval auto get_canonical_unit(Unit auto u)
 
 namespace detail {
 
+// This is evaluated for every named unit definition while system headers are being parsed, so it has to stay cheap.
+// The magnitude sign is determined structurally (a `negative_tag` always sorts first in a magnitude pack), which
+// avoids computing the canonical unit and prime-factorizing its magnitude only to read the sign.
 template<Unit auto U>
-constexpr bool is_positive_canonical_unit_mag = check_magnitude_is_positive(get_canonical_unit(U).mag);
+constexpr bool is_positive_canonical_unit_mag = unit_mag_is_positive(U);
 
 }  // namespace detail
 
@@ -665,6 +689,61 @@ template<Unit T, typename... Expr>
   auto num = get_canonical_unit_impl(typename derived_unit<Expr...>::_num_{});
   auto den = get_canonical_unit_impl(typename derived_unit<Expr...>::_den_{});
   return canonical_unit{num.mag / den.mag, num.reference_unit / den.reference_unit};
+}
+
+// A negative canonical magnitude can only originate from a `negative_tag` in a `scaled_unit` magnitude or
+// in a `named_constant` definition, and such a tag always sorts first in a magnitude pack.  This allows
+// determining the sign structurally in O(expression tree) without forming any magnitude products.
+template<symbol_text Symbol, auto... Args>
+[[nodiscard]] consteval bool unit_mag_is_positive(const named_unit<Symbol, Args...>&)
+{
+  return true;
+}
+
+template<symbol_text Symbol, Unit auto U, auto... Args>
+[[nodiscard]] consteval bool unit_mag_is_positive(const named_unit<Symbol, U, Args...>&)
+{
+  return mp_units::detail::unit_mag_is_positive(U);
+}
+
+template<symbol_text Symbol, Unit auto U>
+[[nodiscard]] consteval bool unit_mag_is_positive(const named_constant<Symbol, U>&)
+{
+  return mp_units::detail::unit_mag_is_positive(U);
+}
+
+template<typename F, int Num, int... Den>
+[[nodiscard]] consteval bool unit_mag_is_positive(const power<F, Num, Den...>&)
+{
+  // an even exponent numerator makes the result positive regardless of the base sign
+  return mp_units::detail::unit_mag_is_positive(F{}) || Num % 2 == 0;
+}
+
+template<typename... Us>
+[[nodiscard]] consteval bool unit_mag_is_positive(const type_list<Us...>&)
+{
+  // the result is positive if and only if the number of negative factors is even
+  return (0U + ... + static_cast<unsigned>(!mp_units::detail::unit_mag_is_positive(Us{}))) % 2 == 0;
+}
+
+template<typename... Expr>
+[[nodiscard]] consteval bool unit_mag_is_positive(const derived_unit_impl<Expr...>&)
+{
+  // the sign of a factor is the same no matter if it ends up in the numerator or the denominator
+  return mp_units::detail::unit_mag_is_positive(typename derived_unit<Expr...>::_num_{}) ==
+         mp_units::detail::unit_mag_is_positive(typename derived_unit<Expr...>::_den_{});
+}
+
+template<auto M, typename U>
+[[nodiscard]] consteval bool unit_mag_is_positive(const scaled_unit_impl<M, U>&)
+{
+  return check_magnitude_is_positive(M) == mp_units::detail::unit_mag_is_positive(U{});
+}
+
+template<typename... Us>
+[[nodiscard]] consteval bool unit_mag_is_positive(const common_unit<Us...>& u)
+{
+  return mp_units::detail::unit_mag_is_positive(u._common_unit_);
 }
 
 }  // namespace detail

--- a/src/core/include/mp-units/ostream.h
+++ b/src/core/include/mp-units/ostream.h
@@ -23,4 +23,6 @@
 
 #pragma once
 
-#warning "2.5.0: This header file is deprecated and does not have to be included anymore."
+#include <mp-units/bits/hacks.h>
+
+MP_UNITS_DEPRECATED_HEADER("2.5.0: This header file is deprecated and does not have to be included anymore.")

--- a/src/systems/include/mp-units/systems/international.h
+++ b/src/systems/include/mp-units/systems/international.h
@@ -37,8 +37,8 @@ MP_UNITS_EXPORT
 namespace mp_units {
 
 // Deprecated namespace alias for backward compatibility
-namespace international
-  [[deprecated("2.6.0: The 'international' namespace has been renamed to 'yard_pound'. Please update your code.")]] {
+namespace [[deprecated(
+  "2.6.0: The 'international' namespace has been renamed to 'yard_pound'. Please update your code.")]] international {
 using namespace yard_pound;
 }
 

--- a/src/systems/include/mp-units/systems/international.h
+++ b/src/systems/include/mp-units/systems/international.h
@@ -26,10 +26,12 @@
 // This header is provided for backward compatibility and will be removed in a future release.
 // Please update your code to use <mp-units/systems/yard_pound.h> instead.
 
+#include <mp-units/bits/hacks.h>
+
 // the module interface unit includes this header only to export the deprecated namespace shim
 #ifndef MP_UNITS_IN_MODULE_INTERFACE
-#warning \
-  "2.6.0: The header <mp-units/systems/international.h> is deprecated. Use <mp-units/systems/yard_pound.h> instead."
+MP_UNITS_DEPRECATED_HEADER(
+  "2.6.0: The header <mp-units/systems/international.h> is deprecated. Use <mp-units/systems/yard_pound.h> instead.")
 #endif
 
 // IWYU pragma: begin_exports

--- a/src/systems/include/mp-units/systems/international.h
+++ b/src/systems/include/mp-units/systems/international.h
@@ -26,20 +26,31 @@
 // This header is provided for backward compatibility and will be removed in a future release.
 // Please update your code to use <mp-units/systems/yard_pound.h> instead.
 
+// the module interface unit includes this header only to export the deprecated namespace shim
+#ifndef MP_UNITS_IN_MODULE_INTERFACE
 #warning \
   "2.6.0: The header <mp-units/systems/international.h> is deprecated. Use <mp-units/systems/yard_pound.h> instead."
+#endif
 
 // IWYU pragma: begin_exports
 #include <mp-units/systems/yard_pound.h>
 // IWYU pragma: end_exports
 
-MP_UNITS_EXPORT
 namespace mp_units {
 
 // Deprecated namespace alias for backward compatibility
+MP_UNITS_EXPORT
 namespace [[deprecated(
   "2.6.0: The 'international' namespace has been renamed to 'yard_pound'. Please update your code.")]] international {
-using namespace yard_pound;
+
+namespace [[deprecated("2.6.0: Use `mp_units::yard_pound::unit_symbols` instead.")]] unit_symbols {
+
+using namespace yard_pound::unit_symbols;
+
 }
+
+using namespace yard_pound;
+
+}  // namespace international
 
 }  // namespace mp_units

--- a/src/systems/mp-units-systems.cpp
+++ b/src/systems/mp-units-systems.cpp
@@ -41,6 +41,7 @@ import std;
 #include <mp-units/systems/iec.h>
 #include <mp-units/systems/iec80000.h>
 #include <mp-units/systems/imperial.h>
+#include <mp-units/systems/international.h>
 #include <mp-units/systems/isq.h>
 #include <mp-units/systems/isq_angle.h>
 #include <mp-units/systems/natural.h>

--- a/src/utility/include/mp-units/cartesian_vector.h
+++ b/src/utility/include/mp-units/cartesian_vector.h
@@ -22,6 +22,9 @@
 
 #pragma once
 
-#warning "2.6.0: <mp-units/cartesian_vector.h> is deprecated; include <mp-units/utility/cartesian_vector.h> instead."
+#include <mp-units/bits/hacks.h>
+
+MP_UNITS_DEPRECATED_HEADER(
+  "2.6.0: <mp-units/cartesian_vector.h> is deprecated; include <mp-units/utility/cartesian_vector.h> instead.")
 
 #include <mp-units/utility/cartesian_vector.h>

--- a/src/utility/include/mp-units/random.h
+++ b/src/utility/include/mp-units/random.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
-#warning "2.6.0: <mp-units/random.h> is deprecated; include <mp-units/utility/random.h> instead."
+#include <mp-units/bits/hacks.h>
+
+MP_UNITS_DEPRECATED_HEADER("2.6.0: <mp-units/random.h> is deprecated; include <mp-units/utility/random.h> instead.")
 
 #include <mp-units/utility/random.h>

--- a/test/static/unit_test.cpp
+++ b/test/static/unit_test.cpp
@@ -372,8 +372,8 @@ static_assert(get_canonical_unit(helion_g_factor).mag == mag<-ratio{4'255'250'61
 // named units require a positive canonical magnitude (only named constants may be negative)
 // object construction forces the class template to be complete, so constraint failure on every
 // `named_unit` specialization is detected (the primary template is declared but never defined)
-template<Unit auto U>
-concept valid_named_unit = requires { named_unit<"tst", U>{}; };
+template<auto U>
+concept valid_named_unit = Unit<MP_UNITS_REMOVE_CONST(decltype(U))> && requires { named_unit<"tst", U>{}; };
 
 static_assert(valid_named_unit<metre / second>);
 static_assert(valid_named_unit<mag<-1> * helion_g_factor>);  // two sign flips cancel

--- a/test/static/unit_test.cpp
+++ b/test/static/unit_test.cpp
@@ -369,6 +369,21 @@ static_assert(Unit<MP_UNITS_NONCONST_TYPE(helion_g_factor)>);
 static_assert(!PrefixableUnit<MP_UNITS_NONCONST_TYPE(helion_g_factor)>);
 static_assert(get_canonical_unit(helion_g_factor).mag == mag<-ratio{4'255'250'615, 1'000'000'000}>);
 
+// named units require a positive canonical magnitude (only named constants may be negative)
+// object construction forces the class template to be complete, so constraint failure on every
+// `named_unit` specialization is detected (the primary template is declared but never defined)
+template<Unit auto U>
+concept valid_named_unit = requires { named_unit<"tst", U>{}; };
+
+static_assert(valid_named_unit<metre / second>);
+static_assert(valid_named_unit<mag<-1> * helion_g_factor>);  // two sign flips cancel
+static_assert(valid_named_unit<square(helion_g_factor)>);    // even power is positive
+static_assert(!valid_named_unit<mag<-1> * metre>);
+static_assert(!valid_named_unit<mag<-ratio{1, 2}> * metre>);
+static_assert(!valid_named_unit<helion_g_factor * metre>);
+static_assert(!valid_named_unit<one / helion_g_factor>);   // negative denominator flips the sign
+static_assert(!valid_named_unit<cubic(helion_g_factor)>);  // odd power stays negative
+
 // operations commutativity
 constexpr auto u1 = mag<1000> * kilometre / hour;
 static_assert(is_of_type<u1, derived_unit<scaled_unit<mag<1000>, kilo_<metre_>>, per<hour_>>>);


### PR DESCRIPTION
## Summary

Chip Hogg's units-library comparison showed master compiling ~10-18% slower per TU than
2.5.0. Bisecting + profiling (clang `-ftime-trace`, gcc `-ftime-report`, MSVC
`/d1reportTime`) traced the regression to expensive work running in requires-clauses at
*definition time* for every named unit while system headers are parsed. This series fixes
those spots and a few bugs found along the way:

- **`is_positive_canonical_unit_mag`** computed the full canonical unit (including prime
  factorization of its magnitude) for every `named_unit` definition just to read the sign.
  It now determines the sign with an O(expression tree) structural walk (a `negative_tag`
  always sorts first in a magnitude pack).
- **`prefixed_unit`** derived from `decltype(M * U)`, instantiating the `operator*`
  machinery for each of the ~670 prefix and unit combinations in `si/unit_symbols.h`.
  `PrefixableUnit` guarantees the result is `scaled_unit<M, U>`, so the base is now spelled
  directly.
- **`disable_representation`** now rejects any `detail::SymbolicConstant` upfront, so
  overload resolution of symbolic expressions (`mag * unit`, ...) no longer evaluates the
  whole representation-concept chain on units and magnitudes before rejecting them.
- `scaled_unit`'s requires-clause resolved the same magnitude comparison twice.
- `namespace name [[deprecated]]` in `international.h` is not valid C++ - Clang rejected
  the header entirely. The attribute now sits where the grammar allows it.
- The deprecated `mp_units::international` shim is now exported from `mp_units.systems`
  (following the `iec80000.h` precedent, with a nested deprecated `unit_symbols`), so
  module consumers get a deprecation warning instead of a hard error.

## Measurements

Interleaved A/B on Chip's example corpus (gcc-12, C++20, header-only, best-of-2, laptop):

| corpus | v2.5.0 | master | this branch |
|---|---|---|---|
| default (si.h + unit_symbols), 19 TUs | 69.1 s | 81.5 s (+18%) | **42.0 s (-48% vs master, -39% vs 2.5.0)** |
| lean (fine-grained headers), 19 TUs | 31.1 s | 47.7 s (+53%) | **35.5 s (-26% vs master)** |

Clang-21 `import mp_units;` vs headers over the same examples: **~2.5-3x faster** per TU
(one-time BMI builds: `mp_units.systems` 10.4 s, `std` 2.2 s, the rest sub-second).

## Verification

- gcc-12/gcc-15/clang-16/clang-21 x `build:all=True` (static + runtime tests, examples,
  header-set verification, clang-21 also C++ modules): 63/63 tests pass on each.
- New static rejection tests for negative named units (even/odd powers, negative
  denominators, double negation) - semantics verified identical to master's behavior.
- Findings that need the V3 engine (QUANTITY_SPEC equation-check costs) are documented in
  `todo/v3-compile-time-engine-findings.md` (kept out of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)