### PR TITLE
feat(core)!: rounding policies replace the forcing conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ This page documents the version history and changes for the **mp-units** library
 - feat: `numerical_value_in(Unit)` and `force_numerical_value_in(Unit)` member functions
         added to `quantity_point` (extract the raw value of a default-origin point; the
         inverse of `point<Unit>(value)`) (#813)
+- (!) feat: rounding policies (`truncated`, `rounded`, `rounded_down`, `rounded_up`) added
+        for truncating conversions; passed as the last argument of `in()`, `numerical_value_in()`,
+        and `value_cast()` (#534)
+- (!) refactor: `force_in()` and `force_numerical_value_in()` deprecated (use `in()` and
+        `numerical_value_in()` with a rounding policy, e.g. `truncated`) (#534)
+- (!) fix: truncating conversions by an irrational factor (e.g. `rad` -> `deg`) now round
+        negative values towards zero, consistently with the rational-factor conversions
+        (previously they rounded towards negative infinity)
+- (!) fix: `quantity_point::min()`/`max()` now report a range bound as the point's own quantity
+        type, so a bound declared in a different unit or representation is no longer truncated
+        (e.g. a `1500 * m` bound on a `km`-based point reported `1 km`, below the declared
+        minimum)
 - feat: `fahrenheit_zero` point origin added (replaces `zeroth_degree_Fahrenheit`)
 - feat: dimensionless quantities with unit one can now be created with `quantity_spec::op(Val)`
         explicit conversions

--- a/docs/examples/currency.md
+++ b/docs/examples/currency.md
@@ -96,7 +96,7 @@ The example uses both types deliberately:
   const quantity pos_usd = 14'230 * USD;
   const quantity pos_eur =  4'902 * EUR;
   // pos_usd + pos_eur                              // does not compile — must convert first
-  const quantity pos_eur_usd = round<USD>(exchange_to<us_dollar>(pos_eur, timestamp)).force_in<int>();
+  const quantity pos_eur_usd = round<USD>(exchange_to<us_dollar>(pos_eur, timestamp)).in<int>(rounded);
   const quantity total_usd = pos_usd + pos_eur_usd; // ok — same unit
   ```
 
@@ -112,8 +112,10 @@ discipline of explicit FX conversion:
 
 The rounding decision is made explicitly at the call site: `round<USD>` rounds to the
 nearest whole dollar; `floor<USD>` or `ceil<USD>` could be substituted depending on the
-desired settlement convention. `.force_in<int>()` changes the representation type to
-`int` so the result stays consistent with the integer-valued input positions.
+desired settlement convention. `.in<int>(rounded)` changes the representation type to `int`
+so the result stays consistent with the integer-valued input positions. The value is already
+a whole number of dollars at that point, so the policy only states which neighbor to pick
+if it ever stops being one, and `rounded` is the honest answer for money.
 
 ## Example Usage
 

--- a/docs/examples/trade_execution.md
+++ b/docs/examples/trade_execution.md
@@ -86,14 +86,19 @@ until the final display.
 
 ## Code Walkthrough
 
-### Computing Notional: `force_in` for Lossless Scaling
+### Computing Notional: Rounding to the Scaled Integer Grid
 
 ```cpp
 --8<-- "example/trade_execution.cpp:87:91"
 ```
 
-`force_in<std::int64_t>(us_dollar_8)` converts the _price_ unit from `USD` to `USD_8`
-and changes the representation from `double` to `std::int64_t` in one step. The product
+`in<std::int64_t>(us_dollar_8, rounded)` converts the _price_ unit from `USD` to `USD_8`
+and changes the representation from `double` to `std::int64_t` in one step. The `rounded`
+policy is the important part: a decimal price is not exactly representable in binary
+floating point, so scaling it by 10⁸ and truncating would report one unit less than the
+quoted price for roughly 7% of two-decimal prices (`0.29 USD` becomes `28999999 USD_8`
+rather than `29000000 USD_8`). Rounding to the nearest scaled integer lands on the
+quoted price. The product
 `price_in_usd8 * f.qty` yields a derived expression (_currency_ × _market quantity_)
 that is implicitly convertible to `notional_value`; the `return` converts it to
 `Notional`.

--- a/docs/getting_started/safety_features.md
+++ b/docs/getting_started/safety_features.md
@@ -97,9 +97,13 @@ quantity length = 1500 * m;
 // quantity<km, int> distance = length;             // ❌ Compile-time error!
 // Error: 1500 m → 1.5 km truncates with int
 
-quantity distance2 = length.force_in(km);           // ✅ OK: explicit truncation (returns quantity)
-auto km_count = length.force_numerical_value_in(km);// ✅ OK: explicit truncation (returns raw int: 1)
-quantity<mm, int> length_mm = length;               // ✅ OK: 1'500'000 mm (no truncation)
+// A rounding policy accepts the loss and states which value you get
+quantity distance2 = length.in(km, truncated);            // ✅ 1 km (towards zero)
+quantity distance3 = length.in(km, rounded);              // ✅ 2 km (nearest, ties to even)
+quantity distance4 = length.in(km, rounded_down);         // ✅ 1 km (towards -infinity)
+quantity distance5 = length.in(km, rounded_up);           // ✅ 2 km (towards +infinity)
+auto km_count = length.numerical_value_in(km, truncated); // ✅ raw int: 1
+quantity<mm, int> length_mm = length;                     // ✅ OK: 1'500'000 mm (no truncation)
 
 // Scaling overflow detection
 quantity length1 = std::int8_t{2} * m;

--- a/docs/how_to_guides/integration/converting_external_quantity_types.md
+++ b/docs/how_to_guides/integration/converting_external_quantity_types.md
@@ -138,14 +138,15 @@ no value truncation would occur:
   because the conversion factor preserves all values
 - **Truncating conversions require explicit action**: Converting from a finer unit to
   a coarser one with a non-floating-point representation (e.g., millimeters to meters
-  for integers) requires `.force_in()` because information would be lost
+  for integers) requires a rounding policy (e.g. `.in(Unit, truncated)`) because
+  information would be lost
 
 Examples of compile-time safety checks:
 
 ```cpp
 Meter height{42};
 
-quantity<isq::height[m]> h3 = height;      // ✅ OK
+quantity<isq::height[m]> h3 = height;        // ✅ OK
 quantity<isq::height[mm], int> h4 = height;  // ✅ OK
 
 // ❌ Compile error: truncation while converting from meters to kilometers
@@ -161,14 +162,14 @@ print(Meter(h4));
 **To fix these issues:**
 
 ```cpp
-// Explicitly allow truncation
-quantity<isq::height[km], int> h5 = quantity{height}.force_in(km);
+// State how the leftover meters should round (42 m is 0 km either way)
+quantity<isq::height[km], int> h5 = quantity{height}.in(km, truncated);
 
-// Force conversion double → int
-print(Meter(h3.force_in<int>()));
+// double → int, rounding to the nearest integer
+print(Meter(h3.in<int>(rounded)));
 
-// Force conversion mm → m
-print(Meter(h4.force_in(m)));
+// mm → m, rounding to the nearest meter
+print(Meter(h4.in(m, rounded)));
 ```
 
 ## Querying Type Information

--- a/docs/how_to_guides/integration/using_custom_representation_types.md
+++ b/docs/how_to_guides/integration/using_custom_representation_types.md
@@ -379,7 +379,7 @@ By default, a conversion between two quantity types is implicit only when it is
 non-truncating: the target representation is floating-point, or both representations are
 integer-like and the unit ratio is an integer multiplier (e.g. `m → mm`). All other
 integer-to-integer conversions (fractional ratios such as `mm → m`) are explicit and
-require `value_cast` or `force_in`.
+require `value_cast` or a conversion with a rounding policy.
 
 If your type has different implicit-conversion semantics, specialize
 [`mp_units::implicitly_scalable`](../../users_guide/framework_basics/representation_types.md#implicitly_scalable):
@@ -629,7 +629,7 @@ custom types.
 - [`customization_points.h`](https://github.com/mpusz/mp-units/blob/master/src/core/include/mp-units/framework/customization_points.h) - User-specializable customization points: the character traits (`numeric_field`, `tensor_order`, `disable_representation`) and CPOs (`real`, `imag`, `modulus`), plus `representation_underlying_type`, `representation_canonical_type`, `treat_as_floating_point`, `representation_values`, `constraint_violation_handler`, `quantity_like_traits`, `quantity_point_like_traits`
 - [`quantity_traits.h`](https://github.com/mpusz/mp-units/blob/master/src/core/include/mp-units/framework/quantity_traits.h) - Public helpers (`unit_for`, `reference_for`, `rep_for`)
 - [`scaling.h`](https://github.com/mpusz/mp-units/blob/master/src/core/include/mp-units/framework/scaling.h) - Built-in scaling implementation
-- [`value_cast.h`](https://github.com/mpusz/mp-units/blob/master/src/core/include/mp-units/framework/value_cast.h) - `value_cast`, `force_in`, `is_integral_scaling`, and `implicitly_scalable`
+- [`value_cast.h`](https://github.com/mpusz/mp-units/blob/master/src/core/include/mp-units/framework/value_cast.h) - `value_cast`, `is_integral_scaling`, and `implicitly_scalable`
 - [`cartesian_vector.h`](https://github.com/mpusz/mp-units/blob/master/src/utility/include/mp-units/utility/cartesian_vector.h) - Vector implementation example
 - [`cartesian_tensor.h`](https://github.com/mpusz/mp-units/blob/master/src/utility/include/mp-units/utility/cartesian_tensor.h) - Second-order tensor implementation example
 <!-- markdownlint-enable MD013 -->

--- a/docs/how_to_guides/integration/working_with_legacy_interfaces.md
+++ b/docs/how_to_guides/integration/working_with_legacy_interfaces.md
@@ -99,20 +99,30 @@ quantity speed = 33. * m / s;   // 118.8 km/h
 legacy_check_speed_limit(speed.numerical_value_in(km / h));
 ```
 
-**Option 2: Explicitly force truncation**
+**Option 2: State how the value should round**
 
-When you're certain that truncation is acceptable, use `.force_numerical_value_in(Unit)`:
+When you're certain that truncation is acceptable, pass a rounding policy (e.g. `truncated`)
+to `.numerical_value_in()`:
 
 ```cpp
 quantity speed = 33 * m / s;   // 118.8 km/h
-legacy_check_speed_limit(speed.force_numerical_value_in(km / h));  // ✅ Truncates to 118
+legacy_check_speed_limit(speed.numerical_value_in(km / h, truncated));  // ✅ Truncates to 118
 ```
 
-!!! warning "Use `.force_numerical_value_in()` Sparingly"
+The policy is a domain decision rather than a formality. Truncating towards zero reports
+118 km/h for a car travelling at 118.8 km/h, which silently favors the driver. When the
+extracted value feeds an enforcement decision, `rounded` or `rounded_up` is the defensible
+choice:
 
-    Only use this function when you've verified that truncation is acceptable for your
-    use case. Document why truncation is safe to help future maintainers understand
-    your reasoning.
+```cpp
+legacy_check_speed_limit(speed.numerical_value_in(km / h, rounded_up));  // ✅ Reports 119
+```
+
+!!! warning "Use Truncating Value Extraction Sparingly"
+
+    Only pass a rounding policy when you've verified that the value loss is acceptable for your
+    use case. Document why the rounding direction you picked is the right one to help future
+    maintainers understand your reasoning.
 
 
 ## Direct Storage Access
@@ -201,7 +211,7 @@ legacy_get_dimensions(
 | Function                          | Purpose                                   | Conversion | Truncation | Returns      |
 |-----------------------------------|-------------------------------------------|------------|------------|--------------|
 | `.numerical_value_in(Unit)`       | Safe value extraction                     | Yes        | Prevented  | By value     |
-| `.force_numerical_value_in(Unit)` | Value extraction with explicit truncation | Yes        | Allowed    | By value     |
+| `.numerical_value_in(Unit, policy)` | Value extraction with explicit rounding | Yes        | Allowed    | By value     |
 | `.numerical_value_ref_in(Unit)`   | Direct storage access                     | No         | N/A        | By reference |
 
 These functions maintain type safety at the boundary between type-safe and legacy code,

--- a/docs/reference/cheat_sheet.md
+++ b/docs/reference/cheat_sheet.md
@@ -294,19 +294,29 @@ constexpr Unit auto two_pi = mag<2> * π;
 ### Unit Conversions
 
 ```cpp
-// Explicit conversions
-quantity distance = (5 * km).in(m);                                  // 5000 m
-quantity speed = (60 * km / h).force_in(m / s);                      // 16 m/s (1)
-quantity temp = delta<deg_C>(3).in<double>(deg_F);                   // 5.4 ℉
-quantity pressure = (101325. * Pa).in(bar);                          // 1.01325 bar
+// Value-preserving conversions
+quantity distance = (5 * km).in(m);                            // 5000 m
+quantity temp = delta<deg_C>(3).in<double>(deg_F);             // 5.4 ℉
+quantity pressure = (101325. * Pa).in(bar);                    // 1.01325 bar
+int distance_value = (42 * m).numerical_value_in(m);           // 42
 
-// Value extraction
-int distance_value = (42 * m).numerical_value_in(m);                 // 42
-double speed_value = (100 * km / h).force_numerical_value_in(m / s); // 27 (2)
+// Truncating conversions: the rounding policy is the last argument
+quantity speed = (60 * km / h).in(m / s, truncated);           // 16 m/s
+quantity d1 = (1567 * m).in(km, truncated);                    // 1 km
+quantity d2 = (1567 * m).in(km, rounded);                      // 2 km
+quantity d3 = (1567 * m).in(km, rounded_down);                 // 1 km
+quantity d4 = (1567 * m).in(km, rounded_up);                   // 2 km
+quantity d5 = (1.23 * s).in<int>(ms, rounded);                 // 1230 ms (unit and rep)
+int speed_value = (100 * km / h).numerical_value_in(m / s, rounded);  // 28
+quantity d6 = value_cast<km>(1567 * m, rounded);               // 2 km (generic contexts)
 ```
 
-1. Potential value truncation.
-2. Potential value truncation.
+| Policy         | Rounds towards                    | `std::chrono` counterpart |
+|----------------|-----------------------------------|---------------------------|
+| `truncated`    | zero                              | `duration_cast`           |
+| `rounded`      | nearest, to even in halfway cases | `round`                   |
+| `rounded_down` | negative infinity                 | `floor`                   |
+| `rounded_up`   | positive infinity                 | `ceil`                    |
 
 ## Output & Formatting
 
@@ -366,7 +376,8 @@ double speed_value = (100 * km / h).force_numerical_value_in(m / s); // 27 (2)
     quantity distance = (5 * km).in(m);                       // ✓ 5000 m (widening)
     quantity height = (186. * cm).in(m);                      // ✓ 1.86 m (floating-point)
     quantity length = (short{2} * m).in<int>(mm);             // ✓ 2000 mm (explicit)
-    quantity duration = (90 * min).force_in(h);               // ✓ 1 h (forced, may truncate)
+    quantity duration = (90 * min).in(h, truncated);          // ✓ 1 h (towards zero)
+    quantity duration2 = (90 * min).in(h, rounded);           // ✓ 2 h (nearest, ties to even)
 
     // quantity wrong = (42 * m).in(km);                      // ✗ Error: truncating int conversion
     // quantity overflow = (std::int8_t{1} * m).in(mm);       // ✗ Error: only 0 preserves the value

--- a/docs/tutorials/working_with_units/safe_unsafe_conversions.md
+++ b/docs/tutorials/working_with_units/safe_unsafe_conversions.md
@@ -89,9 +89,10 @@ truncation and is blocked - even without changing units!
 
     By default, **mp-units** uses `std::chrono::duration`-like logic for these.
 
-## Forcing Truncating Conversions
+## Truncating Conversions
 
-When you need to truncate, make it explicit:
+When a conversion cannot keep the value, you have to say what should happen to the part
+that does not fit:
 
 ```cpp
 // ce-embed height=550 compiler=clang2110 flags="-std=c++23 -stdlib=libc++ -O3" mp-units=trunk
@@ -103,23 +104,37 @@ int main()
   using namespace mp_units;
   using namespace mp_units::si::unit_symbols;
 
-  // Three ways to force truncating conversions:
-  quantity km_int = (500 * m).force_in(km);           // ✅ 0 km (truncates to int)
-  quantity km_dbl = (500 * m).in<double>(km);         // ✅ 0.5 km (changes to double)
-  quantity km_cast = value_cast<double, km>(500 * m); // ✅ 0.5 km (using value_cast)
+  // Option 1: keep the integer and pick a rounding policy
+  quantity km_trunc = (1567 * m).in(km, truncated);      // ✅ 1 km (towards zero)
+  quantity km_round = (1567 * m).in(km, rounded);        // ✅ 2 km (nearest, ties to even)
+  quantity km_down = (1567 * m).in(km, rounded_down);    // ✅ 1 km (towards -infinity)
+  quantity km_up = (1567 * m).in(km, rounded_up);        // ✅ 2 km (towards +infinity)
 
-  std::cout << "Forced conversions:\n";
-  std::cout << "  force_in(km): " << km_int << "\n";
-  std::cout << "  in<double>(km): " << km_dbl << "\n";
-  std::cout << "  value_cast: " << km_cast << "\n";
+  // Option 2: switch to a floating-point representation and keep every digit
+  quantity km_dbl = (1567 * m).in<double>(km);           // ✅ 1.567 km
+  quantity km_cast = value_cast<double, km>(1567 * m);   // ✅ 1.567 km (using value_cast)
+
+  std::cout << "Converting " << 1567 * m << " to km:\n";
+  std::cout << "  truncated:    " << km_trunc << "\n";
+  std::cout << "  rounded:      " << km_round << "\n";
+  std::cout << "  rounded_down: " << km_down << "\n";
+  std::cout << "  rounded_up:   " << km_up << "\n";
+  std::cout << "  in<double>:   " << km_dbl << "\n";
+  std::cout << "  value_cast:   " << km_cast << "\n";
+
+  // Watch out for negatives: truncated rounds towards zero, rounded_down does not
+  std::cout << "\n-1567 m truncated:    " << (-1567 * m).in(km, truncated) << "\n";
+  std::cout << "-1567 m rounded_down: " << (-1567 * m).in(km, rounded_down) << "\n";
 }
 ```
 
-**Key insight**: Explicit syntax prevents accidental data loss!
+**Key insight**: The policy is not paperwork. It is the answer to "which of the two
+neighboring values do I want", and the compiler makes you give it.
 
 ## Challenges
 
-1. **Force truncation**: Create 1234 m as `int`, force convert to km (should get 1 km)
+1. **Round three ways**: Create 1234 m as `int` and convert it to km with `truncated`,
+   `rounded`, and `rounded_up` (you should get 1 km, 1 km, and 2 km)
 2. **Safe with doubles**: Create 1234 m as `double`, convert to km (should get 1.234 km implicitly)
 3. **Mixed representations**: Add 5.5 km (double) + 2000 m (int), what's the result type?
 
@@ -127,6 +142,7 @@ int main()
 
 ✅ Implicit conversions only work when safe (no truncation)  
 ✅ Floating-point types are considered value-preserving  
-✅ Use `.force_in()`, `.in<Rep>()`, or `value_cast` to force truncation  
+✅ Use `.in(Unit, policy)`, `.in<Rep>()`, or `value_cast` for truncating conversions  
+✅ `truncated`, `rounded`, `rounded_down`, and `rounded_up` name the rounding direction  
 ✅ The library follows `std::chrono::duration` logic for safety  
 ✅ Explicit syntax prevents accidental data loss

--- a/docs/users_guide/framework_basics/generic_interfaces.md
+++ b/docs/users_guide/framework_basics/generic_interfaces.md
@@ -66,16 +66,18 @@ some issues start to be clearly visible:
    Trying to use an integral type in this scenario will work only for `s1`, while `s2` and
    `s3` will fail to compile. Failing to compile is a good thing here as the library tries
    to prevent the user from doing a clearly wrong thing. To make the code compile, the user
-   needs to use dedicated [`value_cast` or `force_in`](value_conversions.md#value-truncating-conversions)
+   needs to use a dedicated [`value_cast` or a conversion with a rounding policy](value_conversions.md#value-truncating-conversions)
    like this:
 
     ```cpp
     quantity<isq::speed[mi / h]> s2 = avg_speed(value_cast<km>(140 * mi), 2 * h);
-    quantity<isq::speed[m / s]> s3 = avg_speed((20 * m).force_in(km), (2 * s).force_in(h));
+    quantity<isq::speed[m / s]> s3 = avg_speed((20 * m).in(km, truncated), (2 * s).in(h, truncated));
     ```
 
     but the above will obviously provide an incorrect behavior (e.g., division by `0` in
-    the evaluation of `s3`).
+    the evaluation of `s3`). No rounding policy rescues this: `20 m` is `0 km` to the nearest
+    kilometer as well. A policy states which representable value you get, not how to keep
+    information that the target type cannot hold.
 
 
 ## A naive solution

--- a/docs/users_guide/framework_basics/representation_types.md
+++ b/docs/users_guide/framework_basics/representation_types.md
@@ -603,11 +603,11 @@ affects implicit conversions between quantities.
     representation type with non-standard implicit-conversion semantics.
 
 A specializable variable template that controls **whether** a conversion from
-`quantity<FromUnit, FromRep>` to `quantity<ToUnit, ToRep>` is implicit or requires an
-explicit cast via `value_cast`/`force_in`. It is the policy layer built on top of
-`treat_as_floating_point`: the default formula derives the implicit-conversion decision
-from it, and a specialization overrides that decision for types where the derived rule
-is incorrect:
+`quantity<FromUnit, FromRep>` to `quantity<ToUnit, ToRep>` is implicit or requires
+an explicit cast via `value_cast` or a conversion with a rounding policy. It is the
+layer built on top of `treat_as_floating_point`: the default formula derives the
+implicit-conversion decision from it, and a specialization overrides that decision for
+types where the derived rule is incorrect:
 
 ```cpp
 template<auto FromUnit, typename FromRep, auto ToUnit, typename ToRep>
@@ -684,7 +684,7 @@ constexpr bool mp_units::implicitly_scalable<FromUnit, my_special_int, ToUnit, m
 ```
 
 **Impact:** Controls whether conversions between quantity types are implicit or require
-`value_cast`/`force_in`. See [Value Conversions](../../users_guide/framework_basics/value_conversions.md)
+`value_cast` or a rounding policy. See [Value Conversions](../../users_guide/framework_basics/value_conversions.md)
 for the full picture.
 
 ---

--- a/docs/users_guide/framework_basics/text_output.md
+++ b/docs/users_guide/framework_basics/text_output.md
@@ -375,7 +375,7 @@ The text output will always print the value using the default formatting for thi
 
     ```cpp
     std::cout << v1.in(km / h) << '\n';       // 110 km/h
-    std::cout << v1.force_in(m / s) << '\n';  // 30.5556 m/s
+    std::cout << v1.in(m / s) << '\n';        // 30.5556 m/s
     ```
 
 

--- a/docs/users_guide/framework_basics/the_affine_space.md
+++ b/docs/users_guide/framework_basics/the_affine_space.md
@@ -712,7 +712,7 @@ void example()
 Bounds are enforced at these points:
 
 1. **Construction** from a quantity: `quantity_point{value * unit, origin}`
-2. **Unit conversion**: `qp.in(other_unit)`, `qp.force_in(other_unit)`
+2. **Unit conversion**: `qp.in(other_unit)`, `qp.in(other_unit, policy)`
 3. **Arithmetic operations**: `operator+=`, `operator-=`, `operator++`, `operator--`
 4. **Origin conversion**: `qp.point_for(new_origin)`
 
@@ -1045,9 +1045,9 @@ double celsius = temp.numerical_value_in(deg_C);  // 20.5
 double kelvin = temp.numerical_value_in(K);       // 293.65 (measured from absolute zero)
 ```
 
-A truncating variant, `force_numerical_value_in(Unit)`, is provided for conversions that would
-otherwise be rejected as value-preserving (e.g., an integer representation scaled to a coarser
-unit).
+A truncating variant, `numerical_value_in(Unit, policy)`, is provided for conversions
+that would otherwise be rejected as value-preserving (e.g., an integer representation
+scaled to a coarser unit).
 
 Both member functions are available under exactly the same condition as
 [text output](#text-output-for-points): only when the _point_ uses `default_point_origin(R)`.

--- a/docs/users_guide/framework_basics/value_conversions.md
+++ b/docs/users_guide/framework_basics/value_conversions.md
@@ -63,29 +63,56 @@ quantity<si::kilo<si::metre>> q2 = q1;  // double by default
 
 ## Value-truncating conversions
 
-The second solution is to force a truncating conversion:
+The second solution is to explicitly accept the value loss. Every conversion that the
+framework considers truncating requires the user to state what should happen to the
+information that does not fit in the result. This is done by passing a **rounding policy**
+as the last function argument:
 
 ```cpp
-quantity q1 = 5 * m;
-std::cout << value_cast<km>(q1) << '\n';
-quantity<si::kilo<si::metre>, int> q2 = q1.force_in(km);
+quantity q1 = 1234 * m;
+std::cout << q1.in(km, truncated) << '\n';     // 1 km
+std::cout << q1.in(km, rounded) << '\n';       // 1 km
+std::cout << q1.in(km, rounded_up) << '\n';    // 2 km
+std::cout << q1.in(km, rounded_down) << '\n';  // 1 km
+quantity<si::kilo<si::metre>, int> q2 = q1.in(km, rounded);
 ```
 
-This explicit cast makes it clear that something unsafe is going on. It is easy to spot
+The policy makes it clear at the call site that the conversion loses information and, at
+the same time, states precisely which representable value gets selected. It is easy to spot
 in code reviews or while chasing a bug in the source code.
+
+The library provides four rounding policies:
+
+| Policy         | Semantics                                                           | Consistent with                             |
+|----------------|---------------------------------------------------------------------|---------------------------------------------|
+| `truncated`    | rounds towards zero                                                 | `static_cast`, `std::chrono::duration_cast` |
+| `rounded`      | rounds to the nearest representable value, to even in halfway cases | `std::chrono::round`                        |
+| `rounded_down` | rounds towards negative infinity                                    | `std::chrono::floor`                        |
+| `rounded_up`   | rounds towards positive infinity                                    | `std::chrono::ceil`                         |
 
 !!! note
 
-    `q.force_in(U)` is just a shortcut to run `value_cast<U>(q)`. There is no difference in behavior
-    between those two interfaces. `q.force_in(U)` was added for consistency with `q.in(U)` and
-    `q.force_numerical_value_in(U)`.
+    `mp_units::floor/ceil/round<U>(q)` perform a different operation. They round to an
+    integral multiple of the provided unit even when the representation could store the
+    exact result (e.g. for a floating-point representation). The rounding policies never
+    adjust a value that the destination type represents exactly. Both coincide for
+    integral representations.
 
-Another place where this cast is useful is when a user wants to convert a quantity with
-a floating-point representation to the one using an integral one. Again, this is a truncating
-conversion, so an explicit cast is needed:
+!!! important
+
+    `truncated` and `rounded_down` differ for negative values. `(-1234 * m).in(km, truncated)`
+    yields `-1 km` while `(-1234 * m).in(km, rounded_down)` yields `-2 km`. This is exactly
+    the trap that made `std::chrono` retrofit `floor()`, `ceil()`, and `round()` after
+    shipping the truncating `duration_cast`. In **mp-units**, the conversion states its
+    rounding direction explicitly, so there is no default to be surprised by.
+
+Another place where such a conversion is useful is when a user wants to convert a quantity
+with a floating-point representation to the one using an integral one. Again, this is
+a truncating conversion, so a rounding policy is needed:
 
 ```cpp
-quantity<si::metre, int> q3 = value_cast<int>(3.14 * m);
+quantity<si::metre, int> q3 = (3.14 * m).in<int>(truncated);
+quantity<si::metre, int> q4 = (3.14 * m).in<int>(rounded);
 ```
 
 !!! info
@@ -94,9 +121,38 @@ quantity<si::metre, int> q3 = value_cast<int>(3.14 * m);
     types provide better precision and are privileged in the library as they are considered
     to be value-preserving.
 
+The same policies may be passed as the last argument to `value_cast`, which remains the
+escape hatch for generic contexts where the representation type is a dependent name and
+the member function would require the `template` disambiguator:
+
+```cpp
+quantity q5 = value_cast<km>(1567 * m, rounded);  // 2 km
+quantity q6 = value_cast<int>(3.14 * m);          // truncated (static_cast semantics)
+```
+
+When no policy is provided, `value_cast` keeps its `static_cast`-like (`truncated`) semantics
+for backward compatibility.
+
+!!! note
+
+    A floating-point destination represents every conversion result with a rounding error
+    of at most half ULP, which is the semantics of `rounded`, and the directed modes cannot
+    be delivered for it. This is why a floating-point destination accepts only the
+    `truncated` (understood as the `static_cast` semantics) and `rounded` policies.
+
+    Rounding happens only on the way to an integral representation, so that is where the policies
+    ask something of the representation type:
+
+    - An adjusting policy has to decide which side of a rounding boundary the exact result falls
+      on, which needs a _real scalar_. A real scalar wrapper such as [`safe_int`](safe_int.md)
+      works with every policy, while a vector, tensor, or complex representation offers no single
+      value to compare against a boundary and takes only `truncated` there.
+    - Rounding a floating-point value to an integral one works on the value's integral part, which
+      the library performs for standard floating-point types only.
+
 In some cases, a unit and a representation type should be changed simultaneously. Moreover,
 sometimes, the order of doing those operations matters. In such cases, the library provides
-the `value_cast<U, Rep>(q)` and `q.force_in<Rep>(U)` which always return the most precise
+the `value_cast<U, Rep>(q)` and `q.in<Rep>(U, policy)` which always return the most precise
 result:
 
 === "C++23"
@@ -163,7 +219,7 @@ result:
 using namespace unit_symbols;
 Price price{12.95 * USD};
 Scaled spx1 = value_cast<USD_s, std::int64_t>(price);
-Scaled spx2 = price.force_in<std::int64_t>(USD_s);
+Scaled spx2 = price.in<std::int64_t>(USD_s, truncated);
 ```
 
 As a shortcut, instead of providing a unit and a representation type to `value_cast`, you
@@ -210,7 +266,7 @@ that a naive implementation cannot handle correctly:
     ```cpp
     // deg -> grad: factor 10/9
     // A naive implementation multiplies first: 1e18 * 10 overflows int64_t (max ≈ 9.22e18):
-    quantity q = (std::int64_t{1'000'000'000'000'000'000} * deg).force_in(grad);
+    quantity q = (std::int64_t{1'000'000'000'000'000'000} * deg).in(grad, truncated);
     // Expected:          1'111'111'111'111'111'111ᵍ
     // Naive result:       -938'527'119'301'061'290ᵍ (silent undefined behaviour)
     // mp-units result:   1'111'111'111'111'111'111ᵍ (correct)
@@ -257,10 +313,14 @@ a right-shift with no risk of intermediate overflow and no floating-point operat
     overflow as long as the input value fits in the representation type — for example,
     a value of `std::int32_t` computed in `int64_t` has 32 extra bits of safety margin.
 
-    For the non-integer ratio path, the result is **truncated toward zero**.  The
-    fixed-point constant is rounded *away* from zero at compile time to compensate for
-    one level of double-rounding, keeping the maximum error within 1 ULP of the true
-    result (i.e. at most ±1 relative to the last bit of the output).
+    For the non-integer ratio path, the result honors the requested rounding policy
+    (`truncated` rounds towards zero, and the remaining modes adjust the floor quotient
+    computed by the shift accordingly). The fixed-point constant is rounded *away* from
+    zero at compile time to compensate for one level of double-rounding, keeping the
+    maximum error within 1 ULP of the true result (i.e. at most ±1 relative to the last
+    bit of the output). Because the factor itself is an approximation, a rounding policy
+    may select the neighboring representable value when the exact result lies within that
+    error of a rounding boundary.
 
     !!! hint
 
@@ -278,8 +338,8 @@ conversions:
 
 ```cpp
 quantity q1 = std::int8_t(1) * km;
-quantity q2 = q1.force_in(m);   // Compile-time error (1)
-if(q1 != 1 * m) { /* ... */ }   // Compile-time error (2)
+quantity q2 = q1.in(m, truncated);  // Compile-time error (1)
+if(q1 != 1 * m) { /* ... */ }       // Compile-time error (2)
 ```
 
 1. Forced conversion would overflow on scaling.
@@ -306,11 +366,17 @@ conversion machinery — including how to implement the correct `operator*` and
 The table below provides all the value conversion functions that may be run on `x` being the
 instance of either `quantity` or `quantity_point`:
 
-| Forcing | Representation | Unit | Member function    | Non-member function                            |
-|:-------:|:--------------:|:----:|--------------------|------------------------------------------------|
-|   No    |      Same      | `u`  | `x.in(u)`          |                                                |
-|   No    |      `T`       | Same | `x.in<T>()`        |                                                |
-|   No    |      `T`       | `u`  | `x.in<T>(u)`       |                                                |
-|   Yes   |      Same      | `u`  | `x.force_in(u)`    | `value_cast<u>(x)`                             |
-|   Yes   |      `T`       | Same | `x.force_in<T>()`  | `value_cast<T>(x)`                             |
-|   Yes   |      `T`       | `u`  | `x.force_in<T>(u)` | `value_cast<u, T>(x)` or `value_cast<T, u>(x)` |
+In the table below, `p` is one of the rounding policies (`truncated`, `rounded`,
+`rounded_down`, `rounded_up`), and providing it is what enables a truncating conversion:
+
+| Truncating | Representation | Unit | Member function | Non-member function                                  |
+|:----------:|:--------------:|:----:|-----------------|------------------------------------------------------|
+|     No     |      Same      | `u`  | `x.in(u)`       |                                                      |
+|     No     |      `T`       | Same | `x.in<T>()`     |                                                      |
+|     No     |      `T`       | `u`  | `x.in<T>(u)`    |                                                      |
+|    Yes     |      Same      | `u`  | `x.in(u, p)`    | `value_cast<u>(x, p)`                                |
+|    Yes     |      `T`       | Same | `x.in<T>(p)`    | `value_cast<T>(x, p)`                                |
+|    Yes     |      `T`       | `u`  | `x.in<T>(u, p)` | `value_cast<u, T>(x, p)` or `value_cast<T, u>(x, p)` |
+
+The non-member functions may also be called without a policy, in which case they keep the
+`static_cast`-like (`truncated`) truncating semantics.

--- a/docs/workshops/advanced/incremental_migration.md
+++ b/docs/workshops/advanced/incremental_migration.md
@@ -383,7 +383,7 @@ int main()
     **Why `quantity_like` types don't satisfy `QuantityOf`:**
 
     - Missing static data members: `reference`, `unit`, `quantity_spec`
-    - Missing member functions: `.in()`, `.force_in()`, `.numerical_value_in()`
+    - Missing member functions: `.in()`, `.in(Unit, policy)`, `.numerical_value_in()`
     - Only conversion functions are defined by `quantity_like_traits`
 
     Choose based on priorities:

--- a/docs/workshops/extensions/custom_dimensionless_units.md
+++ b/docs/workshops/extensions/custom_dimensionless_units.md
@@ -196,8 +196,10 @@ int main()
     // For conversions that could truncate, specify representation type:
     std::cout << production.in<double>(carton); // "2100 carton" (divided by 12)
 
-    // Or use force_in for explicit truncation:
-    std::cout << production.force_in(carton);   // "2100 carton" (truncates if needed)
+    // Or keep the integer count and say how a partial carton should round:
+    quantity partial = 25199 * unit;
+    std::cout << partial.in(carton, rounded_down);  // "2099 carton" (full cartons only)
+    std::cout << partial.in(carton, rounded_up);    // "2100 carton" (cartons needed to ship it)
 
     quantity from_cartons = 2100 * carton;
     std::cout << from_cartons.in(unit);         // "25200 unit" (multiplied by 12)
@@ -222,6 +224,15 @@ int main()
     - `floor<Unit>(q)` rounds down to the nearest whole unit
     - `ceil<Unit>(q)` rounds up to the nearest whole unit
     - Both preserve strong typing and prevent errors
+
+    !!! note "Math functions or rounding policies?"
+
+        `floor<Unit>(q)` and `ceil<Unit>(q)` round to a whole number of the target unit and
+        keep the representation type, so they also work on floating-point quantities. The
+        `rounded_down` and `rounded_up` policies round the result of a *conversion* to a
+        value the destination type can represent, so they change nothing when that value is
+        already exact. For an integer quantity converted to a coarser unit the two
+        coincide, and `partial.in(carton, rounded_up)` is the cheaper spelling.
 
     ### Beyond physics: Business and logistics applications
 

--- a/docs/workshops/foundation/interop_with_std_chrono.md
+++ b/docs/workshops/foundation/interop_with_std_chrono.md
@@ -118,7 +118,7 @@ int main()
       print_trip_stats(duration.in<double>(min), distance, avg_speed.in(km / h));
 
       // Schedule alert
-      car_clock::duration dur_to_arrival = (5 * km / avg_speed).force_in<car_clock::rep>();
+      car_clock::duration dur_to_arrival = (5 * km / avg_speed).in<car_clock::rep>(truncated);
       schedule_driver_alert(tp2 + dur_to_arrival);
     }
     ```
@@ -165,7 +165,7 @@ int main()
     - No conversion needed - types match perfectly
     - Conversion back to `std::chrono` is implicit when there's no precision loss
 
-    ### Explicit conversions with `.force_in<Rep>(Unit)`
+    ### Explicit conversions with `.in<Rep>(Unit, policy)`
 
     When truncation or overflow is possible, use explicit conversion:
 
@@ -173,15 +173,34 @@ int main()
     quantity avg_speed = distance / duration;  // mp-units calculation
 
     // Truncating conversion requires explicit cast:
-    car_clock::duration dur = (5 * km / avg_speed).force_in<car_clock::rep>(unit_for<car_clock::duration>);
+    car_clock::duration dur = (5 * km / avg_speed).in<car_clock::rep>(unit_for<car_clock::duration>, truncated);
     schedule_alert(tp2 + dur);  // Use result with std::chrono
     ```
 
-    The `.force_in<Rep>(Unit)` method:
+    The `.in<Rep>(Unit, policy)` method:
 
     - Converts the quantity to the specified unit and representation type
-    - Explicitly acknowledges potential precision loss (truncation, overflow)
+    - States which representable value you get when the conversion cannot be exact
     - Returns the representation type expected by `std::chrono` duration constructors
+
+    The policy vocabulary maps onto the `std::chrono` conversion functions, so the choice you
+    would make there is the choice you make here:
+
+    | **mp-units**   | `std::chrono`   |
+    |----------------|-----------------|
+    | `truncated`    | `duration_cast` |
+    | `rounded`      | `round`         |
+    | `rounded_down` | `floor`         |
+    | `rounded_up`   | `ceil`          |
+
+    `truncated` above converts whole nanoseconds, so the choice does not change the result.
+    It starts to matter as soon as the target unit is coarser. For a driver alert expressed
+    in whole minutes, `rounded_up` is the honest policy, because it never promises an earlier
+    arrival than the computation supports:
+
+    ```cpp
+    quantity time_to_arrival = (5 * km / avg_speed).in<int>(min, rounded_up);
+    ```
 
     ### Best practices for hybrid applications
 

--- a/example/avg_speed.cpp
+++ b/example/avg_speed.cpp
@@ -63,7 +63,7 @@ constexpr QuantityOf<isq::speed> auto avg_speed(QuantityOf<isq::length> auto d, 
 template<QuantityOf<isq::length> D, QuantityOf<isq::duration> T, QuantityOf<isq::speed> V>
 void print_result(D distance, T duration, V speed)
 {
-  const auto result_in_kmph = speed.force_in(si::kilo<si::metre> / non_si::hour);
+  const auto result_in_kmph = speed.in(si::kilo<si::metre> / non_si::hour, truncated);
   std::cout << "Average speed of a car that makes " << distance << " in " << duration << " is " << result_in_kmph
             << ".\n";
 }
@@ -108,7 +108,7 @@ void example()
 
     // it is not possible to make a lossless conversion of miles to meters on an integral type
     // (explicit cast needed)
-    print_result(distance, duration, fixed_int_si_avg_speed(distance.force_in(m), duration));
+    print_result(distance, duration, fixed_int_si_avg_speed(distance.in(m, truncated), duration));
     print_result(distance, duration, fixed_double_si_avg_speed(distance, duration));
     print_result(distance, duration, avg_speed(distance, duration));
   }
@@ -139,7 +139,7 @@ void example()
 
     // it is not possible to make a lossless conversion of centimeters to meters on an integral type
     // (explicit cast needed)
-    print_result(distance, duration, fixed_int_si_avg_speed(distance.force_in(m), duration));
+    print_result(distance, duration, fixed_int_si_avg_speed(distance.in(m, truncated), duration));
     print_result(distance, duration, fixed_double_si_avg_speed(distance, duration));
     print_result(distance, duration, avg_speed(distance, duration));
   }

--- a/example/currency.cpp
+++ b/example/currency.cpp
@@ -118,9 +118,9 @@ int main()
   // Cross-currency arithmetic does not compile — must go through explicit FX conversion:
   // const quantity bad = pos_usd + pos_eur;  // does not compile
 
-  const quantity pos_eur_usd = round<USD>(exchange_to<us_dollar>(pos_eur, timestamp)).force_in<int>();
-  const quantity pos_gbp_usd = round<USD>(exchange_to<us_dollar>(pos_gbp, timestamp)).force_in<int>();
-  const quantity pos_jpy_usd = round<USD>(exchange_to<us_dollar>(pos_jpy, timestamp)).force_in<int>();
+  const quantity pos_eur_usd = round<USD>(exchange_to<us_dollar>(pos_eur, timestamp)).in<int>(rounded);
+  const quantity pos_gbp_usd = round<USD>(exchange_to<us_dollar>(pos_gbp, timestamp)).in<int>(rounded);
+  const quantity pos_jpy_usd = round<USD>(exchange_to<us_dollar>(pos_jpy, timestamp)).in<int>(rounded);
   const quantity total_usd = pos_usd + pos_eur_usd + pos_gbp_usd + pos_jpy_usd;
 
   std::cout << "Portfolio positions:\n";

--- a/example/glide_computer.cpp
+++ b/example/glide_computer.cpp
@@ -93,9 +93,9 @@ void print(const R& gliders)
     std::cout << "- Name: " << g.name << "\n";
     std::cout << "- Polar:\n";
     for (const auto& p : g.polar) {
-      const auto ratio = glide_ratio(g.polar[0]).force_in(one);
+      const auto ratio = glide_ratio(g.polar[0]).in(one);
       std::cout << MP_UNITS_STD_FMT::format("  * {::N[.4f]} @ {::N[.1f]} -> {::N[.1f]} ({::N[.1f]})\n", p.climb, p.v,
-                                            ratio, si::asin(1 / ratio).force_in(si::degree));
+                                            ratio, si::asin(1 / ratio).in(si::degree));
     }
     std::cout << "\n";
   }

--- a/example/total_energy.cpp
+++ b/example/total_energy.cpp
@@ -97,7 +97,7 @@ void si_example()
             << "E = " << E3 << "\n";
 
   std::cout << "\n[converted from SI units back to GeV]\n"
-            << "E = " << E3.force_in(GeV) << "\n";
+            << "E = " << E3.in(GeV) << "\n";
 }
 
 void natural_example()

--- a/example/trade_execution.cpp
+++ b/example/trade_execution.cpp
@@ -86,7 +86,7 @@ struct Fill {
 
 [[nodiscard]] Notional notional(const Fill& f)
 {
-  const quantity price_in_usd8 = f.price.quantity_from_zero().force_in<std::int64_t>(us_dollar_8);
+  const quantity price_in_usd8 = f.price.quantity_from_zero().in<std::int64_t>(us_dollar_8, rounded);
   return price_in_usd8 * f.qty;
 }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -70,6 +70,7 @@ add_mp_units_module(
             include/mp-units/framework/reference.h
             include/mp-units/framework/reference_concepts.h
             include/mp-units/framework/representation_concepts.h
+            include/mp-units/framework/rounding.h
             include/mp-units/framework/scaling.h
             include/mp-units/framework/symbol_text.h
             include/mp-units/framework/symbolic_expression.h

--- a/src/core/include/mp-units/bits/fixed_point.h
+++ b/src/core/include/mp-units/bits/fixed_point.h
@@ -26,6 +26,7 @@
 #include <mp-units/bits/int_power.h>
 #include <mp-units/ext/algorithm.h>
 #include <mp-units/ext/type_traits.h>  // IWYU pragma: keep
+#include <mp-units/framework/rounding.h>
 
 // `double_width_int` only emulates `int128_t` on platforms without native `__int128` (notably
 // MSVC).  On every other platform `int128_t` is the builtin and dwint is unused in library code
@@ -167,12 +168,30 @@ struct fixed_point {
     }
   }
 
-  template<std::integral U>
+  template<rounding_mode Mode = rounding_mode::truncated, std::integral U>
     requires(integer_rep_width_v<U> <= integer_rep_width_v<T>)
   [[nodiscard]] constexpr auto scale(U v) const
   {
-    auto res = v * int_repr_;
-    return static_cast<conditional<is_signed_v<decltype((res))>, std::make_signed_t<U>, U>>(res >> fractional_bits);
+    const auto res = v * int_repr_;
+    using res_t = std::remove_const_t<decltype(res)>;
+    using ret_t = conditional<is_signed_v<res_t>, std::make_signed_t<U>, U>;
+    // arithmetic right shift rounds towards negative infinity
+    auto quot = res >> fractional_bits;
+    if constexpr (Mode != rounding_mode::rounded_down) {
+      const res_t frac = res - (quot << fractional_bits);  // fraction bits, always in [0, 2^fractional_bits)
+      const res_t zero{0};
+      if constexpr (Mode == rounding_mode::truncated) {
+        // towards zero: the floor quotient is one too low for negative non-exact values
+        if (res < zero && frac != zero) ++quot;
+      } else if constexpr (Mode == rounding_mode::rounded_up) {
+        if (frac != zero) ++quot;
+      } else {  // rounding_mode::rounded (to nearest, ties to even)
+        const res_t half = res_t{1} << (fractional_bits - 1);
+        const auto is_odd = quot - (quot / 2) * 2 != zero;
+        if (frac > half || (frac == half && is_odd)) ++quot;
+      }
+    }
+    return static_cast<ret_t>(quot);
   }
 private:
   value_type int_repr_;

--- a/src/core/include/mp-units/bits/sudo_cast.h
+++ b/src/core/include/mp-units/bits/sudo_cast.h
@@ -25,6 +25,7 @@
 #include <mp-units/ext/type_traits.h>
 #include <mp-units/framework/quantity_concepts.h>
 #include <mp-units/framework/reference_concepts.h>
+#include <mp-units/framework/rounding.h>
 #include <mp-units/framework/scaling.h>
 #include <mp-units/framework/unit.h>
 #include <mp-units/framework/unit_magnitude.h>
@@ -64,7 +65,8 @@ struct conversion_type_traits {
  *
  * @tparam To a target quantity type to cast to
  */
-template<Quantity To, typename FwdFrom, Quantity From = std::remove_cvref_t<FwdFrom>>
+template<Quantity To, rounding_mode Mode = rounding_mode::truncated, typename FwdFrom,
+         Quantity From = std::remove_cvref_t<FwdFrom>>
   requires(castable(From::quantity_spec, To::quantity_spec)) &&
           ((equivalent(From::unit, To::unit) && std::constructible_from<typename To::rep, typename From::rep>) ||
            (!equivalent(From::unit, To::unit)))  // && scalable_with_<typename To::rep>))
@@ -72,14 +74,21 @@ template<Quantity To, typename FwdFrom, Quantity From = std::remove_cvref_t<FwdF
 [[nodiscard]] constexpr Quantity auto sudo_cast(FwdFrom&& q)
 {
   if constexpr (equivalent(From::unit, To::unit)) {
-    // no scaling of the number needed
-    return To{
-      detail::silent_cast<typename To::rep>(std::forward<FwdFrom>(q).numerical_value_is_an_implementation_detail_),
-      To::reference};
+    // no scaling of the number needed; rounding applies only when a floating-point source
+    // is narrowed to an integral destination (`silent_cast` truncates that case)
+    if constexpr (Mode != rounding_mode::truncated && treat_as_floating_point<typename From::rep> &&
+                  !treat_as_floating_point<typename To::rep>)
+      return To{detail::silent_cast<typename To::rep>(
+                  detail::round_fp<Mode>(std::forward<FwdFrom>(q).numerical_value_is_an_implementation_detail_)),
+                To::reference};
+    else
+      return To{
+        detail::silent_cast<typename To::rep>(std::forward<FwdFrom>(q).numerical_value_is_an_implementation_detail_),
+        To::reference};
   } else {
     constexpr UnitMagnitude auto c_mag = get_canonical_unit(From::unit).mag / get_canonical_unit(To::unit).mag;
 
-    auto res = scale<typename To::rep>(c_mag, q.numerical_value_is_an_implementation_detail_);
+    auto res = scale_impl<typename To::rep, Mode>(c_mag, q.numerical_value_is_an_implementation_detail_);
     return quantity{std::move(res), To::reference};
   }
 }
@@ -93,7 +102,8 @@ template<Quantity To, typename FwdFrom, Quantity From = std::remove_cvref_t<FwdF
  *
  * @tparam ToQP a target quantity point type to which to cast to
  */
-template<QuantityPoint ToQP, typename FwdFromQP, QuantityPoint FromQP = std::remove_cvref_t<FwdFromQP>>
+template<QuantityPoint ToQP, rounding_mode Mode = rounding_mode::truncated, typename FwdFromQP,
+         QuantityPoint FromQP = std::remove_cvref_t<FwdFromQP>>
   requires(mp_units::castable(FromQP::quantity_spec, ToQP::quantity_spec)) &&
           (detail::same_absolute_point_origins(ToQP::point_origin, FromQP::point_origin)) &&
           ((equivalent(FromQP::unit, ToQP::unit) &&
@@ -104,7 +114,7 @@ template<QuantityPoint ToQP, typename FwdFromQP, QuantityPoint FromQP = std::rem
   if constexpr (is_same_v<MP_UNITS_NONCONST_TYPE(ToQP::point_origin), MP_UNITS_NONCONST_TYPE(FromQP::point_origin)>) {
     // Same origin: delegate entirely to the quantity sudo_cast — no offset arithmetic needed.
     return quantity_point{
-      sudo_cast<typename ToQP::quantity_type>(std::forward<FwdFromQP>(qp).quantity_from(FromQP::point_origin)),
+      sudo_cast<typename ToQP::quantity_type, Mode>(std::forward<FwdFromQP>(qp).quantity_from(FromQP::point_origin)),
       ToQP::point_origin};
   } else {
     // Different origins: we need to (a) convert the rep/unit, (b) add the origin offset.
@@ -130,9 +140,11 @@ template<QuantityPoint ToQP, typename FwdFromQP, QuantityPoint FromQP = std::rem
     // Helper: statically compute the origin offset expressed in the given quantity type Q.
     // We go via quantity_point subtraction to handle all origin relationships correctly,
     // including cases where two natural_point_origins of different units exist.
+    // The offset conversion applies `Mode` too so that a non-representable offset (e.g.
+    // -273.15 K with an integral rep) is rounded consistently with the value itself.
     constexpr auto offset_as = [&]<typename Q>(std::type_identity<Q>) {
       constexpr auto zero = quantity{typename Q::rep{0}, Q::reference};
-      return sudo_cast<Q>(quantity_point{zero, FromQP::point_origin} - quantity_point{zero, ToQP::point_origin});
+      return sudo_cast<Q, Mode>(quantity_point{zero, FromQP::point_origin} - quantity_point{zero, ToQP::point_origin});
     };
 
     constexpr auto output_unit_ref = make_reference(FromQP::quantity_spec, ToQP::unit);
@@ -143,7 +155,7 @@ template<QuantityPoint ToQP, typename FwdFromQP, QuantityPoint FromQP = std::rem
       using intermediate_type = quantity<FromQP::reference, c_rep_type>;
       constexpr auto offset = offset_as(std::type_identity<intermediate_type>{});
       return quantity_point{
-        sudo_cast<typename ToQP::quantity_type>(
+        sudo_cast<typename ToQP::quantity_type, Mode>(
           sudo_cast<intermediate_type>(std::forward<FwdFromQP>(qp).quantity_from(FromQP::point_origin)) + offset),
         ToQP::point_origin};
     } else if constexpr (treat_as_floating_point<c_type>) {
@@ -160,7 +172,7 @@ template<QuantityPoint ToQP, typename FwdFromQP, QuantityPoint FromQP = std::rem
       }();
       using intermediate_type = quantity<intermediate_ref, c_type>;
       return quantity_point{
-        sudo_cast<typename ToQP::quantity_type>(
+        sudo_cast<typename ToQP::quantity_type, Mode>(
           quantity_point{sudo_cast<intermediate_type>(std::forward<FwdFromQP>(qp).quantity_from(FromQP::point_origin)),
                          FromQP::point_origin}
             .point_for(ToQP::point_origin)
@@ -183,16 +195,18 @@ template<QuantityPoint ToQP, typename FwdFromQP, QuantityPoint FromQP = std::rem
         using intermediate_type = quantity<output_unit_ref, c_rep_type>;
         constexpr auto offset = offset_as(std::type_identity<intermediate_type>{});
         return quantity_point{
-          sudo_cast<typename ToQP::quantity_type>(
-            sudo_cast<intermediate_type>(std::forward<FwdFromQP>(qp).quantity_from(FromQP::point_origin)) + offset),
+          sudo_cast<typename ToQP::quantity_type, Mode>(
+            sudo_cast<intermediate_type, Mode>(std::forward<FwdFromQP>(qp).quantity_from(FromQP::point_origin)) +
+            offset),
           ToQP::point_origin};
       } else {
         // offset overflows in the output unit — use the input unit instead
         using intermediate_type = quantity<FromQP::reference, c_rep_type>;
         constexpr auto offset = offset_as(std::type_identity<intermediate_type>{});
         return quantity_point{
-          sudo_cast<typename ToQP::quantity_type>(
-            sudo_cast<intermediate_type>(std::forward<FwdFromQP>(qp).quantity_from(FromQP::point_origin)) + offset),
+          sudo_cast<typename ToQP::quantity_type, Mode>(
+            sudo_cast<intermediate_type, Mode>(std::forward<FwdFromQP>(qp).quantity_from(FromQP::point_origin)) +
+            offset),
           ToQP::point_origin};
       }
     }

--- a/src/core/include/mp-units/ext/type_traits.h
+++ b/src/core/include/mp-units/ext/type_traits.h
@@ -133,6 +133,14 @@ template<typename T, auto... Vs>
   return (false || ... || is_same_v<MP_UNITS_REMOVE_CONST(decltype(Vs)), T>);
 }
 
+// the first list element is mandatory to disambiguate from the empty-pack case of the
+// NTTP-values overload above
+template<typename T, typename T1, typename... Ts>
+[[nodiscard]] consteval bool contains()
+{
+  return is_same_v<T, T1> || (false || ... || is_same_v<T, Ts>);
+}
+
 template<template<typename...> typename T, typename... Ts>
 [[nodiscard]] consteval bool contains()
 {

--- a/src/core/include/mp-units/framework.h
+++ b/src/core/include/mp-units/framework.h
@@ -40,6 +40,7 @@
 #include <mp-units/framework/quantity_traits.h>
 #include <mp-units/framework/reference.h>
 #include <mp-units/framework/representation_concepts.h>
+#include <mp-units/framework/rounding.h>
 #include <mp-units/framework/scaling.h>
 #include <mp-units/framework/symbol_text.h>
 #include <mp-units/framework/symbolic_expression.h>

--- a/src/core/include/mp-units/framework/quantity.h
+++ b/src/core/include/mp-units/framework/quantity.h
@@ -35,6 +35,7 @@
 #include <mp-units/framework/reference.h>
 #include <mp-units/framework/reference_concepts.h>
 #include <mp-units/framework/representation_concepts.h>
+#include <mp-units/framework/rounding.h>
 #include <mp-units/framework/unit_concepts.h>
 #include <mp-units/framework/value_cast.h>
 #include <mp-units/framework/vector_components.h>
@@ -708,25 +709,52 @@ public:
     return detail::sudo_cast<quantity<detail::make_reference(quantity_spec, ToU{}), ToRep>>(*this);
   }
 
+  template<UnitOf<quantity_spec> ToU, RoundingPolicy Policy>
+    requires detail::ExplicitlyCastable<unit, ToU{}, rep> && detail::ValidRoundingPolicyFor<Policy, rep, rep>
+  [[nodiscard]] constexpr QuantityOf<quantity_spec> auto in(ToU, Policy policy) const
+  {
+    return value_cast<ToU{}>(*this, policy);
+  }
+
+  template<RepresentationOf<quantity_spec> ToRep, RoundingPolicy Policy>
+    requires std::constructible_from<ToRep, rep> && detail::ValidRoundingPolicyFor<Policy, rep, ToRep>
+  [[nodiscard]] constexpr QuantityOf<quantity_spec> auto in(Policy policy) const
+  {
+    return value_cast<ToRep>(*this, policy);
+  }
+
+  template<RepresentationOf<quantity_spec> ToRep, UnitOf<quantity_spec> ToU, RoundingPolicy Policy>
+    requires std::constructible_from<ToRep, rep> && detail::ExplicitlyCastable<unit, ToU{}, ToRep> &&
+             detail::ValidRoundingPolicyFor<Policy, rep, ToRep>
+  [[nodiscard]] constexpr QuantityOf<quantity_spec> auto in(ToU, Policy policy) const
+  {
+    return value_cast<ToU{}, ToRep>(*this, policy);
+  }
+
   template<UnitOf<quantity_spec> ToU>
     requires detail::ExplicitlyCastable<unit, ToU{}, rep>
-  [[nodiscard]] constexpr QuantityOf<quantity_spec> auto force_in(ToU) const
+  [[deprecated(
+    "2.6.0: use `in(unit, policy)` with a rounding policy (e.g. `truncated`) "
+    "instead")]] [[nodiscard]] constexpr QuantityOf<quantity_spec> auto force_in(ToU) const
   {
-    return value_cast<ToU{}>(*this);
+    return in(ToU{}, truncated);
   }
 
   template<RepresentationOf<quantity_spec> ToRep>
     requires std::constructible_from<ToRep, rep>
-  [[nodiscard]] constexpr QuantityOf<quantity_spec> auto force_in() const
+  [[deprecated("2.6.0: use `in<Rep>(policy)` with a rounding policy (e.g. `truncated`) instead")]] [[nodiscard]]
+  constexpr QuantityOf<quantity_spec> auto force_in() const
   {
-    return value_cast<ToRep>(*this);
+    return in<ToRep>(truncated);
   }
 
   template<RepresentationOf<quantity_spec> ToRep, UnitOf<quantity_spec> ToU>
     requires std::constructible_from<ToRep, rep> && detail::ExplicitlyCastable<unit, ToU{}, rep>
-  [[nodiscard]] constexpr QuantityOf<quantity_spec> auto force_in(ToU) const
+  [[deprecated(
+    "2.6.0: use `in<Rep>(unit, policy)` with a rounding policy (e.g. `truncated`) "
+    "instead")]] [[nodiscard]] constexpr QuantityOf<quantity_spec> auto force_in(ToU) const
   {
-    return value_cast<ToU{}, ToRep>(*this);
+    return in<ToRep>(ToU{}, truncated);
   }
 
   // Euclidean (or, for a complex field, Hermitian) norm of a vector or tensor quantity, as a scalar
@@ -800,11 +828,20 @@ public:
     return in(U{}).numerical_value_is_an_implementation_detail_;
   }
 
+  template<UnitOf<quantity_spec> U, RoundingPolicy Policy>
+    requires detail::ExplicitlyCastable<unit, U{}, rep> && detail::ValidRoundingPolicyFor<Policy, rep, rep>
+  [[nodiscard]] constexpr RepresentationOf<quantity_spec> auto numerical_value_in(U, Policy policy) const noexcept
+  {
+    return in(U{}, policy).numerical_value_is_an_implementation_detail_;
+  }
+
   template<UnitOf<quantity_spec> U>
     requires detail::ExplicitlyCastable<unit, U{}, rep>
-  [[nodiscard]] constexpr RepresentationOf<quantity_spec> auto force_numerical_value_in(U) const noexcept
+  [[deprecated(
+    "2.6.0: use `numerical_value_in(unit, policy)` with a rounding policy (e.g. `truncated`) "
+    "instead")]] [[nodiscard]] constexpr RepresentationOf<quantity_spec> auto force_numerical_value_in(U) const noexcept
   {
-    return force_in(U{}).numerical_value_is_an_implementation_detail_;
+    return numerical_value_in(U{}, truncated);
   }
 
   // conversion operators

--- a/src/core/include/mp-units/framework/quantity_point.h
+++ b/src/core/include/mp-units/framework/quantity_point.h
@@ -29,6 +29,7 @@
 #include <mp-units/framework/customization_points.h>
 #include <mp-units/framework/quantity.h>
 #include <mp-units/framework/quantity_point_concepts.h>
+#include <mp-units/framework/rounding.h>
 #include <mp-units/overflow_policies.h>
 #if MP_UNITS_HOSTED
 #include <mp-units/bits/format.h>
@@ -93,7 +94,7 @@ template<Quantity auto Q>
   else {
     constexpr auto canonical = get_canonical_unit(Q.unit);
     constexpr auto value_in_coherent_unit = mag<detail::abs(v)> * canonical.mag;
-    return Q.force_in(pow<-1>(denominator(value_in_coherent_unit)) * canonical.reference_unit);
+    return Q.in(pow<-1>(denominator(value_in_coherent_unit)) * canonical.reference_unit, truncated);
   }
 }
 
@@ -521,6 +522,22 @@ struct quantity_point_iface {
 #endif  // MP_UNITS_HOSTED
 };
 
+// Re-expresses a range bound as the point's own quantity type. That conversion is value-preserving
+// for every bounded point type the shipped policies can instantiate (they construct the point's
+// quantity type from the bound, which the framework only permits when nothing is lost), so the bound
+// is reported exactly. A user-defined bounds policy that does not need such a construction may
+// declare a bound that only converts by truncating; that one is rounded *inwards*, because a `min`
+// rounded towards negative infinity or a `max` rounded towards positive infinity would report
+// a range wider than the declared one and admit values outside it.
+template<RoundingPolicy Policy, Quantity ToQ, Quantity Q>
+[[nodiscard]] constexpr ToQ bound_as(const Q& bound)
+{
+  if constexpr (std::convertible_to<Q, ToQ>)
+    return ToQ{bound};
+  else
+    return value_cast<ToQ>(bound, Policy{});
+}
+
 }  // namespace detail
 
 MP_UNITS_EXPORT_BEGIN
@@ -561,7 +578,7 @@ public:
       if constexpr (std::same_as<std::remove_cvref_t<decltype(PO._bounds_.min)>, detail::zero_quantity_t>)
         return {quantity_type::zero(), PO};
       else
-        return {PO._bounds_.min.force_in(unit), PO};
+        return {detail::bound_as<rounded_up_t, quantity_type>(PO._bounds_.min), PO};
     } else {
       return {quantity_type::min(), PO};
     }
@@ -571,7 +588,7 @@ public:
     requires requires { PO._bounds_.max; } || requires { quantity_type::max(); }
   {
     if constexpr (requires { PO._bounds_.max; })
-      return {PO._bounds_.max.force_in(unit), PO};
+      return {detail::bound_as<rounded_down_t, quantity_type>(PO._bounds_.max), PO};
     else
       return {quantity_type::max(), PO};
   }
@@ -736,11 +753,21 @@ public:
     return in(U{}).quantity_from_zero().numerical_value_in(U{});
   }
 
+  template<UnitOf<quantity_spec> U, RoundingPolicy Policy>
+    requires(PO == default_point_origin(R)) && detail::ExplicitlyCastable<unit, U{}, rep> &&
+            detail::ValidRoundingPolicyFor<Policy, rep, rep>
+  [[nodiscard]] constexpr RepresentationOf<quantity_spec> auto numerical_value_in(U, Policy policy) const noexcept
+  {
+    return in(U{}, policy).quantity_from_zero().numerical_value_in(U{});
+  }
+
   template<UnitOf<quantity_spec> U>
     requires(PO == default_point_origin(R)) && detail::ExplicitlyCastable<unit, U{}, rep>
-  [[nodiscard]] constexpr RepresentationOf<quantity_spec> auto force_numerical_value_in(U) const noexcept
+  [[deprecated(
+    "2.6.0: use `numerical_value_in(unit, policy)` with a rounding policy (e.g. `truncated`) "
+    "instead")]] [[nodiscard]] constexpr RepresentationOf<quantity_spec> auto force_numerical_value_in(U) const noexcept
   {
-    return force_in(U{}).quantity_from_zero().numerical_value_in(U{});
+    return numerical_value_in(U{}, truncated);
   }
 
 private:
@@ -778,25 +805,52 @@ public:
     return in_impl(ToU{}, [](const auto& q) { return q.template in<ToRep>(ToU{}); });
   }
 
+  template<UnitOf<quantity_spec> ToU, RoundingPolicy Policy>
+    requires detail::ExplicitlyCastable<unit, ToU{}, rep> && detail::ValidRoundingPolicyFor<Policy, rep, rep>
+  [[nodiscard]] constexpr QuantityPointOf<quantity_spec> auto in(ToU, Policy policy) const
+  {
+    return in_impl(ToU{}, [policy](const auto& q) { return q.in(ToU{}, policy); });
+  }
+
+  template<RepresentationOf<quantity_spec> ToRep, RoundingPolicy Policy>
+    requires std::constructible_from<ToRep, rep> && detail::ValidRoundingPolicyFor<Policy, rep, ToRep>
+  [[nodiscard]] constexpr QuantityPointOf<quantity_spec> auto in(Policy policy) const
+  {
+    return ::mp_units::quantity_point{quantity_ref_from(point_origin).template in<ToRep>(policy), point_origin};
+  }
+
+  template<RepresentationOf<quantity_spec> ToRep, UnitOf<quantity_spec> ToU, RoundingPolicy Policy>
+    requires std::constructible_from<ToRep, rep> && detail::ExplicitlyCastable<unit, ToU{}, ToRep> &&
+             detail::ValidRoundingPolicyFor<Policy, rep, ToRep>
+  [[nodiscard]] constexpr QuantityPointOf<quantity_spec> auto in(ToU, Policy policy) const
+  {
+    return in_impl(ToU{}, [policy](const auto& q) { return q.template in<ToRep>(ToU{}, policy); });
+  }
+
   template<UnitOf<quantity_spec> ToU>
     requires detail::ExplicitlyCastable<unit, ToU{}, rep>
-  [[nodiscard]] constexpr QuantityPointOf<quantity_spec> auto force_in(ToU) const
+  [[deprecated(
+    "2.6.0: use `in(unit, policy)` with a rounding policy (e.g. `truncated`) "
+    "instead")]] [[nodiscard]] constexpr QuantityPointOf<quantity_spec> auto force_in(ToU) const
   {
-    return in_impl(ToU{}, [](const auto& q) { return q.force_in(ToU{}); });
+    return in(ToU{}, truncated);
   }
 
   template<RepresentationOf<quantity_spec> ToRep>
     requires std::constructible_from<ToRep, rep>
-  [[nodiscard]] constexpr QuantityPointOf<quantity_spec> auto force_in() const
+  [[deprecated("2.6.0: use `in<Rep>(policy)` with a rounding policy (e.g. `truncated`) instead")]] [[nodiscard]]
+  constexpr QuantityPointOf<quantity_spec> auto force_in() const
   {
-    return ::mp_units::quantity_point{quantity_ref_from(point_origin).template force_in<ToRep>(), point_origin};
+    return in<ToRep>(truncated);
   }
 
   template<RepresentationOf<quantity_spec> ToRep, UnitOf<quantity_spec> ToU>
     requires std::constructible_from<ToRep, rep> && detail::ExplicitlyCastable<unit, ToU{}, rep>
-  [[nodiscard]] constexpr QuantityPointOf<quantity_spec> auto force_in(ToU) const
+  [[deprecated(
+    "2.6.0: use `in<Rep>(unit, policy)` with a rounding policy (e.g. `truncated`) "
+    "instead")]] [[nodiscard]] constexpr QuantityPointOf<quantity_spec> auto force_in(ToU) const
   {
-    return in_impl(ToU{}, [](const auto& q) { return q.template force_in<ToRep>(ToU{}); });
+    return in<ToRep>(ToU{}, truncated);
   }
 
   // conversion operators

--- a/src/core/include/mp-units/framework/rounding.h
+++ b/src/core/include/mp-units/framework/rounding.h
@@ -1,0 +1,122 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// IWYU pragma: private, include <mp-units/framework.h>
+#include <mp-units/bits/module_macros.h>
+#include <mp-units/ext/type_traits.h>
+
+#ifndef MP_UNITS_IN_MODULE_INTERFACE
+#ifdef MP_UNITS_IMPORT_STD
+import std;
+#else
+#include <cstdint>
+#endif  // MP_UNITS_IMPORT_STD
+#endif  // MP_UNITS_IN_MODULE_INTERFACE
+
+namespace mp_units {
+
+MP_UNITS_EXPORT_BEGIN
+
+/**
+ * @brief Rounding policies for potentially lossy value conversions
+ *
+ * A conversion without a policy (e.g. `q.in(u)`) is only available when the framework
+ * considers it value-preserving (following the `std::chrono` convention, a floating-point
+ * destination is always considered such). For the conversions considered truncating (e.g.
+ * an integral representation scaled by a non-integral factor, or a narrowing of the
+ * representation type), the user has to explicitly state what should happen to the
+ * information that does not fit by passing a rounding policy as the last function argument:
+ *
+ * @code{.cpp}
+ * quantity q1 = (1234 * m).in(km, truncated);          // 1 km
+ * quantity q2 = (1567 * m).in(km, rounded);            // 2 km
+ * quantity q3 = (-1500 * m).in(km, rounded_down);      // -2 km
+ * quantity q4 = (1.23 * s).in<int>(ms, rounded_up);    // 1231 ms
+ * @endcode
+ *
+ * The policy specifies how to round the exact conversion result to a value representable
+ * in the destination type:
+ * - `truncated`    - the semantics of `static_cast` and `std::chrono::duration_cast`:
+ *                    rounds towards zero for an integral destination; a floating-point
+ *                    destination converts to the nearest representable value,
+ * - `rounded`      - rounds to the nearest representable value, to even in halfway cases
+ *                    (the semantics of `std::chrono::round`),
+ * - `rounded_down` - rounds towards negative infinity (the semantics of `std::chrono::floor`),
+ * - `rounded_up`   - rounds towards positive infinity (the semantics of `std::chrono::ceil`).
+ *
+ * A floating-point destination represents every conversion result with a rounding error of
+ * at most half ULP (`rounded` semantics), and the directed modes cannot be delivered for it,
+ * which is why it accepts only the `truncated` and `rounded` policies.
+ *
+ * Note that `mp_units::floor/ceil/round<U>(q)` perform a different operation: they round to
+ * an integral multiple of the target unit even when the representation could store the exact
+ * result (e.g. for a floating-point representation). The policies never adjust a value that
+ * the destination represents exactly. Both coincide for integral representations.
+ */
+struct truncated_t {
+  explicit truncated_t() = default;
+};
+
+struct rounded_t {
+  explicit rounded_t() = default;
+};
+
+struct rounded_down_t {
+  explicit rounded_down_t() = default;
+};
+
+struct rounded_up_t {
+  explicit rounded_up_t() = default;
+};
+
+inline constexpr truncated_t truncated{};
+inline constexpr rounded_t rounded{};
+inline constexpr rounded_down_t rounded_down{};
+inline constexpr rounded_up_t rounded_up{};
+
+/**
+ * @brief A concept matching all rounding policies
+ *
+ * Satisfied only by the types of `truncated`, `rounded`, `rounded_down`, and `rounded_up`.
+ */
+template<typename T>
+concept RoundingPolicy = contains<T, truncated_t, rounded_t, rounded_down_t, rounded_up_t>();
+
+MP_UNITS_EXPORT_END
+
+namespace detail {
+
+// Internal representation of the rounding policies used to parameterize the conversion
+// engine (`sudo_cast`, `scale`) without instantiating it for every policy tag type.
+enum class rounding_mode : std::int8_t { truncated, rounded, rounded_down, rounded_up };
+
+template<RoundingPolicy Policy>
+constexpr rounding_mode rounding_mode_of = is_same_v<Policy, truncated_t>      ? rounding_mode::truncated
+                                           : is_same_v<Policy, rounded_t>      ? rounding_mode::rounded
+                                           : is_same_v<Policy, rounded_down_t> ? rounding_mode::rounded_down
+                                                                               : rounding_mode::rounded_up;
+
+}  // namespace detail
+
+}  // namespace mp_units

--- a/src/core/include/mp-units/framework/scaling.h
+++ b/src/core/include/mp-units/framework/scaling.h
@@ -24,13 +24,19 @@
 
 // IWYU pragma: private, include <mp-units/framework.h>
 #include <mp-units/bits/fixed_point.h>
+#include <mp-units/bits/int_power.h>
 #include <mp-units/framework/representation_concepts.h>
+#include <mp-units/framework/rounding.h>
 
 #ifndef MP_UNITS_IN_MODULE_INTERFACE
+#include <mp-units/ext/contracts.h>
 #ifdef MP_UNITS_IMPORT_STD
 import std;
 #else
 #include <concepts>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
 #endif
 #endif
 
@@ -60,6 +66,101 @@ MP_UNITS_EXPORT template<typename To, typename From>
 
 template<typename T>
 inline constexpr bool treat_as_integral = !treat_as_floating_point<T>;
+
+// A zero and a one of the same type as the value passed in, derived from that value instead of from
+// the `representation_values` customization point. The types the scaling arithmetic runs in are
+// widened or otherwise derived from the operands, so they are never the representation type a caller
+// named and no constraint could speak about them. Subtracting a value from itself is exactly zero and
+// dividing it by itself is exactly one, so these ask nothing of a type beyond the arithmetic
+// `RealScalar` already mandates.
+template<typename T>
+[[nodiscard]] constexpr T get_zero(const T& value)
+{
+  return value - value;
+}
+
+template<typename T>
+[[nodiscard]] constexpr T get_one(const T& value)
+{
+  MP_UNITS_EXPECTS(value != get_zero(value));
+  return value / value;
+}
+
+/**
+ * @brief Integer division with the quotient rounded according to @c Mode
+ */
+template<rounding_mode Mode, typename T, typename D>
+[[nodiscard]] constexpr auto div_round(const T& dividend, const D& divisor)
+{
+  MP_UNITS_EXPECTS(divisor > get_zero(divisor));  // unit magnitude denominators are always positive
+  using quot_type = std::remove_const_t<decltype(dividend / divisor)>;
+  const quot_type quot = dividend / divisor;
+  if constexpr (Mode == rounding_mode::truncated)
+    return quot;
+  else {
+    const quot_type one = get_one(divisor);
+    const quot_type two = one + one;
+    // `%` lets the compiler share work with the division it has already emitted, which measures as
+    // a couple of instructions fewer on some compilers (GCC produces the same code either way).
+    // `%` is optional for a `RealScalar` though, so the subtraction stays as the general form: it
+    // needs only the arithmetic the concept mandates, which is what the emulated 128-bit integer
+    // and any other representation type without `%` rely on.
+    const auto rem = [&] {
+      if constexpr (requires { dividend % divisor; })
+        return dividend % divisor;
+      else
+        return dividend - quot * divisor;
+    }();
+    using rem_type = std::remove_const_t<decltype(rem)>;
+    const rem_type zero = get_zero(rem);
+    if constexpr (Mode == rounding_mode::rounded_down)
+      return rem < zero ? quot - one : quot;
+    else if constexpr (Mode == rounding_mode::rounded_up)
+      return rem > zero ? quot + one : quot;
+    else {  // rounding_mode::rounded (to nearest, ties to even)
+      const auto abs_rem = rem < zero ? rem_type{-rem} : rem;
+      // `abs_rem > divisor / 2` rephrased as `abs_rem > divisor - abs_rem` to stay exact for
+      // odd divisors, and with subtraction instead of `2 * abs_rem` to avoid overflow
+      const auto complement = divisor - abs_rem;
+      const bool is_odd = quot - (quot / two) * two != get_zero(quot);
+      if (abs_rem > complement || (abs_rem == complement && is_odd)) return rem < zero ? quot - one : quot + one;
+      return quot;
+    }
+  }
+}
+
+/**
+ * @brief Rounds a floating-point value to an integral value according to @c Mode
+ *
+ * Hand-rolled rather than delegating to `std::trunc`/`std::floor`/`std::ceil`, which lower to
+ * a single hardware instruction but are not usable in constant expressions before C++23 and are not
+ * guaranteed to exist at all in a freestanding build. `std::nearbyint` would not do for the
+ * round-half-to-even mode either: it honors the dynamic rounding mode, while the policy is specified
+ * as ties-to-even.
+ */
+template<rounding_mode Mode, std::floating_point T>
+[[nodiscard]] constexpr T round_fp(T value)
+{
+  // all values with a magnitude at or above this threshold are integral (their ULP is >= 1),
+  // and every value below it fits into `std::int64_t` (the threshold never exceeds 2^63)
+  constexpr T integral_threshold = int_power<T>(2, std::numeric_limits<T>::digits - 1);
+  if (!(value < integral_threshold && value > -integral_threshold)) return value;
+  const T trunc = static_cast<T>(static_cast<std::int64_t>(value));
+  if constexpr (Mode == rounding_mode::truncated)
+    return trunc;
+  else if constexpr (Mode == rounding_mode::rounded_down)
+    return trunc > value ? trunc - T{1} : trunc;
+  else if constexpr (Mode == rounding_mode::rounded_up)
+    return trunc < value ? trunc + T{1} : trunc;
+  else {  // rounding_mode::rounded (to nearest, ties to even)
+    const T floor = trunc > value ? trunc - T{1} : trunc;
+    const T frac = value - floor;
+    if (frac > T{0.5}) return floor + T{1};
+    if (frac < T{0.5}) return floor;
+    const bool is_odd = static_cast<T>(static_cast<std::int64_t>(floor / T{2})) * T{2} != floor;
+    return is_odd ? floor + T{1} : floor;
+  }
+}
 
 template<auto M, typename T>
 [[nodiscard]] constexpr auto scale_fp(const T& v)
@@ -96,7 +197,7 @@ constexpr decltype(auto) as_element(const T& value)
     return value;
 }
 
-template<auto M, typename T>
+template<auto M, rounding_mode Mode, typename T>
 [[nodiscard]] constexpr auto scale_int(const T& v)
 {
   using element_t = value_type_t<T>;
@@ -107,7 +208,7 @@ template<auto M, typename T>
     return v * mul;
   } else if constexpr (is_integral(pow<-1>(M))) {
     constexpr wider_t div = get_value<wider_t>(pow<-1>(M));
-    return v / div;
+    return div_round<Mode>(v, div);
   } else if constexpr (is_integral(M * (denominator(M) / numerator(M)))) {
     // M is a pure rational p/q (no irrational factors such as π).
     // Use wider_t for the numerator to prevent intermediate overflow in v * num.
@@ -116,7 +217,7 @@ template<auto M, typename T>
     // checked operator* template, cartesian_vector widens element-wise, etc.
     constexpr wider_t num = get_value<wider_t>(numerator(M));
     constexpr element_t den = get_value<element_t>(denominator(M));
-    return v * num / den;
+    return div_round<Mode>(v * num, den);
   } else {
     // M has irrational factors (e.g. π): use long double fixed-point approximation.
     // fixed_point::scale operates on plain integers, so extract the scalar element.
@@ -124,7 +225,55 @@ template<auto M, typename T>
                   "Scaling an integral-element wrapping type by an irrational magnitude factor "
                   "is not supported; use a floating-point element type instead");
     constexpr auto ratio = fixed_point<element_t>(get_value<long double>(M));
-    return ratio.scale(as_element(v));
+    return ratio.template scale<Mode>(as_element(v));
+  }
+}
+
+template<typename To, rounding_mode Mode, UnitMagnitude M, typename From>
+  requires UnitMagnitudeScalable<From>
+[[nodiscard]] constexpr auto scale_impl(M m, const From& value)
+{
+  if constexpr (requires { value * m; }) {
+    // Type provides magnitude-aware scaling via operator*(T, UnitMagnitude).
+    // The customization point has no way to communicate a rounding mode, so only the
+    // status-quo truncating semantics may reach it (guaranteed by the public API constraints).
+    static_assert(Mode == rounding_mode::truncated,
+                  "Rounding policies are not supported for representation types providing "
+                  "a custom operator*(T, UnitMagnitude) scaling");
+    return value * m;
+  } else if constexpr (UsesFloatingPointScaling<From> || UsesFloatingPointScaling<To>) {
+    // Floating-point path — handles both plain arithmetic types and wrappers.
+    // Uses the type's own operator* / operator/ (element-wise for wrappers).
+    // Convert to To first when:
+    //  - From is integral (e.g. int → double): scaling must happen in FP space; or
+    //  - the FP element type is not std::floating_point (e.g. a fixed-point wrapper
+    //    like cnl::scaled_integer used as a real number): the wrapper's own
+    //    operator* may produce a different, more-precise type whose conversion to
+    //    To could overflow the wrapper's narrow rep (e.g. scaled_integer<int,P<-25>>
+    //    times itself yields P<-50>, which cannot be downshifted to P<-15> within
+    //    a 32-bit int).  Converting to To first keeps all arithmetic in To's type.
+    const auto scaled = [&] {
+      if constexpr (treat_as_integral<value_type_t<From>> || !std::floating_point<value_type_t<From>>)
+        return scale_fp<M{}>(static_cast<To>(value));
+      else
+        return scale_fp<M{}>(value);
+    }();
+    // A floating-point destination represents the scaled value with at most half ULP error
+    // (`rounded` semantics, the only policy valid for it), so rounding applies only when the
+    // destination is integral and a mode other than the `silent_cast` truncation is requested.
+    if constexpr (Mode == rounding_mode::truncated || !treat_as_integral<value_type_t<To>>)
+      return silent_cast<To>(scaled);
+    else
+      return silent_cast<To>(round_fp<Mode>(scaled));
+  } else {
+    // Integer arithmetic path (UsesIntegerScaling) — handles plain arithmetic types,
+    // wrappers (safe_int), and containers (cartesian_vector<int>) alike.
+    // For integral/pure-divisor magnitudes, uses the type's own operator* / operator/
+    // (safe_int's overflow checks, cartesian_vector's element-wise operations).
+    // For rational magnitudes, widens the factor to prevent intermediate overflow;
+    // the wider factor propagates through the type's own operators.
+    // static_cast<To> triggers the wrapper's checked narrowing constructor when needed.
+    return static_cast<To>(scale_int<M{}, Mode>(value));
   }
 }
 
@@ -145,35 +294,18 @@ MP_UNITS_EXPORT template<typename To, UnitMagnitude M, typename From>
   requires detail::UnitMagnitudeScalable<From>
 [[nodiscard]] constexpr auto scale(M m, const From& value)
 {
-  if constexpr (requires { value * m; }) {
-    // Type provides magnitude-aware scaling via operator*(T, UnitMagnitude).
-    return value * m;
-  } else if constexpr (detail::UsesFloatingPointScaling<From> || detail::UsesFloatingPointScaling<To>) {
-    // Floating-point path — handles both plain arithmetic types and wrappers.
-    // Uses the type's own operator* / operator/ (element-wise for wrappers).
-    // Convert to To first when:
-    //  - From is integral (e.g. int → double): scaling must happen in FP space; or
-    //  - the FP element type is not std::floating_point (e.g. a fixed-point wrapper
-    //    like cnl::scaled_integer used as a real number): the wrapper's own
-    //    operator* may produce a different, more-precise type whose conversion to
-    //    To could overflow the wrapper's narrow rep (e.g. scaled_integer<int,P<-25>>
-    //    times itself yields P<-50>, which cannot be downshifted to P<-15> within
-    //    a 32-bit int).  Converting to To first keeps all arithmetic in To's type.
-    if constexpr (detail::treat_as_integral<detail::value_type_t<From>> ||
-                  !std::floating_point<detail::value_type_t<From>>)
-      return detail::silent_cast<To>(detail::scale_fp<M{}>(static_cast<To>(value)));
-    else
-      return detail::silent_cast<To>(detail::scale_fp<M{}>(value));
-  } else {
-    // Integer arithmetic path (UsesIntegerScaling) — handles plain arithmetic types,
-    // wrappers (safe_int), and containers (cartesian_vector<int>) alike.
-    // For integral/pure-divisor magnitudes, uses the type's own operator* / operator/
-    // (safe_int's overflow checks, cartesian_vector's element-wise operations).
-    // For rational magnitudes, widens the factor to prevent intermediate overflow;
-    // the wider factor propagates through the type's own operators.
-    // static_cast<To> triggers the wrapper's checked narrowing constructor when needed.
-    return static_cast<To>(detail::scale_int<M{}>(value));
-  }
+  return detail::scale_impl<To, detail::rounding_mode::truncated>(m, value);
+}
+
+/**
+ * @brief Scale @p value by the unit magnitude passed as @p m, converting to type @c To,
+ *        with the result rounded according to @p policy.
+ */
+MP_UNITS_EXPORT template<typename To, UnitMagnitude M, typename From, RoundingPolicy Policy>
+  requires detail::UnitMagnitudeScalable<From>
+[[nodiscard]] constexpr auto scale(M m, const From& value, Policy)
+{
+  return detail::scale_impl<To, detail::rounding_mode_of<Policy>>(m, value);
 }
 
 }  // namespace mp_units

--- a/src/core/include/mp-units/framework/scaling.h
+++ b/src/core/include/mp-units/framework/scaling.h
@@ -98,8 +98,9 @@ template<rounding_mode Mode, typename T, typename D>
   if constexpr (Mode == rounding_mode::truncated)
     return quot;
   else {
-    const quot_type one = get_one(divisor);
-    const quot_type two = one + one;
+    // named `step` rather than `one`, which would shadow the `mp_units::one` unit (MSVC C4459)
+    const quot_type step = get_one(divisor);
+    const quot_type two_steps = step + step;
     // `%` lets the compiler share work with the division it has already emitted, which measures as
     // a couple of instructions fewer on some compilers (GCC produces the same code either way).
     // `%` is optional for a `RealScalar` though, so the subtraction stays as the general form: it
@@ -112,18 +113,18 @@ template<rounding_mode Mode, typename T, typename D>
         return dividend - quot * divisor;
     }();
     using rem_type = std::remove_const_t<decltype(rem)>;
-    const rem_type zero = get_zero(rem);
+    const rem_type no_rem = get_zero(rem);
     if constexpr (Mode == rounding_mode::rounded_down)
-      return rem < zero ? quot - one : quot;
+      return rem < no_rem ? quot - step : quot;
     else if constexpr (Mode == rounding_mode::rounded_up)
-      return rem > zero ? quot + one : quot;
+      return rem > no_rem ? quot + step : quot;
     else {  // rounding_mode::rounded (to nearest, ties to even)
-      const auto abs_rem = rem < zero ? rem_type{-rem} : rem;
+      const auto abs_rem = rem < no_rem ? rem_type{-rem} : rem;
       // `abs_rem > divisor / 2` rephrased as `abs_rem > divisor - abs_rem` to stay exact for
       // odd divisors, and with subtraction instead of `2 * abs_rem` to avoid overflow
       const auto complement = divisor - abs_rem;
-      const bool is_odd = quot - (quot / two) * two != get_zero(quot);
-      if (abs_rem > complement || (abs_rem == complement && is_odd)) return rem < zero ? quot - one : quot + one;
+      const bool is_odd = quot - (quot / two_steps) * two_steps != get_zero(quot);
+      if (abs_rem > complement || (abs_rem == complement && is_odd)) return rem < no_rem ? quot - step : quot + step;
       return quot;
     }
   }
@@ -145,20 +146,22 @@ template<rounding_mode Mode, std::floating_point T>
   // and every value below it fits into `std::int64_t` (the threshold never exceeds 2^63)
   constexpr T integral_threshold = int_power<T>(2, std::numeric_limits<T>::digits - 1);
   if (!(value < integral_threshold && value > -integral_threshold)) return value;
-  const T trunc = static_cast<T>(static_cast<std::int64_t>(value));
+  // `whole` and `lower` rather than `trunc` and `floor`, which would shadow the `mp_units::floor`
+  // and `std::trunc`/`std::floor` function templates (MSVC C4459)
+  const T whole = static_cast<T>(static_cast<std::int64_t>(value));
   if constexpr (Mode == rounding_mode::truncated)
-    return trunc;
+    return whole;
   else if constexpr (Mode == rounding_mode::rounded_down)
-    return trunc > value ? trunc - T{1} : trunc;
+    return whole > value ? whole - T{1} : whole;
   else if constexpr (Mode == rounding_mode::rounded_up)
-    return trunc < value ? trunc + T{1} : trunc;
+    return whole < value ? whole + T{1} : whole;
   else {  // rounding_mode::rounded (to nearest, ties to even)
-    const T floor = trunc > value ? trunc - T{1} : trunc;
-    const T frac = value - floor;
-    if (frac > T{0.5}) return floor + T{1};
-    if (frac < T{0.5}) return floor;
-    const bool is_odd = static_cast<T>(static_cast<std::int64_t>(floor / T{2})) * T{2} != floor;
-    return is_odd ? floor + T{1} : floor;
+    const T lower = whole > value ? whole - T{1} : whole;
+    const T frac = value - lower;
+    if (frac > T{0.5}) return lower + T{1};
+    if (frac < T{0.5}) return lower;
+    const bool is_odd = static_cast<T>(static_cast<std::int64_t>(lower / T{2})) * T{2} != lower;
+    return is_odd ? lower + T{1} : lower;
   }
 }
 

--- a/src/core/include/mp-units/framework/value_cast.h
+++ b/src/core/include/mp-units/framework/value_cast.h
@@ -31,6 +31,7 @@
 #include <mp-units/framework/quantity_point_concepts.h>
 #include <mp-units/framework/reference.h>
 #include <mp-units/framework/representation_concepts.h>
+#include <mp-units/framework/rounding.h>
 #include <mp-units/framework/unit_concepts.h>
 
 namespace mp_units {
@@ -63,6 +64,61 @@ concept ExplicitlyCastable = UnitConvertibleTo<MP_UNITS_REMOVE_CONST(decltype(Fr
                              (!scaling_overflows_non_zero_values<Rep>(FromU, ToU) ||
                               unsatisfied<"The result of scaling '{}' to '{}' overflows the '{}' representation type">(
                                 FromU, ToU, type_name<Rep>()));
+
+// The `truncated` policy is the exact replacement for the pre-2.6.0 forcing conversions, so it keeps
+// supporting every representation type they did.
+//
+// Rounding is only ever performed on the way to an integral destination, so the two requirements below
+// apply exactly there: an adjusting policy has to decide which side of a rounding boundary the exact
+// result falls on, which needs a real scalar (a vector, a tensor, or a complex value offers no single
+// value to compare against a boundary), and rounding a floating-point value works on its integral
+// part, which the library performs for standard floating-point types only. A floating-point
+// destination instead represents every result to within half ULP on its own (the semantics of
+// `rounded`), so it rounds nothing and only rejects the directed policies as undeliverable.
+//
+// Each requirement is stated as a plain predicate naming the case that violates it, so that the
+// library can ask whether a policy applies without emitting a diagnostic: `unsatisfied` throws where
+// the implementation supports it, which would turn a query inside an `if constexpr` into a hard error
+// instead of `false`.
+
+// An adjusting policy is one that may move the result to a neighboring representable value, which is
+// every policy but `truncated`.
+template<typename T>
+concept AdjustingRoundingPolicy = RoundingPolicy<T> && !is_same_v<T, truncated_t>;
+
+template<typename Policy, typename FromRep, typename ToRep>
+constexpr bool rounding_lacks_real_scalars =
+  AdjustingRoundingPolicy<Policy> && treat_as_integral<ToRep> && (!RealScalar<FromRep> || !RealScalar<ToRep>);
+
+// a representation type treated as floating-point without being one of the standard floating-point
+// types (e.g. a fixed-point wrapper used as a real number) cannot have its integral part taken
+template<typename Policy, typename FromRep, typename ToRep>
+constexpr bool rounding_lacks_standard_floating_point =
+  AdjustingRoundingPolicy<Policy> && treat_as_integral<ToRep> && treat_as_floating_point<FromRep> &&
+  !std::floating_point<FromRep>;
+
+template<typename Policy, typename ToRep>
+constexpr bool rounding_direction_undeliverable =
+  treat_as_floating_point<ToRep> && (is_same_v<Policy, rounded_down_t> || is_same_v<Policy, rounded_up_t>);
+
+template<typename Policy, typename FromRep, typename ToRep>
+constexpr bool rounding_policy_applies =
+  RoundingPolicy<Policy> && !rounding_lacks_real_scalars<Policy, FromRep, ToRep> &&
+  !rounding_lacks_standard_floating_point<Policy, FromRep, ToRep> && !rounding_direction_undeliverable<Policy, ToRep>;
+
+template<typename Policy, typename FromRep, typename ToRep>
+concept ValidRoundingPolicyFor =
+  RoundingPolicy<Policy> &&
+  (!rounding_lacks_real_scalars<Policy, FromRep, ToRep> ||
+   unsatisfied<"Rounding policies other than 'truncated' need to compare against a rounding boundary, "
+               "which requires real scalar representation types (here: '{}' to '{}')">(type_name<FromRep>(),
+                                                                                       type_name<ToRep>())) &&
+  (!rounding_lacks_standard_floating_point<Policy, FromRep, ToRep> ||
+   unsatisfied<"Rounding a floating-point '{}' to an integral '{}' requires a standard floating-point "
+               "source type">(type_name<FromRep>(), type_name<ToRep>())) &&
+  (!rounding_direction_undeliverable<Policy, ToRep> ||
+   unsatisfied<"A floating-point representation type '{}' rounds every conversion result to nearest; "
+               "only the 'truncated' and 'rounded' policies are valid for it">(type_name<ToRep>()));
 
 }  // namespace detail
 
@@ -114,16 +170,19 @@ constexpr bool implicitly_scalable =
  * (e.g. non-truncating) conversion. In truncating cases an explicit cast have to be used.
  *
  * auto d = value_cast<si::second>(1234 * ms);
+ * auto e = value_cast<si::second>(1567 * ms, rounded);
  *
  * @tparam ToU a unit to use for a target quantity
+ * @param policy an optional rounding policy (`truncated` when not provided)
  */
-template<auto ToU, typename FwdQ, Quantity Q = std::remove_cvref_t<FwdQ>>
+template<auto ToU, typename FwdQ, RoundingPolicy Policy = truncated_t, Quantity Q = std::remove_cvref_t<FwdQ>>
   requires UnitOf<MP_UNITS_REMOVE_CONST(decltype(ToU)), Q::quantity_spec> &&
-           detail::ExplicitlyCastable<Q::unit, ToU, typename Q::rep>
-[[nodiscard]] constexpr Quantity auto value_cast(FwdQ&& q)
+           detail::ExplicitlyCastable<Q::unit, ToU, typename Q::rep> &&
+           detail::ValidRoundingPolicyFor<Policy, typename Q::rep, typename Q::rep>
+[[nodiscard]] constexpr Quantity auto value_cast(FwdQ&& q, Policy = Policy{})
 {
-  return detail::sudo_cast<quantity<detail::make_reference(Q::quantity_spec, ToU), typename Q::rep>>(
-    std::forward<FwdQ>(q));
+  return detail::sudo_cast<quantity<detail::make_reference(Q::quantity_spec, ToU), typename Q::rep>,
+                           detail::rounding_mode_of<Policy>>(std::forward<FwdQ>(q));
 }
 
 /**
@@ -133,14 +192,17 @@ template<auto ToU, typename FwdQ, Quantity Q = std::remove_cvref_t<FwdQ>>
  * (e.g. non-truncating) conversion. In truncating cases an explicit cast have to be used.
  *
  * auto q = value_cast<int>(1.23 * ms);
+ * auto r = value_cast<int>(1.55 * ms, rounded);
  *
  * @tparam ToRep a representation type to use for a target quantity
+ * @param policy an optional rounding policy (`truncated` when not provided)
  */
-template<typename ToRep, typename FwdQ, Quantity Q = std::remove_cvref_t<FwdQ>>
-  requires RepresentationOf<ToRep, Q::quantity_spec> && std::constructible_from<ToRep, typename Q::rep>
-[[nodiscard]] constexpr quantity<Q::reference, ToRep> value_cast(FwdQ&& q)
+template<typename ToRep, typename FwdQ, RoundingPolicy Policy = truncated_t, Quantity Q = std::remove_cvref_t<FwdQ>>
+  requires RepresentationOf<ToRep, Q::quantity_spec> && std::constructible_from<ToRep, typename Q::rep> &&
+           detail::ValidRoundingPolicyFor<Policy, typename Q::rep, ToRep>
+[[nodiscard]] constexpr quantity<Q::reference, ToRep> value_cast(FwdQ&& q, Policy = Policy{})
 {
-  return detail::sudo_cast<quantity<Q::reference, ToRep>>(std::forward<FwdQ>(q));
+  return detail::sudo_cast<quantity<Q::reference, ToRep>, detail::rounding_mode_of<Policy>>(std::forward<FwdQ>(q));
 }
 
 /**
@@ -153,23 +215,29 @@ template<typename ToRep, typename FwdQ, Quantity Q = std::remove_cvref_t<FwdQ>>
  *
  * @tparam ToU a unit to use for the target quantity
  * @tparam ToRep a representation type to use for the target quantity
+ * @param policy an optional rounding policy (`truncated` when not provided)
  */
-template<Unit auto ToU, typename ToRep, typename FwdQ, Quantity Q = std::remove_cvref_t<FwdQ>>
+template<Unit auto ToU, typename ToRep, typename FwdQ, RoundingPolicy Policy = truncated_t,
+         Quantity Q = std::remove_cvref_t<FwdQ>>
   requires UnitOf<MP_UNITS_REMOVE_CONST(decltype(ToU)), Q::quantity_spec> &&
            RepresentationOf<ToRep, Q::quantity_spec> && std::constructible_from<ToRep, typename Q::rep> &&
-           detail::ExplicitlyCastable<Q::unit, ToU, ToRep>
-[[nodiscard]] constexpr Quantity auto value_cast(FwdQ&& q)
+           detail::ExplicitlyCastable<Q::unit, ToU, ToRep> &&
+           detail::ValidRoundingPolicyFor<Policy, typename Q::rep, ToRep>
+[[nodiscard]] constexpr Quantity auto value_cast(FwdQ&& q, Policy = Policy{})
 {
-  return detail::sudo_cast<quantity<detail::make_reference(Q::quantity_spec, ToU), ToRep>>(std::forward<FwdQ>(q));
+  return detail::sudo_cast<quantity<detail::make_reference(Q::quantity_spec, ToU), ToRep>,
+                           detail::rounding_mode_of<Policy>>(std::forward<FwdQ>(q));
 }
 
-template<typename ToRep, Unit auto ToU, typename FwdQ, Quantity Q = std::remove_cvref_t<FwdQ>>
+template<typename ToRep, Unit auto ToU, typename FwdQ, RoundingPolicy Policy = truncated_t,
+         Quantity Q = std::remove_cvref_t<FwdQ>>
   requires UnitOf<MP_UNITS_REMOVE_CONST(decltype(ToU)), Q::quantity_spec> &&
            RepresentationOf<ToRep, Q::quantity_spec> && std::constructible_from<ToRep, typename Q::rep> &&
-           detail::ExplicitlyCastable<Q::unit, ToU, ToRep>
-[[nodiscard]] constexpr Quantity auto value_cast(FwdQ&& q)
+           detail::ExplicitlyCastable<Q::unit, ToU, ToRep> &&
+           detail::ValidRoundingPolicyFor<Policy, typename Q::rep, ToRep>
+[[nodiscard]] constexpr Quantity auto value_cast(FwdQ&& q, Policy policy = Policy{})
 {
-  return value_cast<ToU, ToRep>(std::forward<FwdQ>(q));
+  return value_cast<ToU, ToRep>(std::forward<FwdQ>(q), policy);
 }
 
 
@@ -186,14 +254,16 @@ template<typename ToRep, Unit auto ToU, typename FwdQ, Quantity Q = std::remove_
  * type), but not the "meaning" (quantity type).
  *
  * @tparam ToQ a target quantity type to which to cast the representation
+ * @param policy an optional rounding policy (`truncated` when not provided)
  */
-template<Quantity ToQ, typename FwdQ, Quantity Q = std::remove_cvref_t<FwdQ>>
+template<Quantity ToQ, typename FwdQ, RoundingPolicy Policy = truncated_t, Quantity Q = std::remove_cvref_t<FwdQ>>
   requires(ToQ::quantity_spec == Q::quantity_spec) && UnitOf<MP_UNITS_NONCONST_TYPE(ToQ::unit), Q::quantity_spec> &&
           std::constructible_from<typename ToQ::rep, typename Q::rep> &&
-          detail::ExplicitlyCastable<Q::unit, ToQ::unit, typename ToQ::rep>
-[[nodiscard]] constexpr Quantity auto value_cast(FwdQ&& q)
+          detail::ExplicitlyCastable<Q::unit, ToQ::unit, typename ToQ::rep> &&
+          detail::ValidRoundingPolicyFor<Policy, typename Q::rep, typename ToQ::rep>
+[[nodiscard]] constexpr Quantity auto value_cast(FwdQ&& q, Policy = Policy{})
 {
-  return detail::sudo_cast<ToQ>(std::forward<FwdQ>(q));
+  return detail::sudo_cast<ToQ, detail::rounding_mode_of<Policy>>(std::forward<FwdQ>(q));
 }
 
 /**
@@ -205,14 +275,18 @@ template<Quantity ToQ, typename FwdQ, Quantity Q = std::remove_cvref_t<FwdQ>>
  * auto qp = value_cast<si::second>(quantity_point{1234 * ms});
  *
  * @tparam ToU a unit to use for a target quantity point
+ * @param policy an optional rounding policy (`truncated` when not provided)
  */
-template<Unit auto ToU, typename FwdQP, QuantityPoint QP = std::remove_cvref_t<FwdQP>>
+template<Unit auto ToU, typename FwdQP, RoundingPolicy Policy = truncated_t,
+         QuantityPoint QP = std::remove_cvref_t<FwdQP>>
   requires UnitOf<MP_UNITS_REMOVE_CONST(decltype(ToU)), QP::quantity_spec> &&
-           detail::ExplicitlyCastable<QP::unit, ToU, typename QP::rep>
-[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp)
+           detail::ExplicitlyCastable<QP::unit, ToU, typename QP::rep> &&
+           detail::ValidRoundingPolicyFor<Policy, typename QP::rep, typename QP::rep>
+[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp, Policy policy = Policy{})
 {
-  return quantity_point{value_cast<ToU>(std::forward<FwdQP>(qp).quantity_from_origin_is_an_implementation_detail_),
-                        QP::point_origin};
+  return quantity_point{
+    value_cast<ToU>(std::forward<FwdQP>(qp).quantity_from_origin_is_an_implementation_detail_, policy),
+    QP::point_origin};
 }
 
 /**
@@ -224,12 +298,16 @@ template<Unit auto ToU, typename FwdQP, QuantityPoint QP = std::remove_cvref_t<F
  * auto qp = value_cast<int>(quantity_point{1.23 * ms});
  *
  * @tparam ToRep a representation type to use for a target quantity point
+ * @param policy an optional rounding policy (`truncated` when not provided)
  */
-template<typename ToRep, typename FwdQP, QuantityPoint QP = std::remove_cvref_t<FwdQP>>
-  requires RepresentationOf<ToRep, QP::quantity_spec> && std::constructible_from<ToRep, typename QP::rep>
-[[nodiscard]] constexpr quantity_point<QP::reference, QP::point_origin, ToRep> value_cast(FwdQP&& qp)
+template<typename ToRep, typename FwdQP, RoundingPolicy Policy = truncated_t,
+         QuantityPoint QP = std::remove_cvref_t<FwdQP>>
+  requires RepresentationOf<ToRep, QP::quantity_spec> && std::constructible_from<ToRep, typename QP::rep> &&
+           detail::ValidRoundingPolicyFor<Policy, typename QP::rep, ToRep>
+[[nodiscard]] constexpr quantity_point<QP::reference, QP::point_origin, ToRep> value_cast(FwdQP&& qp,
+                                                                                          Policy policy = Policy{})
 {
-  return {value_cast<ToRep>(std::forward<FwdQP>(qp).quantity_from_origin_is_an_implementation_detail_),
+  return {value_cast<ToRep>(std::forward<FwdQP>(qp).quantity_from_origin_is_an_implementation_detail_, policy),
           QP::point_origin};
 }
 
@@ -243,25 +321,30 @@ template<typename ToRep, typename FwdQP, QuantityPoint QP = std::remove_cvref_t<
  *
  * @tparam ToU a unit to use for the target quantity
  * @tparam ToRep a representation type to use for the target quantity
+ * @param policy an optional rounding policy (`truncated` when not provided)
  */
-template<Unit auto ToU, typename ToRep, typename FwdQP, QuantityPoint QP = std::remove_cvref_t<FwdQP>>
+template<Unit auto ToU, typename ToRep, typename FwdQP, RoundingPolicy Policy = truncated_t,
+         QuantityPoint QP = std::remove_cvref_t<FwdQP>>
   requires UnitOf<MP_UNITS_REMOVE_CONST(decltype(ToU)), QP::quantity_spec> &&
            RepresentationOf<ToRep, QP::quantity_spec> && std::constructible_from<ToRep, typename QP::rep> &&
-           detail::ExplicitlyCastable<QP::unit, ToU, ToRep>
-[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp)
+           detail::ExplicitlyCastable<QP::unit, ToU, ToRep> &&
+           detail::ValidRoundingPolicyFor<Policy, typename QP::rep, ToRep>
+[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp, Policy policy = Policy{})
 {
   return quantity_point{
-    value_cast<ToU, ToRep>(std::forward<FwdQP>(qp).quantity_from_origin_is_an_implementation_detail_),
+    value_cast<ToU, ToRep>(std::forward<FwdQP>(qp).quantity_from_origin_is_an_implementation_detail_, policy),
     QP::point_origin};
 }
 
-template<typename ToRep, Unit auto ToU, typename FwdQP, QuantityPoint QP = std::remove_cvref_t<FwdQP>>
+template<typename ToRep, Unit auto ToU, typename FwdQP, RoundingPolicy Policy = truncated_t,
+         QuantityPoint QP = std::remove_cvref_t<FwdQP>>
   requires UnitOf<MP_UNITS_REMOVE_CONST(decltype(ToU)), QP::quantity_spec> &&
            RepresentationOf<ToRep, QP::quantity_spec> && std::constructible_from<ToRep, typename QP::rep> &&
-           detail::ExplicitlyCastable<QP::unit, ToU, ToRep>
-[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp)
+           detail::ExplicitlyCastable<QP::unit, ToU, ToRep> &&
+           detail::ValidRoundingPolicyFor<Policy, typename QP::rep, ToRep>
+[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp, Policy policy = Policy{})
 {
-  return value_cast<ToU, ToRep>(std::forward<FwdQP>(qp));
+  return value_cast<ToU, ToRep>(std::forward<FwdQP>(qp), policy);
 }
 
 /**
@@ -279,15 +362,19 @@ template<typename ToRep, Unit auto ToU, typename FwdQP, QuantityPoint QP = std::
  * type), but not the "meaning" (quantity type or the actual point that is being described).
  *
  * @tparam ToQ a target quantity type to which to cast the representation of the point
+ * @param policy an optional rounding policy (`truncated` when not provided)
  */
-template<Quantity ToQ, typename FwdQP, QuantityPoint QP = std::remove_cvref_t<FwdQP>>
+template<Quantity ToQ, typename FwdQP, RoundingPolicy Policy = truncated_t,
+         QuantityPoint QP = std::remove_cvref_t<FwdQP>>
   requires(ToQ::quantity_spec == QP::quantity_spec) && UnitOf<MP_UNITS_NONCONST_TYPE(ToQ::unit), QP::quantity_spec> &&
           std::constructible_from<typename ToQ::rep, typename QP::rep> &&
-          detail::ExplicitlyCastable<QP::unit, ToQ::unit, typename ToQ::rep>
-[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp)
+          detail::ExplicitlyCastable<QP::unit, ToQ::unit, typename ToQ::rep> &&
+          detail::ValidRoundingPolicyFor<Policy, typename QP::rep, typename ToQ::rep>
+[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp, Policy policy = Policy{})
 {
-  return quantity_point{value_cast<ToQ>(std::forward<FwdQP>(qp).quantity_from_origin_is_an_implementation_detail_),
-                        QP::point_origin};
+  return quantity_point{
+    value_cast<ToQ>(std::forward<FwdQP>(qp).quantity_from_origin_is_an_implementation_detail_, policy),
+    QP::point_origin};
 }
 
 /**
@@ -317,15 +404,18 @@ template<Quantity ToQ, typename FwdQP, QuantityPoint QP = std::remove_cvref_t<Fw
  * plus the resolution of `qp` as represented in `ToQP`.
  *
  * @tparam ToQP a target quantity point type to which to cast the representation of the point
+ * @param policy an optional rounding policy (`truncated` when not provided)
  */
-template<QuantityPoint ToQP, typename FwdQP, QuantityPoint QP = std::remove_cvref_t<FwdQP>>
+template<QuantityPoint ToQP, typename FwdQP, RoundingPolicy Policy = truncated_t,
+         QuantityPoint QP = std::remove_cvref_t<FwdQP>>
   requires(ToQP::quantity_spec == QP::quantity_spec) && UnitOf<MP_UNITS_NONCONST_TYPE(ToQP::unit), QP::quantity_spec> &&
           (detail::same_absolute_point_origins(ToQP::point_origin, QP::point_origin)) &&
           std::constructible_from<typename ToQP::rep, typename QP::rep> &&
-          detail::ExplicitlyCastable<QP::unit, ToQP::unit, typename ToQP::rep>
-[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp)
+          detail::ExplicitlyCastable<QP::unit, ToQP::unit, typename ToQP::rep> &&
+          detail::ValidRoundingPolicyFor<Policy, typename QP::rep, typename ToQP::rep>
+[[nodiscard]] constexpr QuantityPoint auto value_cast(FwdQP&& qp, Policy = Policy{})
 {
-  return detail::sudo_cast<ToQP>(std::forward<FwdQP>(qp));
+  return detail::sudo_cast<ToQP, detail::rounding_mode_of<Policy>>(std::forward<FwdQP>(qp));
 }
 
 MP_UNITS_EXPORT_END

--- a/src/core/include/mp-units/math.h
+++ b/src/core/include/mp-units/math.h
@@ -27,6 +27,7 @@
 #include <mp-units/framework/customization_points.h>
 #include <mp-units/framework/quantity.h>
 #include <mp-units/framework/quantity_point.h>
+#include <mp-units/framework/rounding.h>
 #include <mp-units/framework/unit.h>
 #include <mp-units/framework/value_cast.h>
 
@@ -174,7 +175,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::exp;
 #endif
   return value_cast<get_unit(R)>(
-    quantity{static_cast<Rep>(exp(q.force_numerical_value_in(q.unit))), detail::clone_reference_with<one>(R)});
+    quantity{static_cast<Rep>(exp(q.numerical_value_in(q.unit))), detail::clone_reference_with<one>(R)});
 }
 
 /**
@@ -405,7 +406,7 @@ template<typename Rep, Reference R>
  */
 template<Unit auto To, auto R, typename Rep>
 [[nodiscard]] constexpr quantity<detail::clone_reference_with<To>(R), Rep> floor(const quantity<R, Rep>& q) noexcept
-  requires requires { q.force_in(To); } &&
+  requires requires { q.in(To, truncated); } &&
            ((treat_as_floating_point<Rep> && (requires(Rep v) { floor(v); }
 #if MP_UNITS_HOSTED
                                               || requires(Rep v) { std::floor(v); }
@@ -413,7 +414,7 @@ template<Unit auto To, auto R, typename Rep>
                                               )) ||
             (!treat_as_floating_point<Rep> && requires { representation_values<Rep>::one(); }))
 {
-  const quantity res = q.force_in(To);
+  const quantity res = q.in(To, truncated);
   if constexpr (treat_as_floating_point<Rep>) {
 #if MP_UNITS_HOSTED
     using std::floor;
@@ -435,7 +436,7 @@ template<Unit auto To, auto R, typename Rep>
 template<Unit auto To, auto R, auto PO, typename Rep>
 [[nodiscard]] constexpr QuantityPointOf<quantity_point<R, PO, Rep>::quantity_spec> auto floor(
   const quantity_point<R, PO, Rep>& qp) noexcept
-  requires requires { qp.force_in(To); } &&
+  requires requires { qp.in(To, truncated); } &&
            ((treat_as_floating_point<Rep> && (requires(Rep v) { floor(v); }
 #if MP_UNITS_HOSTED
                                               || requires(Rep v) { std::floor(v); }
@@ -443,7 +444,7 @@ template<Unit auto To, auto R, auto PO, typename Rep>
                                               )) ||
             (!treat_as_floating_point<Rep> && requires { representation_values<Rep>::one(); }))
 {
-  const quantity_point res = qp.force_in(To);
+  const quantity_point res = qp.in(To, truncated);
   if constexpr (treat_as_floating_point<Rep>) {
     using ReturnType = std::remove_reference_t<decltype(res)>;
 #if MP_UNITS_HOSTED
@@ -465,7 +466,7 @@ template<Unit auto To, auto R, auto PO, typename Rep>
  */
 template<Unit auto To, auto R, typename Rep>
 [[nodiscard]] constexpr quantity<detail::clone_reference_with<To>(R), Rep> ceil(const quantity<R, Rep>& q) noexcept
-  requires requires { q.force_in(To); } &&
+  requires requires { q.in(To, truncated); } &&
            ((treat_as_floating_point<Rep> && (requires(Rep v) { ceil(v); }
 #if MP_UNITS_HOSTED
                                               || requires(Rep v) { std::ceil(v); }
@@ -473,7 +474,7 @@ template<Unit auto To, auto R, typename Rep>
                                               )) ||
             (!treat_as_floating_point<Rep> && requires { representation_values<Rep>::one(); }))
 {
-  const quantity res = q.force_in(To);
+  const quantity res = q.in(To, truncated);
   if constexpr (treat_as_floating_point<Rep>) {
 #if MP_UNITS_HOSTED
     using std::ceil;
@@ -495,7 +496,7 @@ template<Unit auto To, auto R, typename Rep>
 template<Unit auto To, auto R, auto PO, typename Rep>
 [[nodiscard]] constexpr QuantityPointOf<quantity_point<R, PO, Rep>::quantity_spec> auto ceil(
   const quantity_point<R, PO,Rep>& qp) noexcept
-  requires requires { qp.force_in(To); } &&
+  requires requires { qp.in(To, truncated); } &&
            ((treat_as_floating_point<Rep> && (requires(Rep v) { ceil(v); }
 #if MP_UNITS_HOSTED
                                               || requires(Rep v) { std::ceil(v); }
@@ -503,7 +504,7 @@ template<Unit auto To, auto R, auto PO, typename Rep>
                                               )) ||
             (!treat_as_floating_point<Rep> && requires { representation_values<Rep>::one(); }))
 {
-  const quantity_point res = qp.force_in(To);
+  const quantity_point res = qp.in(To, truncated);
   if constexpr (treat_as_floating_point<Rep>) {
     using ReturnType = std::remove_reference_t<decltype(res)>;
 #if MP_UNITS_HOSTED
@@ -590,7 +591,7 @@ template<Unit auto To, auto R, typename Rep>
 {
   constexpr QuantitySpec auto spec = get_quantity_spec(To) * quantity<R, Rep>::quantity_spec;
   constexpr Unit auto unit = To * quantity<R, Rep>::unit;
-  return spec(representation_values<Rep>::one() * one).force_in(unit) / q;
+  return spec(representation_values<Rep>::one() * one).in(unit, truncated) / q;
 }
 
 /**

--- a/src/systems/include/mp-units/systems/angular/math.h
+++ b/src/systems/include/mp-units/systems/angular/math.h
@@ -30,6 +30,7 @@
 #ifndef MP_UNITS_IN_MODULE_INTERFACE
 #include <mp-units/framework/customization_points.h>
 #include <mp-units/framework/quantity.h>
+#include <mp-units/framework/rounding.h>
 #include <mp-units/framework/unit.h>
 #include <mp-units/framework/value_cast.h>
 #ifdef MP_UNITS_IMPORT_STD
@@ -50,7 +51,7 @@ template<ReferenceOf<angle> auto R, typename Rep>
   using std::sin;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(sin(q.force_numerical_value_in(radian)));
+    using rep = decltype(sin(q.numerical_value_in(radian, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{sin(value_cast<rep>(q).numerical_value_in(radian)), one};
   } else
@@ -64,7 +65,7 @@ template<ReferenceOf<angle> auto R, typename Rep>
   using std::cos;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(cos(q.force_numerical_value_in(radian)));
+    using rep = decltype(cos(q.numerical_value_in(radian, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{cos(value_cast<rep>(q).numerical_value_in(radian)), one};
   } else
@@ -78,7 +79,7 @@ template<ReferenceOf<angle> auto R, typename Rep>
   using std::tan;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(tan(q.force_numerical_value_in(radian)));
+    using rep = decltype(tan(q.numerical_value_in(radian, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{tan(value_cast<rep>(q).numerical_value_in(radian)), one};
   } else
@@ -92,7 +93,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::asin;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(asin(q.force_numerical_value_in(one)));
+    using rep = decltype(asin(q.numerical_value_in(one, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{asin(value_cast<rep>(q).numerical_value_in(one)), radian};
   } else
@@ -106,7 +107,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::acos;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(acos(q.force_numerical_value_in(one)));
+    using rep = decltype(acos(q.numerical_value_in(one, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{acos(value_cast<rep>(q).numerical_value_in(one)), radian};
   } else
@@ -120,7 +121,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::atan;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(atan(q.force_numerical_value_in(one)));
+    using rep = decltype(atan(q.numerical_value_in(one, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{atan(value_cast<rep>(q).numerical_value_in(one)), radian};
   } else
@@ -139,7 +140,7 @@ template<auto R1, typename Rep1, auto R2, typename Rep2>
   using std::atan2;
   if constexpr (!treat_as_floating_point<Rep1> || !treat_as_floating_point<Rep2>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(atan2(y.force_numerical_value_in(unit), x.force_numerical_value_in(unit)));
+    using rep = decltype(atan2(y.numerical_value_in(unit, truncated), x.numerical_value_in(unit, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{atan2(value_cast<rep>(y).numerical_value_in(unit), value_cast<rep>(x).numerical_value_in(unit)),
                     radian};

--- a/src/systems/include/mp-units/systems/si/math.h
+++ b/src/systems/include/mp-units/systems/si/math.h
@@ -31,6 +31,7 @@
 #ifndef MP_UNITS_IN_MODULE_INTERFACE
 #include <mp-units/framework/customization_points.h>
 #include <mp-units/framework/quantity.h>
+#include <mp-units/framework/rounding.h>
 #include <mp-units/framework/unit.h>
 #include <mp-units/framework/value_cast.h>
 #ifdef MP_UNITS_IMPORT_STD
@@ -50,7 +51,7 @@ template<ReferenceOf<isq::angular_measure> auto R, typename Rep>
   using std::sin;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(sin(q.force_numerical_value_in(radian)));
+    using rep = decltype(sin(q.numerical_value_in(radian, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{sin(value_cast<rep>(q).numerical_value_in(radian)), one};
   } else
@@ -64,7 +65,7 @@ template<ReferenceOf<isq::angular_measure> auto R, typename Rep>
   using std::cos;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(cos(q.force_numerical_value_in(radian)));
+    using rep = decltype(cos(q.numerical_value_in(radian, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{cos(value_cast<rep>(q).numerical_value_in(radian)), one};
   } else
@@ -78,7 +79,7 @@ template<ReferenceOf<isq::angular_measure> auto R, typename Rep>
   using std::tan;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(tan(q.force_numerical_value_in(radian)));
+    using rep = decltype(tan(q.numerical_value_in(radian, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{tan(value_cast<rep>(q).numerical_value_in(radian)), one};
   } else
@@ -92,7 +93,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::asin;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(asin(q.force_numerical_value_in(one)));
+    using rep = decltype(asin(q.numerical_value_in(one, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{asin(value_cast<rep>(q).numerical_value_in(one)), radian};
   } else
@@ -106,7 +107,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::acos;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(acos(q.force_numerical_value_in(one)));
+    using rep = decltype(acos(q.numerical_value_in(one, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{acos(value_cast<rep>(q).numerical_value_in(one)), radian};
   } else
@@ -120,7 +121,7 @@ template<ReferenceOf<dimensionless> auto R, typename Rep>
   using std::atan;
   if constexpr (!treat_as_floating_point<Rep>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(atan(q.force_numerical_value_in(one)));
+    using rep = decltype(atan(q.numerical_value_in(one, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{atan(value_cast<rep>(q).numerical_value_in(one)), radian};
   } else
@@ -140,7 +141,7 @@ template<auto R1, typename Rep1, auto R2, typename Rep2>
   using std::atan2;
   if constexpr (!treat_as_floating_point<Rep1> || !treat_as_floating_point<Rep2>) {
     // check what is the return type when called with the integral value
-    using rep = decltype(atan2(y.force_numerical_value_in(unit), x.force_numerical_value_in(unit)));
+    using rep = decltype(atan2(y.numerical_value_in(unit, truncated), x.numerical_value_in(unit, truncated)));
     // use this type ahead of calling the function to prevent narrowing if a unit conversion is needed
     return quantity{atan2(value_cast<rep>(y).numerical_value_in(unit), value_cast<rep>(x).numerical_value_in(unit)),
                     radian};

--- a/test/runtime/linear_algebra_test.cpp
+++ b/test/runtime/linear_algebra_test.cpp
@@ -309,6 +309,16 @@ TEST_CASE("linear algebra type as a quantity representation")
 namespace {
 using vec3i = utility::cartesian_vector<int>;
 [[nodiscard]] constexpr vec3i make_vec3i(int x, int y, int z) { return {x, y, z}; }
+
+// An adjusting policy has to decide which side of a rounding boundary the exact result falls on, and
+// a vector provides no single value to compare against one, so only `truncated` is available for it.
+template<typename Policy>
+concept vector_rounding_valid =
+  requires(quantity<isq::displacement[si::metre], vec3i> q, Policy p) { q.in(si::kilo<si::metre>, p); };
+static_assert(vector_rounding_valid<truncated_t>);
+static_assert(!vector_rounding_valid<rounded_t>);
+static_assert(!vector_rounding_valid<rounded_down_t>);
+static_assert(!vector_rounding_valid<rounded_up_t>);
 }  // namespace
 
 TEST_CASE("built-in cartesian_vector with an integral representation")
@@ -319,10 +329,10 @@ TEST_CASE("built-in cartesian_vector with an integral representation")
     CHECK(v.numerical_value_in(m) == vec3i{3000, 2000, 1000});
   }
 
-  SECTION("truncating unit conversion requires the forcing interface")
+  SECTION("truncating unit conversion requires a rounding policy")
   {
     const quantity v = make_vec3i(1500, 1500, 1500) * isq::displacement[m];
-    CHECK(v.force_numerical_value_in(km) == vec3i{1, 1, 1});
+    CHECK(v.numerical_value_in(km, truncated) == vec3i{1, 1, 1});
   }
 
   SECTION("integral multiplication and division by a scalar number")

--- a/test/runtime/safe_int_test.cpp
+++ b/test/runtime/safe_int_test.cpp
@@ -222,7 +222,7 @@ TEST_CASE("safe_int as quantity representation", "[safe_int][quantity]")
     quantity<isq::length[ft], safe_int<std::int16_t>> feet = safe_int<std::int16_t>{100} * ft;
 
     auto total = meters + feet;
-    REQUIRE(total.force_in(m).numerical_value_in(m) > 0);
+    REQUIRE(total.in(m, truncated).numerical_value_in(m) > 0);
   }
 
   SECTION("cross-unit overflow throws")
@@ -232,10 +232,10 @@ TEST_CASE("safe_int as quantity representation", "[safe_int][quantity]")
 
     // Adding meters + feet works (promoted to safe_int<int>)
     auto total = meters + feet;
-    REQUIRE(total.force_in(m).numerical_value_in(m) > 0);
+    REQUIRE(total.in(m, truncated).numerical_value_in(m) > 0);
 
     // But forcing back to int16_t overflows (30000 + ~3048 = ~33048 > 32767)
-    REQUIRE_THROWS_AS(total.force_in<safe_int<std::int16_t>>(m), std::overflow_error);
+    REQUIRE_THROWS_AS(total.in<safe_int<std::int16_t>>(m, truncated), std::overflow_error);
   }
 
   SECTION("multiplication overflow throws")

--- a/test/static/bounded_quantity_point_test.cpp
+++ b/test/static/bounded_quantity_point_test.cpp
@@ -978,6 +978,26 @@ static_assert(std::numeric_limits<qp_clamp>::max().quantity_from(clamp_origin) =
 // lowest() delegates to min() because .min exists in bounds.
 static_assert(std::numeric_limits<qp_clamp>::lowest().quantity_from(clamp_origin) == -90.0 * deg);
 
+// ---- Bounds declared in another unit or representation ---------------------
+
+// The bounds are declared as whole metres while the point counts kilometres in `double`. The bound
+// is reported as the point's own quantity type, so it comes out exactly rather than being truncated
+// to the whole kilometre below (which would report a range wider than the declared one).
+QUANTITY_SPEC(test_height_coarse, isq::height);
+inline constexpr struct coarse_bounds_origin final :
+    absolute_point_origin<test_height_coarse, clamp_to_range{1500 * m, 8500 * m}> {
+} coarse_bounds_origin;
+
+using qp_coarse = quantity_point<test_height_coarse[km], coarse_bounds_origin, double>;
+static_assert(qp_coarse::min().quantity_from(coarse_bounds_origin) == 1.5 * km);
+static_assert(qp_coarse::max().quantity_from(coarse_bounds_origin) == 8.5 * km);
+static_assert(std::numeric_limits<qp_coarse>::min().quantity_from(coarse_bounds_origin) == 1.5 * km);
+static_assert(std::numeric_limits<qp_coarse>::max().quantity_from(coarse_bounds_origin) == 8.5 * km);
+
+// the reported range is exactly the declared one, so it neither admits nor rejects too much
+static_assert(qp_coarse::min().quantity_from(coarse_bounds_origin) == 1500 * m);
+static_assert(qp_coarse::max().quantity_from(coarse_bounds_origin) == 8500 * m);
+
 // ---- Half-line min-only (halfbound_min_origin: value >= 0 m) ---------------
 
 using qp_hmin = quantity_point<test_halfbounded[m], halfbound_min_origin, double>;

--- a/test/static/fixed_point_test.cpp
+++ b/test/static/fixed_point_test.cpp
@@ -66,6 +66,24 @@ static_assert(scale<int>(mag<1>, 42) == 42);
 static_assert(scale<double>(mag_ratio<1, 2>, 1.0) == 0.5);
 static_assert(scale<float>(mag<3>, 1.0f) == 3.0f);
 
+// rounding policies on the integral-inverse (pure divisor) path
+static_assert(scale<int>(mag_ratio<1, 1000>, 1567, rounded) == 2);
+static_assert(scale<int>(mag_ratio<1, 1000>, 1500, rounded) == 2);  // tie rounds to even
+static_assert(scale<int>(mag_ratio<1, 1000>, 2500, rounded) == 2);  // tie rounds to even
+static_assert(scale<int>(mag_ratio<1, 1000>, -1234, truncated) == -1);
+static_assert(scale<int>(mag_ratio<1, 1000>, -1234, rounded_down) == -2);
+static_assert(scale<int>(mag_ratio<1, 1000>, -1234, rounded_up) == -1);
+static_assert(scale<int>(mag_ratio<1, 1000>, 1234, rounded_up) == 2);
+
+// rounding policies on the rational path (widened integer arithmetic)
+static_assert(scale<int>(mag_ratio<3, 2>, 3, truncated) == 4);    // 4.5
+static_assert(scale<int>(mag_ratio<3, 2>, 3, rounded) == 4);      // tie rounds to even
+static_assert(scale<int>(mag_ratio<3, 2>, 5, rounded) == 8);      // 7.5, tie rounds to even
+static_assert(scale<int>(mag_ratio<3, 2>, 3, rounded_up) == 5);   // 4.5
+static_assert(scale<int>(mag_ratio<3, 2>, -3, truncated) == -4);  // -4.5
+static_assert(scale<int>(mag_ratio<3, 2>, -3, rounded_down) == -5);
+static_assert(scale<int>(mag_ratio<3, 2>, -3, rounded) == -4);  // tie rounds to even
+
 // UnitMagnitudeScalable concept
 static_assert(detail::UnitMagnitudeScalable<int>);
 static_assert(detail::UnitMagnitudeScalable<long>);
@@ -82,6 +100,40 @@ static_assert(value_cast<angular::radian>(180 * angular::degree).numerical_value
 // Negative: implicit conversion is blocked at compile time to prevent accidental precision loss.
 static_assert(!std::is_convertible_v<quantity<angular::radian, int>, quantity<angular::degree, int>>);
 static_assert(!std::is_convertible_v<quantity<angular::degree, int>, quantity<angular::radian, int>>);
+
+// Rounding policies on the irrational-factor path (deg = (π/180) rad, fixed-point multiply
+// followed by a right shift). The shift floors, so every policy but `rounded_down` has to
+// adjust the quotient, which makes this the most delicate of the three scaling paths.
+static_assert((50 * angular::degree).in(angular::radian, truncated).numerical_value_in(angular::radian) == 0);
+static_assert((50 * angular::degree).in(angular::radian, rounded).numerical_value_in(angular::radian) == 1);
+static_assert((50 * angular::degree).in(angular::radian, rounded_down).numerical_value_in(angular::radian) == 0);
+static_assert((50 * angular::degree).in(angular::radian, rounded_up).numerical_value_in(angular::radian) == 1);
+
+// 120 deg is 2.0944 rad: only `rounded_up` crosses to the next integer
+static_assert((120 * angular::degree).in(angular::radian, truncated).numerical_value_in(angular::radian) == 2);
+static_assert((120 * angular::degree).in(angular::radian, rounded).numerical_value_in(angular::radian) == 2);
+static_assert((120 * angular::degree).in(angular::radian, rounded_down).numerical_value_in(angular::radian) == 2);
+static_assert((120 * angular::degree).in(angular::radian, rounded_up).numerical_value_in(angular::radian) == 3);
+
+// negative values: `truncated` rounds towards zero, `rounded_down` towards negative infinity
+static_assert((-120 * angular::degree).in(angular::radian, truncated).numerical_value_in(angular::radian) == -2);
+static_assert((-120 * angular::degree).in(angular::radian, rounded).numerical_value_in(angular::radian) == -2);
+static_assert((-120 * angular::degree).in(angular::radian, rounded_down).numerical_value_in(angular::radian) == -3);
+static_assert((-120 * angular::degree).in(angular::radian, rounded_up).numerical_value_in(angular::radian) == -2);
+
+// -30 deg is -0.5236 rad, so the nearest integer is -1 while truncation yields 0
+static_assert((-30 * angular::degree).in(angular::radian, truncated).numerical_value_in(angular::radian) == 0);
+static_assert((-30 * angular::degree).in(angular::radian, rounded).numerical_value_in(angular::radian) == -1);
+static_assert((-30 * angular::degree).in(angular::radian, rounded_down).numerical_value_in(angular::radian) == -1);
+static_assert((-30 * angular::degree).in(angular::radian, rounded_up).numerical_value_in(angular::radian) == 0);
+
+// the reverse direction (rad -> deg, factor 180/π): 100 rad is 5729.578 deg
+static_assert((100 * angular::radian).in(angular::degree, truncated).numerical_value_in(angular::degree) == 5729);
+static_assert((100 * angular::radian).in(angular::degree, rounded).numerical_value_in(angular::degree) == 5730);
+static_assert((-100 * angular::radian).in(angular::degree, truncated).numerical_value_in(angular::degree) == -5729);
+static_assert((-100 * angular::radian).in(angular::degree, rounded).numerical_value_in(angular::degree) == -5730);
+static_assert((-100 * angular::radian).in(angular::degree, rounded_down).numerical_value_in(angular::degree) == -5730);
+static_assert((-100 * angular::radian).in(angular::degree, rounded_up).numerical_value_in(angular::degree) == -5729);
 
 // Large-value safety: deg -> grad uses factor 10/9.  Being a pure rational, the
 // computation uses exact 128-bit integer arithmetic — correct on all platforms,

--- a/test/static/quantity_point_test.cpp
+++ b/test/static/quantity_point_test.cpp
@@ -843,8 +843,12 @@ static_assert(point<deg_C>(20.).numerical_value_in(deg_F) == 68.);
 static_assert(point<deg_C>(20.).numerical_value_in(K) == 293.15);
 static_assert(point<K>(300.).numerical_value_in(K) == 300.);
 static_assert(point<K>(300.).numerical_value_in(deg_C) == 26.85);
-// force_numerical_value_in(U) - value-truncating variant (integer rep, non-exact scaling)
-static_assert(point<m>(2500).force_numerical_value_in(km) == 2);
+// numerical_value_in(U, policy) - value-truncating variants (integer rep, non-exact scaling)
+static_assert(point<m>(2500).numerical_value_in(km, truncated) == 2);
+static_assert(point<m>(2500).numerical_value_in(km, rounded) == 2);  // tie rounds to even
+static_assert(point<m>(2501).numerical_value_in(km, rounded) == 3);
+static_assert(point<m>(2500).numerical_value_in(km, rounded_up) == 3);
+static_assert(point<m>(2999).numerical_value_in(km, rounded_down) == 2);
 // numerical_value_in round-trips construction
 static_assert(point<deg_C>(point<deg_C>(20.5).numerical_value_in(deg_C)) == point<deg_C>(20.5));
 
@@ -908,9 +912,31 @@ static_assert(is_of_type<(mean_sea_level + 2 * km).in(m), quantity_point<m, mean
 static_assert(is_of_type<(mean_sea_level + 2 * km).in<double>(), quantity_point<km, mean_sea_level>>);
 static_assert(is_of_type<(mean_sea_level + 2 * km).in<double>(m), quantity_point<m, mean_sea_level>>);
 
+static_assert(is_of_type<(mean_sea_level + 2500. * m).in(km, truncated), quantity_point<km, mean_sea_level>>);
+static_assert(is_of_type<(mean_sea_level + 2500. * m).in<int>(truncated), quantity_point<m, mean_sea_level, int>>);
+static_assert(is_of_type<(mean_sea_level + 2500. * m).in<int>(km, truncated), quantity_point<km, mean_sea_level, int>>);
+
+// rounding policies for quantity points
+static_assert((mean_sea_level + 2500 * m).in(km, truncated).quantity_from(mean_sea_level).numerical_value_in(km) == 2);
+static_assert((mean_sea_level + 2501 * m).in(km, rounded).quantity_from(mean_sea_level).numerical_value_in(km) == 3);
+static_assert((mean_sea_level + 2500 * m).in(km, rounded_up).quantity_from(mean_sea_level).numerical_value_in(km) == 3);
+static_assert((mean_sea_level - 2500 * m).in(km, truncated).quantity_from(mean_sea_level).numerical_value_in(km) == -2);
+static_assert((mean_sea_level - 2500 * m).in(km, rounded_down).quantity_from(mean_sea_level).numerical_value_in(km) ==
+              -3);
+
+// Cross-origin conversions apply the policy to the origin offset as well. A 20 degC point is
+// 293.15 K, so the policy decides between 293 K and 294 K for an integral representation.
+static_assert(point<deg_C>(20).in(K, truncated).numerical_value_in(K) == 293);
+static_assert(point<deg_C>(20).in(K, rounded).numerical_value_in(K) == 293);
+static_assert(point<deg_C>(20).in(K, rounded_down).numerical_value_in(K) == 293);
+static_assert(point<deg_C>(20).in(K, rounded_up).numerical_value_in(K) == 294);
+
+// deprecated forcing conversions remain available for the transition period
+MP_UNITS_DIAGNOSTIC_PUSH
+MP_UNITS_DIAGNOSTIC_IGNORE_DEPRECATED
 static_assert(is_of_type<(mean_sea_level + 2500. * m).force_in(km), quantity_point<km, mean_sea_level>>);
-static_assert(is_of_type<(mean_sea_level + 2500. * m).force_in<int>(), quantity_point<m, mean_sea_level, int>>);
-static_assert(is_of_type<(mean_sea_level + 2500. * m).force_in<int>(km), quantity_point<km, mean_sea_level, int>>);
+static_assert(point<m>(2500).force_numerical_value_in(km) == 2);
+MP_UNITS_DIAGNOSTIC_POP
 
 // in(unit) for offset units at default origin: switches to unit._point_origin_
 static_assert(is_of_type<point<deg_C>(20.).in(deg_F), quantity_point<deg_F, usc::fahrenheit_zero>>);
@@ -937,7 +963,7 @@ static_assert(invalid_unit_conversion<quantity_point>);
 template<auto Origin>
 concept invalid_numerical_value_extraction = requires {
   requires !requires { (Origin + 2 * m).numerical_value_in(m); };
-  requires !requires { (Origin + 2 * m).force_numerical_value_in(m); };
+  requires !requires { (Origin + 2 * m).numerical_value_in(m, truncated); };
   // the explicit-origin path remains available
   requires requires { (Origin + 2 * m).quantity_from(Origin).numerical_value_in(m); };
 };

--- a/test/static/quantity_test.cpp
+++ b/test/static/quantity_test.cpp
@@ -542,16 +542,80 @@ static_assert(quantity<isq::length[m]>(2000. * m).in(km).numerical_value_in(km) 
 static_assert(quantity<isq::length[km], int>(2 * km).in(km).numerical_value_in(km) == 2);
 static_assert(quantity<isq::length[km], int>(2 * km).in(m).numerical_value_in(m) == 2000);
 
-static_assert(is_of_type<(2. * km).force_in(m), quantity<si::metre>>);
-static_assert(is_of_type<isq::length(2. * km).force_in(m), quantity<isq::length[m]>>);
-static_assert(is_of_type<isq::height(2. * km).force_in(m), quantity<isq::height[m]>>);
+static_assert(is_of_type<(2. * km).in(m, truncated), quantity<si::metre>>);
+static_assert(is_of_type<isq::length(2. * km).in(m, truncated), quantity<isq::length[m]>>);
+static_assert(is_of_type<isq::height(2. * km).in(m, truncated), quantity<isq::height[m]>>);
 
-static_assert(quantity<isq::length[km]>(2. * km).force_in(km).numerical_value_in(km) == 2.);
-static_assert(quantity<isq::length[km]>(2. * km).force_in(m).numerical_value_in(m) == 2000.);
-static_assert(quantity<isq::length[m]>(2000. * m).force_in(km).numerical_value_in(km) == 2.);
-static_assert(quantity<isq::length[km], int>(2 * km).force_in(km).numerical_value_in(km) == 2);
-static_assert(quantity<isq::length[km], int>(2 * km).force_in(m).numerical_value_in(m) == 2000);
-static_assert(quantity<isq::length[m], int>(2000 * m).force_in(km).numerical_value_in(km) == 2);
+static_assert(quantity<isq::length[km]>(2. * km).in(km, truncated).numerical_value_in(km) == 2.);
+static_assert(quantity<isq::length[km]>(2. * km).in(m, truncated).numerical_value_in(m) == 2000.);
+static_assert(quantity<isq::length[m]>(2000. * m).in(km, truncated).numerical_value_in(km) == 2.);
+static_assert(quantity<isq::length[km], int>(2 * km).in(km, truncated).numerical_value_in(km) == 2);
+static_assert(quantity<isq::length[km], int>(2 * km).in(m, truncated).numerical_value_in(m) == 2000);
+static_assert(quantity<isq::length[m], int>(2000 * m).in(km, truncated).numerical_value_in(km) == 2);
+
+// rounding policies for truncating unit conversions (integral representation, rational factor)
+static_assert((1234 * m).in(km, truncated).numerical_value_in(km) == 1);
+static_assert((1234 * m).in(km, rounded).numerical_value_in(km) == 1);
+static_assert((1567 * m).in(km, rounded).numerical_value_in(km) == 2);
+static_assert((1500 * m).in(km, rounded).numerical_value_in(km) == 2);  // tie rounds to even
+static_assert((2500 * m).in(km, rounded).numerical_value_in(km) == 2);  // tie rounds to even
+static_assert((3500 * m).in(km, rounded).numerical_value_in(km) == 4);  // tie rounds to even
+static_assert((1234 * m).in(km, rounded_down).numerical_value_in(km) == 1);
+static_assert((1234 * m).in(km, rounded_up).numerical_value_in(km) == 2);
+static_assert((1000 * m).in(km, rounded_up).numerical_value_in(km) == 1);  // exact conversion needs no adjustment
+
+// negative values: `truncated` rounds towards zero, `rounded_down` towards negative infinity
+static_assert((-1234 * m).in(km, truncated).numerical_value_in(km) == -1);
+static_assert((-1234 * m).in(km, rounded_down).numerical_value_in(km) == -2);
+static_assert((-1234 * m).in(km, rounded_up).numerical_value_in(km) == -1);
+static_assert((-1500 * m).in(km, rounded).numerical_value_in(km) == -2);  // tie rounds to even
+static_assert((-1567 * m).in(km, rounded).numerical_value_in(km) == -2);
+
+// rounding policies for representation type conversions
+static_assert((1.5 * s).in<int>(rounded).numerical_value_in(s) == 2);
+static_assert((2.5 * s).in<int>(rounded).numerical_value_in(s) == 2);  // tie rounds to even
+static_assert((1.9 * s).in<int>(truncated).numerical_value_in(s) == 1);
+static_assert((-1.9 * s).in<int>(truncated).numerical_value_in(s) == -1);
+static_assert((-1.1 * s).in<int>(rounded_down).numerical_value_in(s) == -2);
+static_assert((1.1 * s).in<int>(rounded_up).numerical_value_in(s) == 2);
+
+// rounding policies for unit and representation type conversions in one step
+static_assert((1.23 * s).in<int>(ms, rounded).numerical_value_in(ms) == 1230);
+
+// a floating-point destination accepts `truncated` (static_cast semantics) and `rounded`
+static_assert((1.5 * km).in(m, truncated).numerical_value_in(m) == 1500.);
+static_assert((1.5 * km).in(m, rounded).numerical_value_in(m) == 1500.);
+
+// Values at or above 2^52 are already integral, so rounding must return them untouched
+// rather than round-trip them through a narrower integer type.
+static_assert((1.e19 * mm).in<std::int64_t>(m, rounded).numerical_value_in(m) == 10'000'000'000'000'000LL);
+static_assert((-1.e19 * mm).in<std::int64_t>(m, rounded).numerical_value_in(m) == -10'000'000'000'000'000LL);
+
+// numerical value accessor with a rounding policy
+static_assert((1567 * m).numerical_value_in(km, truncated) == 1);
+static_assert((1567 * m).numerical_value_in(km, rounded) == 2);
+
+template<template<auto, typename> typename Q>
+concept invalid_rounding_policy = requires {
+  // a floating-point destination cannot deliver the directed rounding modes
+  requires !requires { Q<isq::length[km], double>(2. * km).in(m, rounded_down); };
+  requires !requires { Q<isq::length[km], double>(2. * km).in(m, rounded_up); };
+  requires !requires { Q<isq::length[m], double>(2. * m).template in<float>(rounded_down); };
+};
+static_assert(invalid_rounding_policy<quantity>);
+
+#if MP_UNITS_HOSTED
+// A complex representation has no single value to compare against a rounding boundary, so an
+// adjusting policy is unavailable where rounding would actually happen (an integral destination).
+// Its floating-point conversions round nothing, so `rounded` remains accepted for those.
+template<typename Policy>
+concept phasor_conversion_valid =
+  requires(quantity<isq::voltage_phasor[V], std::complex<double>> q, Policy p) { q.in(mV, p); };
+static_assert(phasor_conversion_valid<truncated_t>);
+static_assert(phasor_conversion_valid<rounded_t>);
+static_assert(!phasor_conversion_valid<rounded_down_t>);
+static_assert(!phasor_conversion_valid<rounded_up_t>);
+#endif
 
 static_assert((15. * m).in(nm).numerical_value_in(m) == 15.);
 static_assert((15'000. * nm).in(m).numerical_value_in(nm) == 15'000.);
@@ -579,9 +643,9 @@ concept invalid_unit_conversion = requires {
   requires !requires { Q<isq::length[m], int>(2 * m).in(s); };         // unit of a different quantity & dimension
   requires !requires { Q<isq::frequency[Hz], int>(60 * Hz).in(Bq); };  // unit of a different kind (same dimension)
 
-  requires !requires { Q<isq::length[m], int>(2 * m).force_in(s); };  // unit of a different quantity & dimension
+  requires !requires { Q<isq::length[m], int>(2 * m).in(s, truncated); };  // unit of a different quantity & dimension
   requires !requires {
-    Q<isq::frequency[Hz], int>(60 * Hz).force_in(Bq);
+    Q<isq::frequency[Hz], int>(60 * Hz).in(Bq, truncated);
   };  // unit of a different kind (same dimension)
 };
 static_assert(invalid_unit_conversion<quantity>);
@@ -1630,12 +1694,30 @@ static_assert(value_cast<int>(1.23 * m).numerical_value_in(m) == 1);
 static_assert(value_cast<km, int>(1.23 * m).numerical_value_in(km) == 0);
 static_assert(value_cast<int, km>(1.23 * m).numerical_value_in(km) == 0);
 
+// value_cast with a rounding policy
+static_assert(value_cast<km>(1567 * m, rounded).numerical_value_in(km) == 2);
+static_assert(value_cast<km>(1567 * m, truncated).numerical_value_in(km) == 1);
+static_assert(value_cast<int>(1.5 * m, rounded).numerical_value_in(m) == 2);
+static_assert(value_cast<km, int>(1567. * m, rounded).numerical_value_in(km) == 2);
+static_assert(value_cast<int, km>(1567. * m, rounded_up).numerical_value_in(km) == 2);
+static_assert(value_cast<quantity<km, int>>(1567 * m, rounded).numerical_value_in(km) == 2);
+
+static_assert((2 * km).in(m, truncated).numerical_value_in(m) == 2000);
+static_assert((2000 * m).in(km, truncated).numerical_value_in(km) == 2);
+static_assert((2000.0 * m / (3600.0 * s)).in(km / h, truncated).numerical_value_in(km / h) == 2);
+
+static_assert((1.23 * m).in<int>(truncated).numerical_value_in(m) == 1);
+static_assert((1.23 * m).in<int>(km, truncated).numerical_value_in(km) == 0);
+
+// deprecated forcing conversions remain available for the transition period
+MP_UNITS_DIAGNOSTIC_PUSH
+MP_UNITS_DIAGNOSTIC_IGNORE_DEPRECATED
 static_assert((2 * km).force_in(m).numerical_value_in(m) == 2000);
 static_assert((2000 * m).force_in(km).numerical_value_in(km) == 2);
-static_assert((2000.0 * m / (3600.0 * s)).force_in(km / h).numerical_value_in(km / h) == 2);
-
 static_assert((1.23 * m).force_in<int>().numerical_value_in(m) == 1);
 static_assert((1.23 * m).force_in<int>(km).numerical_value_in(km) == 0);
+static_assert((1567 * m).force_numerical_value_in(km) == 1);
+MP_UNITS_DIAGNOSTIC_POP
 
 //////////////////
 // quantity_cast
@@ -1702,7 +1784,7 @@ concept overflowing_unit_conversion = requires {
   requires !requires { quantity<si::metre, std::int8_t>(Q); };
   requires !requires { quantity<si::milli<si::metre>, std::int16_t>(Q); };
   requires !requires { Q.in(si::metre); };
-  requires !requires { Q.force_in(si::metre); };
+  requires !requires { Q.in(si::metre, truncated); };
   requires !requires { Q + std::int8_t(1) * nm; };  // promotion to int
   requires !requires { Q - std::int8_t(1) * nm; };  // promotion to int
   requires !requires { Q % std::int8_t(1) * m; };

--- a/test/static/safe_int_test.cpp
+++ b/test/static/safe_int_test.cpp
@@ -1125,4 +1125,23 @@ static_assert(std::is_convertible_v<quantity<isq::length[si::metre], safe_int<in
 static_assert(!std::is_convertible_v<quantity<isq::length[si::milli<si::metre>], safe_int<int>>,
                                      quantity<isq::length[si::metre], safe_int<int>>>);
 
+// `safe_int` is a drop-in replacement for its underlying integral type, so every rounding policy
+// works with it: 1567 mm is 1.567 m, resolved exactly as it would be for `int`.
+inline constexpr quantity<isq::length[si::milli<si::metre>], safe_int<int>> mm_1567{safe_int<int>{1567} *
+                                                                                    si::milli<si::metre>};
+static_assert(mm_1567.in(si::metre, truncated).numerical_value_in(si::metre) == safe_int<int>{1});
+static_assert(mm_1567.in(si::metre, rounded).numerical_value_in(si::metre) == safe_int<int>{2});
+static_assert(mm_1567.in(si::metre, rounded_down).numerical_value_in(si::metre) == safe_int<int>{1});
+static_assert(mm_1567.in(si::metre, rounded_up).numerical_value_in(si::metre) == safe_int<int>{2});
+static_assert((-mm_1567).in(si::metre, truncated).numerical_value_in(si::metre) == safe_int<int>{-1});
+static_assert((-mm_1567).in(si::metre, rounded_down).numerical_value_in(si::metre) == safe_int<int>{-2});
+
+// Rounding a floating-point value to an integral one works on the value's integral part, which the
+// engine can only do for a standard floating-point source.
+template<typename Policy>
+concept lossy_fp_conversion_valid =
+  requires(quantity<isq::length[si::metre], constrained<double>> q, Policy p) { q.template in<int>(p); };
+static_assert(lossy_fp_conversion_valid<truncated_t>);
+static_assert(!lossy_fp_conversion_valid<rounded_t>);
+
 }  // namespace


### PR DESCRIPTION
Resolves #534.

`force_in()` names an attitude rather than a result, does not compose with the rest of the
conversion API, and leaves the caller no way to say *which* representable value they want. A
truncating conversion now takes a rounding policy as its last argument instead:

```cpp
quantity q1 = (1234 * m).in(km, truncated);       // 1 km, towards zero
quantity q2 = (1567 * m).in(km, rounded);         // 2 km, nearest, ties to even
quantity q3 = (-1234 * m).in(km, rounded_down);   // -2 km, towards -infinity
quantity q4 = (1.23 * s).in<int>(ms, rounded_up); // 1231 ms
```

## Why an argument rather than another name

The 2023 discussion in #534 kept stalling on the same thing: whichever prefix wins
(`force_`, `coerce_`, `cast_`) has to compose with a whole family, and no prefix reads well
across all of it, which is exactly what `cast_numerical_value_to` versus
`numerical_value_cast_to` showed. A tag argument sidesteps that: one policy slot serves
`in()`, `numerical_value_in()`, `value_cast()`, and `scale()` alike, on both `quantity` and
`quantity_point`, so the member API collapses from six spellings to three. It also says
something the names never could, namely *which* neighbour you get.

[Au](https://aurora-opensource.github.io/au/main/tutorial/103-unit-conversions/#forcing-lossy-conversions-the-policy-argument)
reached the same mechanism independently and is deprecating `coerce_as`/`coerce_in` in 0.6.0
in favour of `q.as(u, ignore(TRUNCATION_RISK))`. The vocabularies differ for a reason: Au's
compile-time overflow heuristic produces false positives by design, so it needs to name the
risk being waived, while this library's check fires only on guaranteed overflow and needs no
opt-out. Here the policy names the consequence the caller accepts.

The tags map onto the `std::chrono` conversion functions, so the choice is the one a reader
already knows:

| Policy         | Rounds towards                    | `std::chrono` counterpart |
|----------------|-----------------------------------|---------------------------|
| `truncated`    | zero                              | `duration_cast`           |
| `rounded`      | nearest, to even in halfway cases | `round`                   |
| `rounded_down` | negative infinity                 | `floor`                   |
| `rounded_up`   | positive infinity                 | `ceil`                    |

`mp_units::floor/ceil/round<U>()` keep their own, different meaning and are untouched: they
round to an integral multiple of a unit even when the representation holds the exact value,
whereas a policy never adjusts a value the destination represents exactly. The two coincide
for integral representations.

## Deprecation

`force_in()` and `force_numerical_value_in()` are deprecated on both `quantity` and
`quantity_point` and delegate to the new functions. `x.in(u, truncated)` is their exact
replacement, so the migration is mechanical.

## Behaviour changes

- A truncating conversion by an irrational factor (e.g. `rad` to `deg`) used to round
  negative values towards negative infinity. It now rounds towards zero under `truncated`,
  consistent with the rational factors.
- `quantity_point::min()`/`max()` no longer convert a range bound through the bound's own
  representation type, which could report a range wider than the declared one (a `min` of
  `1500 m` became `1 km`). The bound is now reported as the point's quantity type, which the
  framework only permits when nothing is lost, so bounds come out exactly.

## Implementation notes

The rounding mode travels through the engine as a non-type parameter, so `sudo_cast`,
`scale`, both integer scaling paths, and the fixed-point path all honour it, including the
origin offset of a cross-origin `quantity_point` conversion. The adjusting paths ask nothing
of a representation type beyond the arithmetic `RealScalar` already mandates: zero and one
are derived from the operands (`v - v` and, given the positive-divisor precondition,
`v / v`), and the remainder uses `%` where a type provides it with a subtraction fallback for
those that do not, such as the emulated 128-bit integer.

Where rounding cannot be delivered, the policy is rejected at the call site with a dedicated
diagnostic rather than failing inside the engine: a vector, tensor, or complex representation
has no single value to compare against a boundary; a floating-point destination rounds
nothing and so takes only `truncated` and `rounded`; and rounding a non-standard
floating-point source to an integral type is unsupported.

## Verification

- gcc-12/C++20, clang-16/C++20, clang-21/C++26, gcc-15/C++26: all build clean with
  warnings-as-errors and pass 63/63 runtime tests.
- `all_verify_interface_header_sets`: 119 headers compiled standalone, no warnings.
- `pre-commit run` clean.
- New static tests cover every policy on all three scaling paths (integral divisor, rational,
  and the irrational fixed-point path), negative values and ties-to-even, floating-point to
  integral conversions including values at or above 2^52, cross-origin points, `value_cast`,
  the deprecated spellings, and the representation-type limits above.

Docs: the value conversions chapter is rewritten around the policies, and the cheat sheet,
safety features, conversions tutorial, chrono and dimensionless workshops, legacy interface
guide, and the currency and trade execution examples now show the policy that actually fits
each case rather than a blanket truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
